### PR TITLE
Mock responses example

### DIFF
--- a/service-worker/mock-responses/README.md
+++ b/service-worker/mock-responses/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Mock Responses
+===
+See https://googlechrome.github.io/samples/service-worker/mock-responses/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Sample of using a Service Worker to provide a fallback response when a fetch() fails.">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Service Worker Sample: Mock Responses</title>
+
+    <!-- Add to homescreen for Chrome on Android -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Mock Responses">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
+
+    <!-- Tile icon for Win8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileColor" content="#3372DF">
+
+    <link rel="icon" href="../../images/favicon.ico">
+
+    <link rel="stylesheet" href="../../styles/main.css">
+  </head>
+
+  <body>
+    <h1>Service Worker Sample: Mock Responses</h1>
+
+    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+
+    <p>
+      This sample demonstrates basic Service Worker registration, with the service worker's fetch handler
+      not taking any special action for most requests. However, there is special behavior if a request
+      is made to the <a href="https://developers.google.com/url-shortener/">Google URL Shortener API</a>
+      and a custom request header is set, <code>X-Mock-Response</code>. (There's no special significance
+      to this name; any convention that both the controlled page and the service worker agree on could be used.)
+      Instead of returning actual responses for those API requests, the service worker will return mock response
+      that should appear identical to a real API response from the perspective of this controlled page.
+    </p>
+
+    <p>
+      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
+      the registered Service Worker to view logging statements for the various actions the
+      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
+    </p>
+
+    <!-- // [START code-block] -->
+    <div class="output">
+      <p id="status"></p>
+
+      <div id="request" style="display: none">
+        <p>
+          Try this example both with the box checked (which will return a static, mock response) and
+          with the box unchecked (which will make an actual call to the URL Shortener API). The response
+          will be handled identically by this page regardless of whether it is mocked or genuine.
+        </p>
+
+        <div>
+          <input id="original-url" value="https://www.google.com/" size="50">
+          <button id="shorten-button">Shorten</button>
+        </div>
+        <div>
+          <input id="mock-checkbox" type="checkbox" checked>Mock Response</input>
+        </div>
+
+        <p>Short URL: <a id="short-url"></a></p>
+      </div>
+    </div>
+
+    <script>
+      function showRequest() {
+        document.querySelector('#shorten-button').addEventListener('click', makeApiRequest);
+        document.querySelector('#request').style.display = 'block';
+      }
+
+      function makeApiRequest() {
+        var xhr = new XMLHttpRequest();
+        // See https://developers.google.com/url-shortener/v1/getting_started#shorten
+        xhr.open('POST', 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyCr0XVB-Hz1ohPpjvLatdj4qZ5zcSohHsU');
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        // Only set the custom 'X-Mock-Response' header if the box is checked. The service worker will
+        // use the header's presence to determine whether to return a mock or genuine response.
+        if (document.querySelector('#mock-checkbox').checked) {
+          xhr.setRequestHeader('X-Mock-Response', 'yes');
+        }
+
+        xhr.addEventListener('load', function() {
+          var response = JSON.parse(xhr.response);
+          console.log('Response is', response);
+
+          var shortUrlElement = document.querySelector('#short-url');
+          shortUrlElement.href = response.id;
+          shortUrlElement.innerText = response.id;
+        });
+
+        var request = {
+          longUrl: document.querySelector('#original-url').value
+        };
+        var requestJson = JSON.stringify(request);
+        xhr.send(requestJson);
+      }
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js', { scope: './' }).then(function() {
+          if (navigator.serviceWorker.controller) {
+            // If .controller is set, then this page is being actively controlled by the Service Worker.
+            document.querySelector('#status').textContent = 'The Service Worker is currently handling network operations.';
+
+            showRequest();
+          } else {
+            // If .controller isn't set, then prompt the user to reload the page so that the Service Worker can take
+            // control. Until that happens, the Service Worker's fetch handler won't be used.
+            document.querySelector('#status').textContent = 'Please reload this page to allow the Service Worker to handle network operations.';
+          }
+        }, function(error) {
+          // Something went wrong during registration. The service-worker.js file
+          // might be unavailable or contain a syntax error.
+          document.querySelector('#status').textContent = error;
+        });
+      } else {
+        // The current browser doesn't support Service Workers.
+        var aElement = document.createElement('a');
+        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
+        aElement.textContent = 'unavailable';
+        document.querySelector('#status').appendChild(aElement);
+      }
+    </script>
+    <!-- // [END code-block] -->
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- Built with love using Web Starter Kit -->
+  </body>
+</html>

--- a/service-worker/mock-responses/service-worker.js
+++ b/service-worker/mock-responses/service-worker.js
@@ -47,8 +47,8 @@ self.addEventListener('fetch', function(event) {
 
     console.log(' Responding with a mock response body:', responseBody);
     event.respondWith(mockResponse);
-  } else {
-    console.log(' Responding with the default response.');
-    event.respondWith(event.default());
   }
+
+  // If event.respondWith() isn't called because this wasn't a request that we want to mock,
+  // then the default request/response behavior will automatically be used.
 });

--- a/service-worker/mock-responses/service-worker.js
+++ b/service-worker/mock-responses/service-worker.js
@@ -1,0 +1,54 @@
+/*
+ Copyright 2014 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+self.addEventListener('fetch', function(event) {
+  console.log('Handling fetch event for', event.request.url);
+  var requestUrl = new URL(event.request.url);
+
+  // Determine whether this is a URL Shortener API request that should be mocked.
+  // Matching on just the pathname gives some flexibility in case there are multiple domains that
+  // might host the same RESTful API (imagine this being used to mock responses against what might be
+  // a test, or QA, or production environment).
+  // Also check for the existence of the 'X-Mock-Response' header.
+  if (requestUrl.pathname == '/urlshortener/v1/url' && event.request.headers.has('X-Mock-Response')) {
+    // This matches the result format documented at
+    // https://developers.google.com/url-shortener/v1/getting_started#shorten
+    var responseBody = {
+      kind: 'urlshortener#url',
+      id: 'http://goo.gl/IKyjuU',
+      longUrl: 'https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html'
+    };
+    // We can't directly return an object or a string, so wrap it in a Blob.
+    var blobResponseBody = new Blob([JSON.stringify(responseBody)]);
+
+    var responseInit = {
+      // status/statusText default to 200/OK, but we're explicitly setting them here.
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'Content-Type': 'application/json',
+        // Purely optional, but we return a custom response header indicating that this is a
+        // mock response. The controlled page could check for this header if it wanted to.
+        'X-Mock-Response': 'yes'
+      }
+    };
+
+    var mockResponse = new Response(blobResponseBody, responseInit);
+
+    console.log(' Responding with a mock response body:', responseBody);
+    event.respondWith(mockResponse);
+  } else {
+    console.log(' Responding with the default response.');
+    event.respondWith(event.default());
+  }
+});


### PR DESCRIPTION
@gauntface @jakearchibald @kenjibaheux @coonsta @slightlyoff & other interested parties:

Here's a sample that returns mock responses to API requests (assuming a specific request header is set), closing #34

You can view a live version of the sample at https://rawgit.com/jeffposnick/samples/sw-mock-responses/service-worker/mock-responses/index.html
