### PR TITLE
Force HTTPS across the SW samples.

### DIFF
--- a/service-worker/fallback-response/index.html
+++ b/service-worker/fallback-response/index.html
@@ -42,6 +42,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -42,6 +42,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/post-message/index.html
+++ b/service-worker/post-message/index.html
@@ -39,6 +39,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/prefetch/index.html
+++ b/service-worker/prefetch/index.html
@@ -42,6 +42,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/read-through-caching/index.html
+++ b/service-worker/read-through-caching/index.html
@@ -39,6 +39,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/registration-events/index.html
+++ b/service-worker/registration-events/index.html
@@ -42,6 +42,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/registration/index.html
+++ b/service-worker/registration/index.html
@@ -42,6 +42,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
   </head>
 

--- a/service-worker/selective-caching/index.html
+++ b/service-worker/selective-caching/index.html
@@ -39,6 +39,14 @@ limitations under the License.
 
     <link rel="icon" href="../../images/favicon.ico">
 
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
     <link rel="stylesheet" href="../../styles/main.css">
 
     <link rel='stylesheet' type='text/css' href='http://fonts.googleapis.com/css?family=Special+Elite'>


### PR DESCRIPTION
Following @jakearchibald's lead at https://github.com/jakearchibald/trained-to-thrill/blob/master/www/static/js-unmin/index.js#L6

Putting it early up in the `<head>` since we know the rest of the page won't work if we're on HTTP.
