### PR TITLE
SW Sample: Post Message

### DIFF
--- a/service-worker/post-message/README.md
+++ b/service-worker/post-message/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Posting Messages
+===
+See https://googlechrome.github.io/samples/service-worker/post-message/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/post-message/index.html
+++ b/service-worker/post-message/index.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Sample of using postMessage to communicate with Service Workers.">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Service Worker Sample: Posting Messages</title>
+
+    <!-- Add to homescreen for Chrome on Android -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Posting Messages">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
+
+    <!-- Tile icon for Win8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileColor" content="#3372DF">
+
+    <link rel="icon" href="../../images/favicon.ico">
+
+    <link rel="stylesheet" href="../../styles/main.css">
+  </head>
+
+  <body>
+    <h1>Service Worker Sample: Posting Messages</h1>
+
+    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+
+    <p>
+      This sample demonstrates basic Service Worker registration, in conjunction with using the
+      <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window.postMessage"><code>postMessage</code></a>
+      interface to communicate with the service worker controlling the page. Note that while the service worker can
+      reply to messages sent from a controlled page, it's currently not possible for the service worker to originate a
+      message. (The Push API specification, which is closely related to service workers, is currently being developed,
+      and covers some of the use cases in which a service worker creates a message displayed to an end user.)
+    </p>
+
+    <p>
+      The service worker's
+      <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-onmessage-attribute"><code>onmessage</code> handler</a>
+      behaves differently depending on the type of message it receives; there's an arbitrary set of "commands" that this
+      controlled page can send it to do things like determine whether the resource at a given URL is present in the
+      cache, add resources to the cache, or remove them. Since the controlled page doesn't have access to the service
+      worker's cache, using this type of message passing is a common way to get insight into the cache's contents.
+    </p>
+
+    <p>
+      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
+      the registered Service Worker to view logging statements for the various actions the
+      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
+    </p>
+
+    <!-- // [START code-block] -->
+    <div class="output">
+      <div id="status"></div>
+
+      <div id="commands" style="display: none">
+        <div>
+          <label for="url">Resource URL:</label>
+          <input id="url" type="text" size="50" value="http://localhost:8000">
+          <button id="add">Add to Cache</button>
+          <button id="delete">Delete from Cache</button>
+        </div>
+        <div>
+          <button id="list-contents">List Cache Contents</button>
+        </div>
+        <ul id="contents"></ul>
+      </div>
+    </div>
+
+    <script>
+      function setStatus(statusMessage) {
+        document.querySelector('#status').textContent = statusMessage;
+      }
+
+      function showCommands() {
+        document.querySelector('#add').addEventListener('click', function() {
+          sendMessage({
+            command: 'add',
+            url: document.querySelector('#url').value
+          }).then(function() {
+            setStatus('Added to cache.');
+          }).catch(setStatus);
+        });
+
+        document.querySelector('#delete').addEventListener('click', function() {
+          sendMessage({
+            command: 'delete',
+            url: document.querySelector('#url').value
+          }).then(function() {
+            setStatus('Deleted from cache.');
+          }).catch(setStatus);
+        });
+
+        document.querySelector('#list-contents').addEventListener('click', function() {
+          sendMessage({
+            command: 'keys'
+          }).then(function(data) {
+            var contentsElement = document.querySelector('#contents');
+            while (contentsElement.firstChild) {
+              contentsElement.removeChild(contentsElement.firstChild);
+            }
+
+            data.urls.forEach(function(url) {
+              var liElement = document.createElement('li');
+              liElement.textContent = url;
+              contentsElement.appendChild(liElement);
+            });
+          }).catch(setStatus);
+        });
+
+        document.querySelector('#commands').style.display = 'block';
+      }
+
+      function sendMessage(message) {
+        return new Promise(function(resolve, reject) {
+          var messageChannel = new MessageChannel();
+          messageChannel.port1.onmessage = function(event) {
+            if (event.data.error) {
+              reject(event.data.error);
+            } else {
+              resolve(event.data);
+            }
+          };
+
+          navigator.serviceWorker.controller.postMessage(message, [messageChannel.port2]);
+        });
+      }
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('./service-worker.js', {scope: './'}).then(function() {
+            // Registration was successful. Now, check to see whether the Service Worker is controlling the page.
+            if (navigator.serviceWorker.controller) {
+              // If .controller is set, then this page is being actively controlled by the Service Worker.
+              // Show the interface for sending messages to the service worker.
+              showCommands();
+            } else {
+              // If .controller isn't set, then prompt the user to reload the page so that the Service Worker can take
+              // control. Until that happens, the Service Worker's message handler won't be used.
+              document.querySelector('#status').textContent =
+                'Please reload this page to allow the service worker to take control.';
+            }
+        }).catch(function(error) {
+          // Something went wrong during registration. The service-worker.js file
+          // might be unavailable or contain a syntax error.
+          document.querySelector('#status').textContent = error;
+        });
+      } else {
+        // The current browser doesn't support Service Workers.
+        var aElement = document.createElement('a');
+        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
+        aElement.textContent = 'Service Workers are not supported in the current browser.';
+        document.querySelector('#status').appendChild(aElement);
+      }
+    </script>
+    <!-- // [END code-block] -->
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- Built with love using Web Starter Kit -->
+  </body>
+</html>

