### PR TITLE
Display an error message when the TextDecoder interface isn't available.

### DIFF
--- a/encoding-api/index.html
+++ b/encoding-api/index.html
@@ -30,16 +30,20 @@
     <pre id="results"></pre>
 
     <script>
-      // The local files to be fetched, mapped to the encoding that they're using.
-      var filesToEncoding = {
-        'utf8.bin': 'utf-8',
-        'utf16le.bin': 'utf-16le',
-        'macintosh.bin': 'macintosh'
-      };
+      if ('TextDecoder' in window) {
+        // The local files to be fetched, mapped to the encoding that they're using.
+        var filesToEncoding = {
+          'utf8.bin': 'utf-8',
+          'utf16le.bin': 'utf-16le',
+          'macintosh.bin': 'macintosh'
+        };
 
-      Object.keys(filesToEncoding).forEach(function(file) {
-        fetchAndDecode(file, filesToEncoding[file]);
-      });
+        Object.keys(filesToEncoding).forEach(function(file) {
+          fetchAndDecode(file, filesToEncoding[file]);
+        });
+      } else {
+        document.querySelector('#results').textContent = 'Your browser does not support the Encoding API.'
+      }
 
       // Use XHR to fetch `file` and interpret its contents as being encoded with `encoding`.
       function fetchAndDecode(file, encoding) {


### PR DESCRIPTION
My intention for this sample was to show the native functionality on supported browsers, so I'm not including the [polyfill](https://github.com/inexorabletash/text-encoding), and just display a message if the browser doesn't support `TextDecoder`.

@ebidel let me know if you think these samples **should** demonstrate use of polyfills (when available).
