### PR TITLE
Update Service Worker/basic sample readme.

### DIFF
--- a/service-worker/basic/readme.md
+++ b/service-worker/basic/readme.md
@@ -1,16 +1,14 @@
-
 Service Worker Sample
 ===
 
 See https://googlechrome.github.io/samples/service-worker/basic/index.html for a live demo.
 
 
-#### Directions: 
+#### Directions:
 
-* Install Chrome Canary (Linux users can [build Chromium](https://code.google.com/p/chromium/wiki/LinuxBuildInstructions), Android users can [build ChromeShell](https://code.google.com/p/chromium/wiki/AndroidBuildInstructions).)
-* Open the browser and enable the Experimental Web Platform Features flag by cutting and pasting this URL: `chrome://flags/#enable-experimental-web-platform-features` . Enable the *Experimental Web Platform Features* option, then restart the browser.
-* Open the demo at https://googlechrome.github.io/samples/service-worker/basic/index.html  (source) 
-* Open the Inspector. Things are logged there later on.
+* Install Chrome, or another browser that supports Service Workers.
+* Open the demo at https://googlechrome.github.io/samples/service-worker/basic/index.html  [(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/basic/index.html)
+* Open the Developer Tools. Things are logged there later on.
 * Try visiting Cleveland and get a 404. Go back.
 * Click the 'Register' button, watch the Inspector console, then try visiting Cleveland again... oooh.
-* Go to `chrome://inspect#service-workers` and click on `Inspect` to open the Inspector and debug your Service Worker.
+* Go to `chrome://inspect#service-workers` and click on `Inspect` to open the Inspector and debug your Service Worker [(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/basic/service-worker.js)


### PR DESCRIPTION
Service Workers no longer require Canary or flipping flags.