--- a/service-worker/post-message/index.html
+++ b/service-worker/post-message/index.html
@@ -49,7 +49,7 @@ limitations under the License.
 
     <p>
       This sample demonstrates basic Service Worker registration, in conjunction with using the
-      <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window.postMessage"><code>postMessage</code></a>
+      <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage"><code>postMessage</code></a>
       interface to communicate with the service worker controlling the page. Note that while the service worker can
       reply to messages sent from a controlled page, it's currently not possible for the service worker to originate a
       message. (The Push API specification, which is closely related to service workers, is currently being developed,
@@ -71,14 +71,13 @@ limitations under the License.
       <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
     </p>
 
-    <!-- // [START code-block] -->
     <div class="output">
       <div id="status"></div>
 
       <div id="commands" style="display: none">
         <div>
           <label for="url">Resource URL:</label>
-          <input id="url" type="text" size="50" value="http://localhost:8000">
+          <input id="url" type="text" size="50" value="https://www.google.com/">
           <button id="add">Add to Cache</button>
           <button id="delete">Delete from Cache</button>
         </div>
@@ -100,8 +99,9 @@ limitations under the License.
             command: 'add',
             url: document.querySelector('#url').value
           }).then(function() {
+            // If the promise resolves, just display a success message.
             setStatus('Added to cache.');
-          }).catch(setStatus);
+          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
         });
 
         document.querySelector('#delete').addEventListener('click', function() {
@@ -109,8 +109,9 @@ limitations under the License.
             command: 'delete',
             url: document.querySelector('#url').value
           }).then(function() {
+            // If the promise resolves, just display a success message.
             setStatus('Deleted from cache.');
-          }).catch(setStatus);
+          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
         });
 
         document.querySelector('#list-contents').addEventListener('click', function() {
@@ -118,22 +119,28 @@ limitations under the License.
             command: 'keys'
           }).then(function(data) {
             var contentsElement = document.querySelector('#contents');
+            // Clear out the existing items from the list.
             while (contentsElement.firstChild) {
               contentsElement.removeChild(contentsElement.firstChild);
             }
 
+            // Add each cached URL to the list, one by one.
             data.urls.forEach(function(url) {
               var liElement = document.createElement('li');
               liElement.textContent = url;
               contentsElement.appendChild(liElement);
             });
-          }).catch(setStatus);
+          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
         });
 
         document.querySelector('#commands').style.display = 'block';
       }
 
       function sendMessage(message) {
+        // This wraps the message posting/response in a promise, which will resolve if the response doesn't
+        // contain an error, and reject with the error if it does. If you'd prefer, it's possible to call
+        // controller.postMessage() and set up the onmessage handler independently of a promise, but this is
+        // a convenient wrapper.
         return new Promise(function(resolve, reject) {
           var messageChannel = new MessageChannel();
           messageChannel.port1.onmessage = function(event) {
@@ -144,6 +151,10 @@ limitations under the License.
             }
           };
 
+          // This sends the message data as well as transferring messageChannel.port2 to the service worker.
+          // The service worker can then use the transferred port to reply via postMessage(), which
+          // will in turn trigger the onmessage handler on messageChannel.port1.
+          // See https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage
           navigator.serviceWorker.controller.postMessage(message, [messageChannel.port2]);
         });
       }
@@ -174,7 +185,6 @@ limitations under the License.
         document.querySelector('#status').appendChild(aElement);
       }
     </script>
