### PR TITLE
Selective caching example

### DIFF
--- a/service-worker/selective-caching/README.md
+++ b/service-worker/selective-caching/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Selective Caching
+===
+See https://googlechrome.github.io/samples/service-worker/selective-caching/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/selective-caching/index.html
+++ b/service-worker/selective-caching/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Sample of selective caching with Service Workers.">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Service Worker Sample: Selective Caching</title>
+
+    <!-- Add to homescreen for Chrome on Android -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Selective Caching">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
+
+    <!-- Tile icon for Win8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileColor" content="#3372DF">
+
+    <link rel="icon" href="../../images/favicon.ico">
+
+    <link rel="stylesheet" href="../../styles/main.css">
+
+    <link rel='stylesheet' type='text/css' href='http://fonts.googleapis.com/css?family=Special+Elite'>
+    <style>
+      .output {
+        font-family: 'Special Elite';
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Service Worker Sample: Selective Caching</h1>
+
+    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+
+    <p>
+      This sample demonstrates basic Service Worker registration, in conjunction with selective
+      caching.
+    </p>
+
+    <p>
+      In this case, we're caching all font resources by checking for responses with a <code>Content-Type</code> header
+      that starts with <code>font/</code>. The same principle can be extended to selectively cache any category of
+      content based on request or response headers (assuming the response is
+      <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">non-opaque</a>).
+    </p>
+
+    <p>
+      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
+      the registered Service Worker to view logging statements for the various actions the
+      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
+    </p>
+
+    <!-- // [START code-block] -->
+    <div class="output">
+      <div id="status"></div>
+    </div>
+
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('./service-worker.js', {scope: './'}).then(
+          function() {
+            // Registration was successful. Now, check to see whether the Service Worker is controlling the page.
+            if (navigator.serviceWorker.controller) {
+              // If .controller is set, then this page is being actively controlled by the Service Worker.
+              document.querySelector('#status').textContent =
+                'This funky font has been cached by the controlling service worker.';
+            } else {
+              // If .controller isn't set, then prompt the user to reload the page so that the Service Worker can take
+              // control. Until that happens, the Service Worker's fetch handler won't be used.
+              document.querySelector('#status').textContent =
+                'Please reload this page to allow the Service Worker to handle network operations.';
+            }
+          },
+          function(error) {
+            // Something went wrong during registration. The service-worker.js file
+            // might be unavailable or contain a syntax error.
+            document.querySelector('#status').textContent = error;
+          }
+        );
+      } else {
+        // The current browser doesn't support Service Workers.
+        var aElement = document.createElement('a');
+        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
+        aElement.textContent = 'Service Workers are not supported in the current browser.';
+        document.querySelector('#status').appendChild(aElement);
+      }
+    </script>
+    <!-- // [END code-block] -->
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- Built with love using Web Starter Kit -->
+  </body>
+</html>

--- a/service-worker/selective-caching/service-worker.js
+++ b/service-worker/selective-caching/service-worker.js
@@ -63,6 +63,9 @@ self.addEventListener('fetch', function(event) {
           // undefined, and we need to fetch() the resource.
           console.log(' No response for %s found in cache. About to fetch from network...', event.request.url);
 
+          // We call .clone() on the request since we might use it in a call to cache.put() later on.
+          // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
+          // (see https://fetch.spec.whatwg.org/#dom-request-clone)
           return fetch(event.request.clone()).then(function(response) {
             console.log('  Response for %s from network is: %O', event.request.url, response);
 
@@ -77,8 +80,9 @@ self.addEventListener('fetch', function(event) {
               // All of the Google Web Fonts are served off of a domain that supports CORS, so that isn't an issue here.
               // It is something to keep in mind if you're attempting to cache other resources from a cross-origin
               // domain that doesn't support CORS, though!
-              // We need to call .clone() on the response object to save a copy of it to the cache.
-              // (https://fetch.spec.whatwg.org/#dom-request-clone)
+              // We call .clone() on the response to save a copy of it to the cache. By doing so, we get to keep
+              // the original response object which we will return back to the controlled page.
+              // (see https://fetch.spec.whatwg.org/#dom-response-clone)
               console.log('  Caching the response to', event.request.url);
               cache.put(event.request, response.clone());
             } else {

--- a/service-worker/selective-caching/service-worker.js
+++ b/service-worker/selective-caching/service-worker.js
@@ -1,3 +1,16 @@
+/*
+ Copyright 2014 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 // While overkill for this specific sample in which there is only one cache,
 // this is one best practice that can be followed in general to keep track of
 // all multiple caches used by a given service worker, and keep them all versioned.

--- a/service-worker/selective-caching/service-worker.js
+++ b/service-worker/selective-caching/service-worker.js
@@ -1,0 +1,89 @@
+// While overkill for this specific sample in which there is only one cache,
+// this is one best practice that can be followed in general to keep track of
+// all multiple caches used by a given service worker, and keep them all versioned.
+
+// Note that since global state is discarded in between service worker restarts, these
+// variables will be reinitialized each time the service worker handles an event, and you
+// should not attempt to change their values inside an event handler. (Treat them as constants.)
+
+// If at any point you want to force pages that use this service worker to start using a fresh
+// cache, then increment the CACHE_VERSION value. It will kick off the service worker update
+// flow and the old cache(s) will be purged as part of the activate event handler when the
+// updated service worker is activated.
+var CACHE_VERSION = 1;
+var CURRENT_CACHES = {
+  'font-cache': 'font-cache-v' + CACHE_VERSION
+};
+
+self.addEventListener('activate', function(event) {
+  // Delete all caches that aren't named in CURRENT_CACHES.
+  // While there is only one cache in this example, the same logic will handle the case where
+  // there are multiple versioned caches.
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          if (!CURRENT_CACHES.hasOwnProperty(cacheName)) {
+            console.log('Deleting out of date cache:', cacheName);
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  console.log('Handling fetch event for', event.request.url);
+
+  event.respondWith(
+    caches.open(CURRENT_CACHES['font-cache']).then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        if (response) {
+          // If there is an entry in the cache for event.request, then response will be defined
+          // and we can just return it. Note that in this example, only font resources are cached.
+          console.log(' Found response in cache:', response);
+
+          return response;
+        } else {
+          // Otherwise, if there is no entry in the cache for event.request, response will be
+          // undefined, and we need to fetch() the resource.
+          console.log(' No response for %s found in cache. About to fetch from network...', event.request.url);
+
+          return fetch(event.request.clone()).then(function(response) {
+            console.log('  Response for %s from network is: %O', event.request.url, response);
+
+            if (response.status < 400 &&
+                response.headers.has('content-type') &&
+                response.headers.get('content-type').match(/^font\//i)) {
+              // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
+              // We also only want to cache responses that correspond to fonts,
+              // i.e. have a Content-Type response header that starts with "font/".
+              // Note that for opaque filtered responses (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque)
+              // we can't access to the response headers, so this check will always fail and the font won't be cached.
+              // All of the Google Web Fonts are served off of a domain that supports CORS, so that isn't an issue here.
+              // It is something to keep in mind if you're attempting to cache other resources from a cross-origin
+              // domain that doesn't support CORS, though!
+              // We need to call .clone() on the response object to save a copy of it to the cache.
+              // (https://fetch.spec.whatwg.org/#dom-request-clone)
+              console.log('  Caching the response to', event.request.url);
+              cache.put(event.request, response.clone());
+            } else {
+              console.log('  Not caching the response to', event.request.url)
+            }
+
+            // Return the original response object, which will be used to fulfill the resource request.
+            return response;
+          });
+        }
+      }).catch(function(error) {
+        // This catch() will handle exceptions that arise from the match() or fetch() operations.
+        // Note that a HTTP error response (e.g. 404) will NOT trigger an exception.
+        // It will return a normal response object that has the appropriate error code set.
+        console.error('  Error in fetch handler:', error);
+
+        throw error;
+      });
+    })
+  );
+});


### PR DESCRIPTION
@gauntface @jakearchibald @kenjibaheux @coonsta @slightlyoff & other interested parties:

Here's a sample covering selective caching of responses, closing https://github.com/GoogleChrome/samples/issues/32

In this implementation, I'm pulling in a Google Web Font onto a controlled page, and within the service worker's `fetch` handler, caching responses that have `Content-Type: font/...` set. While not particularly useful on its own, I think it illustrates how developers can control what type of responses they want to cache.

Additionally, this is the first sample that uses a cache naming/versioning scheme along with an `activate` handler that clears out old caches. Any feedback about how I implemented that would be appreciated. If it looks good, I'll go back and add in a similar approach to the existing samples, closing https://github.com/GoogleChrome/samples/issues/42
