### PR TITLE
SW Sample: Offline Analytics

### DIFF
--- a/service-worker/offline-analytics/README.md
+++ b/service-worker/offline-analytics/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Read-through Caching (w/Offline Analytics)
+===
+See https://googlechrome.github.io/samples/service-worker/read-through-caching/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/offline-analytics/index.html
+++ b/service-worker/offline-analytics/index.html
@@ -78,9 +78,9 @@ limitations under the License.
       will check for any saved requests and "replay" them, by sending them to the Google Analytics
       server with the appropriate
       <a href="https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt>"<code>qt</code></a>
-      parameter set to specify the delta since the ping was created. If that replay succeeds, the request
-      will be removed from IndexedDB, and if it fails (because the network is still not available) then
-      it will be retried the next time the service worker script starts up.
+      parameter set to specify the delta since the ping was created. If that replay succeeds, the
+      request will be removed from IndexedDB, and if it fails (because the network is still not
+      available) then it will be retried the next time the service worker script starts up.
     </p>
 
     <p>

--- a/service-worker/offline-analytics/index.html
+++ b/service-worker/offline-analytics/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Sample of read-through caching and offline analytics with service workers.">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Service Worker Sample: Read-through Caching (w/Offline Analytics)</title>
+
+    <!-- Add to homescreen for Chrome on Android -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Read-through Caching (w/Offline Analytics)">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
+
+    <!-- Tile icon for Win8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileColor" content="#3372DF">
+
+    <link rel="icon" href="../../images/favicon.ico">
+
+    <script>
+      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
+      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
+
+    <link rel="stylesheet" href="../../styles/main.css">
+  </head>
+
+  <body>
+    <h1>Service Worker Sample: Read-through Caching (w/Offline Analytics)</h1>
+
+    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+
+    <p>
+      This sample demonstrates basic service worker registration, in conjunction with read-through
+      caching. After the service worker starts controlling this page, the first time a specific
+      resource is requested, it's <code>fetch()</code>ed from the network and a copy of the response
+      is stored in the service worker's cache. All subsequent times that the same resource is
+      requested, it's returned directly from the cache.
+    </p>
+
+    <p>
+      <strong>Note:</strong> This is a very aggressive approach to caching, and might not be appropriate
+      if your web application makes requests for arbitrary URLs as part of its normal operation
+      (e.g. a RSS client or a news aggregator), as the cache could end up containing large responses
+      that might not end up ever being accessed. Other approaches, like selectively caching based on
+      response headers or only caching responses served from a specific domain, might be more
+      appropriate for those use cases.
+    </p>
+
+    <p>
+      Additionally, this sample will save up any failed Google Analytics <code>/collect</code> pings
+      that fail, and store them in IndexedDB. Every time the service worker script starts up, it
+      will check for any saved requests and "replay" them, by sending them to the Google Analytics
+      server with the appropriate
+      <a href="https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt>"<code>qt</code></a>
+      parameter set to specify the delta since the ping was created. If that replay succeeds, the request
+      will be removed from IndexedDB, and if it fails (because the network is still not available) then
+      it will be retried the next time the service worker script starts up.
+    </p>
+
+    <p>
+      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
+      the registered service worker to view logging statements for the various actions the
+      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
+    </p>
+
+    <div class="output">
+      <div id="status"></div>
+
+      <ul id="images" style="display: none">
+        <li><img src="http://www.chromium.org/_/rsrc/1302286216006/config/customLogo.gif"></li>
+        <li><img src="http://www.chromium.org/_/rsrc/1365117468642/chromium-projects/chrome-64.png"></li>
+      </ul>
+    </div>
+
+    <script>
+      function showImages() {
+        document.querySelector('#images').style.display = 'block';
+      }
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('./service-worker.js', {scope: './'}).then(function() {
+          // Registration was successful. Now, check to see whether the service worker is controlling the page.
+          if (navigator.serviceWorker.controller) {
+            // If .controller is set, then this page is being actively controlled by the service worker.
+            document.querySelector('#status').textContent = 'The service worker is currently handling network operations. ' +
+              'If you reload the page, the images (and everything else) will be served from the service worker\'s cache.';
+
+            showImages();
+          } else {
+            // If .controller isn't set, then prompt the user to reload the page so that the service worker can take
+            // control. Until that happens, the service worker's fetch handler won't be used.
+            document.querySelector('#status').textContent = 'Please reload this page to allow the service worker to handle network operations.';
+          }
+        }).catch(function(error) {
+          // Something went wrong during registration. The service-worker.js file
+          // might be unavailable or contain a syntax error.
+          document.querySelector('#status').textContent = error;
+        });
+      } else {
+        // The current browser doesn't support service workers.
+        var aElement = document.createElement('a');
+        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
+        aElement.textContent = 'Service workers are not supported in the current browser.';
+        document.querySelector('#status').appendChild(aElement);
+      }
+    </script>
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- Built with love using Web Starter Kit -->
+  </body>
+</html>

