### PR TITLE
Network Information sample

### DIFF
--- a/network-information/README.md
+++ b/network-information/README.md
@@ -1,0 +1,5 @@
+Network Information Sample
+===
+See https://googlechrome.github.io/samples/network-information/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/6338383617982464

--- a/network-information/index.html
+++ b/network-information/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Network Information Sample</title>
+
+    <link rel="stylesheet" href="../styles/main.css">
+  </head>
+  <body>
+    <h1>Network Information Sample</h1>
+    <p>Available in <a href="http://www.chromestatus.com/feature/6338383617982464">Chrome 38+</a> (Android, iOS, ChromeOS)</p>
+
+    <p>
+      This demo illustrates the use of the <a href="http://w3c.github.io/netinfo/">Network Information API</a>
+      to retrieve the current network type and monitor for network type changes.
+    </p>
+
+    <p>
+      The Network Information API is <a href="https://code.google.com/p/chromium/issues/detail?id=368358#c18">not initially available</a>
+      on all platforms. For best results, try this demo using Chrome on Android, iOS, or ChromeOS.
+    </p>
+
+    <p>On supported devices, changing your network connection will update the type on this page.</p>
+
+    <!-- // [START code-block] -->
+    <p>Your current network type is <strong id="type"></strong>.</p>
+
+    <script>
+      function updateDisplayedType() {
+        var type = 'unknown';
+        if ('connection' in navigator) {
+          type = navigator.connection.type;
+        }
+        document.querySelector('#type').textContent = type;
+      }
+
+      updateDisplayedType();
+      navigator.connection.addEventListener('typechange', updateDisplayedType);
+    </script>
+    <!-- // [END code-block] -->
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1');
+      ga('send', 'pageview');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
@devnook & co., please take a look if you have the chance.

Support for the Network Information API is currently only available using Chrome 38 (current dev channel) on an Android, iOS, or ChromeOS device. The sample falls back to the `unknown` network type on unsupported devices.

You can view a working demo using a supported device at https://rawgit.com/jeffposnick/samples/network-information/network-information/index.html