-    <!-- // [END code-block] -->
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/service-worker/post-message/service-worker.js
+++ b/service-worker/post-message/service-worker.js
@@ -1,0 +1,111 @@
+/*
+ Copyright 2014 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// This polyfill provides Cache.add(), Cache.addAll(), and CacheStorage.match(),
+// which are not implemented in Chrome 40.
+importScripts('../serviceworker-cache-polyfill.js');
+
+// While overkill for this specific sample in which there is only one cache,
+// this is one best practice that can be followed in general to keep track of
+// all multiple caches used by a given service worker, and keep them all versioned.
+
+// Note that since global state is discarded in between service worker restarts, these
+// variables will be reinitialized each time the service worker handles an event, and you
+// should not attempt to change their values inside an event handler. (Treat them as constants.)
+
+// If at any point you want to force pages that use this service worker to start using a fresh
+// cache, then increment the CACHE_VERSION value. It will kick off the service worker update
+// flow and the old cache(s) will be purged as part of the activate event handler when the
+// updated service worker is activated.
+var CACHE_VERSION = 1;
+var CURRENT_CACHES = {
+  'some-cache': 'some-cache-v' + CACHE_VERSION
+};
+
+self.addEventListener('activate', function(event) {
+  // Delete all caches that aren't named in CURRENT_CACHES.
+  // While there is only one cache in this example, the same logic will handle the case where
+  // there are multiple versioned caches.
+  var expectedCacheNames = Object.keys(CURRENT_CACHES).map(function(key) {
+    return CURRENT_CACHES[key];
+  });
+
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          if (expectedCacheNames.indexOf(cacheName) == -1) {
+            // If this cache name isn't present in the array of "expected" cache names, then delete it.
+            console.log('Deleting out of date cache:', cacheName);
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
+
+self.addEventListener('message', function(event) {
+  console.log('Handling message event:', event);
+
+  caches.open(CURRENT_CACHES['some-cache']).then(function(cache) {
+    switch (event.data.command) {
+      case 'keys':
+        cache.keys().then(function(requests) {
+          var urls = requests.map(function(request) {
+            return request.url;
+          });
+
+          event.ports[0].postMessage({
+            error: null,
+            urls: urls
+          });
+        }).catch(function(error) {
+          event.ports[0].postMessage({
+            error: error.toString()
+          });
+        });
+      break;
+
+      case 'add':
+        cache.add(new Request(event.data.url, {mode: 'no-cors'})).then(function(response) {
+          event.ports[0].postMessage({
+            error: null
+          });
+        }).catch(function(error) {
+          console.error('vvvvv');
+          event.ports[0].postMessage({
+            error: error.toString()
+          });
+        });
+      break;
+
+      case 'delete':
+        cache.delete(event.data.url).then(function() {
+          event.ports[0].postMessage({
+            error: null
+          });
+        }).catch(function(error) {
+          event.ports[0].postMessage({
+            error: error.toString()
+          });
+        });
+      break;
+
+      default:
+        event.ports[0].postMessage({
+          error: 'Unknown command: ' + event.data.command
+        });
+    }
+  });
+});

--- a/service-worker/post-message/service-worker.js
+++ b/service-worker/post-message/service-worker.js
@@ -17,7 +17,8 @@ importScripts('../serviceworker-cache-polyfill.js');
 
 // While overkill for this specific sample in which there is only one cache,
 // this is one best practice that can be followed in general to keep track of
-// all multiple caches used by a given service worker, and keep them all versioned.
+// multiple caches used by a given service worker, and keep them all versioned.
+// It maps a shorthand identifier for a cache to a specific, versioned cache name.
 
 // Note that since global state is discarded in between service worker restarts, these
 // variables will be reinitialized each time the service worker handles an event, and you
@@ -29,7 +30,7 @@ importScripts('../serviceworker-cache-polyfill.js');
 // updated service worker is activated.
 var CACHE_VERSION = 1;
 var CURRENT_CACHES = {
-  'some-cache': 'some-cache-v' + CACHE_VERSION
+  'post-message': 'post-message-cache-v' + CACHE_VERSION
 };
 
 self.addEventListener('activate', function(event) {
@@ -58,7 +59,7 @@ self.addEventListener('activate', function(event) {
 self.addEventListener('message', function(event) {
   console.log('Handling message event:', event);
 
-  caches.open(CURRENT_CACHES['some-cache']).then(function(cache) {
+  caches.open(CURRENT_CACHES['post-message']).then(function(cache) {
     switch (event.data.command) {
       // This command returns a list of the URLs corresponding to the Request objects
       // that serve as keys for the current cache.


### PR DESCRIPTION
@gauntface @jakearchibald @kenjibaheux @coonsta @slightlyoff & other interested parties:

This sample demonstrates the use of `postMessage()` to interact with the service worker controlling a page. Users can add, delete, and get a list of items in the cache.

There's a live demo at https://rawgit.com/jeffposnick/samples/sw-post-message/service-worker/post-message/index.html