--- a/service-worker/offline-analytics/service-worker.js
+++ b/service-worker/offline-analytics/service-worker.js
@@ -1,0 +1,188 @@
+/*
+ Copyright 2014 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// While overkill for this specific sample in which there is only one cache,
+// this is one best practice that can be followed in general to keep track of
+// multiple caches used by a given service worker, and keep them all versioned.
+// It maps a shorthand identifier for a cache to a specific, versioned cache name.
+
+// Note that since global state is discarded in between service worker restarts, these
+// variables will be reinitialized each time the service worker handles an event, and you
+// should not attempt to change their values inside an event handler. (Treat them as constants.)
+
+// If at any point you want to force pages that use this service worker to start using a fresh
+// cache, then increment the CACHE_VERSION value. It will kick off the service worker update
+// flow and the old cache(s) will be purged as part of the activate event handler when the
+// updated service worker is activated.
+var CACHE_VERSION = 1;
+var CURRENT_CACHES = {
+  'offline-analytics': 'offline-analytics-v' + CACHE_VERSION
+};
+
+var idbDatabase;
+var STORE_NAME = 'urls';
+
+function openDatabaseAndReplayRequests() {
+  var indexedDBOpenRequest = indexedDB.open('offline-analytics', CACHE_VERSION);
+
+  indexedDBOpenRequest.onerror = function(error) {
+    console.error('IndexedDB error:', error);
+  };
+
+  indexedDBOpenRequest.onupgradeneeded = function() {
+    this.result.createObjectStore(STORE_NAME, {keyPath: 'url'});
+  };
+
+  indexedDBOpenRequest.onsuccess = function() {
+    idbDatabase = this.result;
+    replayAnalyticsRequests();
+  };
+}
+
+function getObjectStore(storeName, mode) {
+  return idbDatabase.transaction(storeName, mode).objectStore(storeName);
+}
+
+function saveAnalyticsRequest(requestUrl) {
+  getObjectStore(STORE_NAME, 'readwrite').add({
+    url: requestUrl,
+    timestamp: Date.now()
+  });
+}
+
+function replayAnalyticsRequests() {
+  var savedRequests = [];
+
+  getObjectStore(STORE_NAME, 'readonly').openCursor().onsuccess = function(event) {
+    var cursor = event.target.result;
+
+    if (cursor) {
+      // Keep moving the cursor forward and collecting saved requests.
+      savedRequests.push(cursor.value);
+      cursor.continue();
+    } else {
+      // At this point, we have all the saved requests.
+      console.log('About to replay %d saved Google Analytics requests...', savedRequests.length);
+
+      savedRequests.forEach(function(savedRequest) {
+        var queueTime = Date.now() - savedRequest.timestamp;
+        var requestUrl = savedRequest.url + '&qt=' + queueTime;
+
+        console.log(' Replaying', requestUrl);
+
+        fetch(requestUrl, {mode: 'no-cors'}).then(function() {
+          // Since this is a no-cors request, we can't actually differentiate a HTTP 200 response vs.
+          // an HTTP 4xx/5xx response here, so this MIGHT not be a success. But it's the best we can do.
+          getObjectStore(STORE_NAME, 'readwrite').delete(savedRequest.url);
+          console.log(' Replaying succeeded.');
+        }).catch(function(error) {
+          // This will be triggered if the network is still down. The request will be replayed again
+          // the next time the service worker starts up.
+          console.error(' Replaying failed:', error);
+        });
+      });
+    }
+  };
+}
+
+openDatabaseAndReplayRequests();
+
+self.addEventListener('activate', function(event) {
+  // Delete all caches that aren't named in CURRENT_CACHES.
+  // While there is only one cache in this example, the same logic will handle the case where
+  // there are multiple versioned caches.
+  var expectedCacheNames = Object.keys(CURRENT_CACHES).map(function(key) {
+    return CURRENT_CACHES[key];
+  });
+
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          if (expectedCacheNames.indexOf(cacheName) == -1) {
+            // If this cache name isn't present in the array of "expected" cache names, then delete it.
+            console.log('Deleting out of date cache:', cacheName);
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
+
+// This sample illustrates an aggressive approach to caching, in which every valid response is
+// cached and every request is first checked against the cache.
+// This may not be an appropriate approach if your web application makes requests for
+// arbitrary URLs as part of its normal operation (e.g. a RSS client or a news aggregator),
+// as the cache could end up containing large responses that might not end up ever being accessed.
+// Other approaches, like selectively caching based on response headers or only caching
+// responses served from a specific domain, might be more appropriate for those use cases.
+self.addEventListener('fetch', function(event) {
+  console.log('Handling fetch event for', event.request.url);
+
+  event.respondWith(
+    caches.open(CURRENT_CACHES['offline-analytics']).then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        if (response) {
+          // If there is an entry in the cache for event.request, then response will be defined
+          // and we can just return it.
+          console.log(' Found response in cache:', response);
+
+          return response;
+        } else {
+          // Otherwise, if there is no entry in the cache for event.request, response will be
+          // undefined, and we need to fetch() the resource.
+          console.log(' No response for %s found in cache. About to fetch from network...', event.request.url);
+
+          // We call .clone() on the request since we might use it in the call to cache.put() later on.
+          // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
+          // (see https://fetch.spec.whatwg.org/#dom-request-clone)
+          return fetch(event.request.clone()).then(function(response) {
+            console.log('  Response for %s from network is: %O', event.request.url, response);
+
+            // Optional: add in extra conditions here, e.g. response.type == 'basic' to only cache
+            // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
+            if (response.status < 400) {
+              // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
+              // One limitation is that, for non-CORS requests, we get back a filtered opaque response
+              // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
+              // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
+              // blindly caching those opaque responses, we run the risk of caching a transient error response.
+              //
+              // We need to call .clone() on the response object to save a copy of it to the cache.
+              // (https://fetch.spec.whatwg.org/#dom-request-clone)
+              cache.put(event.request, response.clone());
+            }
+
+            // Return the original response object, which will be used to fulfill the resource request.
+            return response;
+          }).catch(function(error) {
+            console.error('  Unable to fetch %s due to "%s".', event.request.url, error);
+
+            if (event.request.url.match(/\/\/www.google-analytics.com\/collect/i)) {
+              console.log('  Storing Google Analytics request in IndexedDB to be replayed later.');
+              saveAnalyticsRequest(event.request.url);
+            }
+
+            throw error;
+          });
+        }
+      }).catch(function(error) {
+        // This catch() will handle exceptions that arise from the match() or fetch() operations.
+        // Note that a HTTP error response (e.g. 404) will NOT trigger an exception.
+        // It will return a normal response object that has the appropriate error code set.
+        throw error;
+      });
+    })
+  );
+});

--- a/service-worker/offline-analytics/service-worker.js
+++ b/service-worker/offline-analytics/service-worker.js
@@ -80,11 +80,13 @@ function replayAnalyticsRequests() {
 
         console.log(' Replaying', requestUrl);
 
-        fetch(requestUrl, {mode: 'no-cors'}).then(function() {
-          // Since this is a no-cors request, we can't actually differentiate a HTTP 200 response vs.
-          // an HTTP 4xx/5xx response here, so this MIGHT not be a success. But it's the best we can do.
-          getObjectStore(STORE_NAME, 'readwrite').delete(savedRequest.url);
-          console.log(' Replaying succeeded.');
+        fetch(requestUrl).then(function(response) {
+          if (response.status < 400) {
+            getObjectStore(STORE_NAME, 'readwrite').delete(savedRequest.url);
+            console.log(' Replaying succeeded.');
+          } else {
+            console.error(' Replaying failed:', response);
+          }
         }).catch(function(error) {
           // This will be triggered if the network is still down. The request will be replayed again
           // the next time the service worker starts up.

--- a/service-worker/offline-analytics/service-worker.js
+++ b/service-worker/offline-analytics/service-worker.js
@@ -30,25 +30,32 @@ var CURRENT_CACHES = {
 };
 
 var idbDatabase;
+var IDB_VERSION = 1;
 var STORE_NAME = 'urls';
 
+// This is basic boilerplate for interacting with IndexedDB. Adapted from
+// https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
 function openDatabaseAndReplayRequests() {
-  var indexedDBOpenRequest = indexedDB.open('offline-analytics', CACHE_VERSION);
+  var indexedDBOpenRequest = indexedDB.open('offline-analytics', IDB_VERSION);
 
+  // This top-level error handler will be invoked any time there's an IndexedDB-related error.
   indexedDBOpenRequest.onerror = function(error) {
     console.error('IndexedDB error:', error);
   };
 
+  // This should only execute if there's a need to create a new database for the given IDB_VERSION.
   indexedDBOpenRequest.onupgradeneeded = function() {
     this.result.createObjectStore(STORE_NAME, {keyPath: 'url'});
   };
 
+  // This will execute each time the database is opened.
   indexedDBOpenRequest.onsuccess = function() {
     idbDatabase = this.result;
     replayAnalyticsRequests();
   };
 }
 
+// Helper method to get the object store that we care about.
 function getObjectStore(storeName, mode) {
   return idbDatabase.transaction(storeName, mode).objectStore(storeName);
 }
@@ -57,6 +64,7 @@ function replayAnalyticsRequests() {
   var savedRequests = [];
 
   getObjectStore(STORE_NAME, 'readonly').openCursor().onsuccess = function(event) {
+    // See https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#Using_a_cursor
     var cursor = event.target.result;
 
     if (cursor) {
@@ -69,15 +77,21 @@ function replayAnalyticsRequests() {
 
       savedRequests.forEach(function(savedRequest) {
         var queueTime = Date.now() - savedRequest.timestamp;
+        // The qt= URL parameter specifies the time delta in between right now, and when the
+        // /collect request was initially intended to be sent. See
+        // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
         var requestUrl = savedRequest.url + '&qt=' + queueTime;
 
         console.log(' Replaying', requestUrl);
 
         fetch(requestUrl).then(function(response) {
           if (response.status < 400) {
+            // If sending the /collect request was successful, then remove it from the IndexedDB.
             getObjectStore(STORE_NAME, 'readwrite').delete(savedRequest.url);
             console.log(' Replaying succeeded.');
           } else {
+            // This will be triggered if, e.g., Google Analytics returns a HTTP 50x response.
+            // The request will be replayed the next time the service worker starts up.
             console.error(' Replaying failed:', response);
           }
         }).catch(function(error) {
@@ -90,6 +104,10 @@ function replayAnalyticsRequests() {
   };
 }
 
+// Open the IndexedDB and check for requests to replay each time the service worker starts up.
+// Since the service worker is terminated fairly frequently, it should start up again for most
+// page navigations. It also might start up if it's used in a background sync or a push
+// notification context.
 openDatabaseAndReplayRequests();
 
 self.addEventListener('activate', function(event) {
@@ -184,7 +202,12 @@ self.addEventListener('fetch', function(event) {
 });
 
 function checkForAnalyticsRequest(requestUrl) {
-  if (requestUrl.match(/\/\/www.google-analytics.com\/collect/i)) {
+  // Construct a URL object (https://developer.mozilla.org/en-US/docs/Web/API/URL.URL)
+  // to make it easier to check the various components without dealing with string parsing.
+  var url = new URL(requestUrl);
+
+  if ((url.hostname == 'www.google-analytics.com' || url.hostname == 'ssl.google-analytics.com') &&
+       url.pathname == '/collect') {
     console.log('  Storing Google Analytics request in IndexedDB to be replayed later.');
     saveAnalyticsRequest(requestUrl);
   }


### PR DESCRIPTION
@jakearchibald @ebidel & co.:

This builds on an existing sample that demonstrates offline functionality, and addresses the question of how to get a system like Google Analytics that relies on sending data to a remote server to play nicely with offline web pages.

The code queues failed Google Analytics pings in `IndexedDB` and attempts to resend them each time the service worker starts up, with the `dt=` parameter set to reflect the original time of the page view event.
