### PR TITLE
Add ES6 Classes samples

### DIFF
--- a/classes-es6/README.md
+++ b/classes-es6/README.md
@@ -1,0 +1,5 @@
+Classes (ES6) Sample
+===
+See https://googlechrome.github.io/samples/classes-es6/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/4633745457938432

--- a/classes-es6/index.html
+++ b/classes-es6/index.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Sample illustrating the use of Classes (ES6).">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>ES6 Classes</title>
+
+    <!-- Add to homescreen for Chrome on Android -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="icon" sizes="192x192" href="../images/touch/chrome-touch-icon-192x192.png">
+
+    <!-- Add to homescreen for Safari on iOS -->
+    <meta name="apple-mobile-web-app-title" content="ES6 Classes Sample">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" href="../images/apple-touch-icon-precomposed.png">
+
+    <!-- Tile icon for Win8 (144x144 + tile color) -->
+    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileColor" content="#3372DF">
+
+    <link rel="icon" href="../images/favicon.ico">
+
+    <link rel="stylesheet" href="../styles/main.css">
+  </head>
+
+  <body>
+    <h1>Classes (ES6) Sample</h1>
+
+    <p>Available in <a href="http://www.chromestatus.com/feature/4633745457938432">Chrome 42+</a></p>
+
+    <p>ES6 Classes formalize the common JavaScript pattern of simulating class-like inheritance hierarchies
+        using functions and prototypes. They are effectively simple sugaring over prototype-based OO, offering
+        a convenient declarative form for class patterns which encourage interoperability.</p>
+
+    <p>Classes (as shipped in Chrome) support prototype-based inheritance, constructors, super calls, instance
+        and static methods. The samples included in this demo are:</p>
+
+    <p>
+       <ul>
+        <li>Creating a new class (declaration-form)</li>
+        <li>Creating a new class (expression-form)</li>
+        <li>Extending an existing class</li>
+        <li>Subclassing methods of a parent class</li>
+        <li>Defining static methods</li>
+        <li>Subclassing built-ins (not yet supported)</li>
+       </ul>
+    </p>
+
+    <!-- // [START code-block] -->
+    <div class="output">
+        <pre id="log"></pre>
+    </div>
+
+    <script>
+        "use strict";
+
+        function log() {
+            document.querySelector('#log').textContent += Array.prototype.join.call(arguments, '') + '\n';
+        }
+
+        // Example 1: Creating a new class (declaration-form)
+        // ===============================================================
+
+        // A base class is defined using the new reserved 'class' keyword
+        class Polygon {
+            // ..and an (optional) custom class constructor. If one is
+            // not supplied, a default constructor is used instead:
+            // constructor() { }
+            constructor(height, width) {
+                this.name = 'Polygon';
+                this.height = height;
+                this.width = width;
+            }
+
+            // Simple class instance methods using short-hand method
+            // declaration
+            sayName() {
+                log('Hi, I am a ', this.name + '.');
+            }
+
+            sayHistory() {
+                log('"Polygon" is derived from the Greek polus (many) and gonia (angle).')
+            }
+
+            // We will look at static and subclassed methods shortly
+        }
+
+        // Classes are used just like ES5 constructor functions:
+        let p = new Polygon(300,400);
+        p.sayName();
+        log('The width of this polygon is ' + p.width);
+
+
+        // Example 2: Creating a new class (expression-form)
+        // ===============================================================
+
+        // Our Polygon class above is an example of a Class declaration.
+        // ES6 classes also support Class expressions - just another way
+        // of defining a new class. For example:
+        const MyPoly = class Poly {
+            getPolyName() {
+                log('Hi. I was created with a Class expression. My name is ' + Poly.name);
+            }
+        }
+
+        let inst = new MyPoly();
+        inst.getPolyName();
+
+
+        // Example 3: Extending an existing class
+        // ===============================================================
+
+        // Classes support extending other classes, but can also extend
+        // other objects. Let's extend the Polygon class to create a new
+        // derived class called Square.
+        class Square extends Polygon {
+            constructor(length) {
+                // The reserved 'super' keyword allows access to parent methods.
+                // Here, it will call the parent class' constructor with lengths
+                // provided for the Polygon's width and height
+                super(length, length);
+                // Note: In derived classes, super() must be called before you
+                // can use 'this'. Leaving this out will cause a reference error.
+                this.name = 'Square';
+            }
+
+            // Getter/setter methods are supported in classes,
+            // similar to their ES5 equivalents
+            get area() {
+                return this.height * this.width;
+            }
+
+            set area(value) {
+                this.area = value;
+            }
+        }
+
+        let s = new Square(5);
+
+        s.sayName();
+        log('The area of this square is ' + s.area);
+
+        // Example 4: Subclassing methods of a parent class
+        // ===============================================================
+
+        class Rectangle extends Polygon {
+            constructor(height, width) {
+                super(height, width);
+                this.name = 'Rectangle';
+            }
+            // Here, sayName() is a subclassed method which
+            // overrides their superclass method of the same name.
+            sayName() {
+                log('Sup! My name is ', this.name + '.');
+                super.sayHistory();
+            }
+        }
+
+        let r = new Rectangle(50, 60);
+        r.sayName();
+
+        // Example 5: Defining static methods
+        // ===============================================================
+
+        // Classes support static members which can be accessed without an
+        // instance being present.
+        class Tripple {
+            // Using the 'static' keyword creates a method which is associated
+            // with a class, but not with an instance of the class.
+            static tripple(n) {
+                n = n | 1;
+                return n * 3
+            }
+        }
+
+        // Similar to earlier methods in our other examples, super() calls to a
+        // parent class can also be made from inside a static method:
+        class BiggerTripple extends Tripple {
+            static tripple(n) {
+                return super.tripple(n) * super.tripple(n);
+            }
+        }
+
+        log(Tripple.tripple());
+        log(Tripple.tripple(6));
+        log(BiggerTripple.tripple(3));
+        var tp = new Tripple();
+        // log(tp.tripple()); tp.tripple is not a function
+
+
+        // Example 6: Subclassing built-in classes
+        // ===============================================================
+        // Note: At this time (Chrome 42), V8 does not support subclassing built-ins
+        // and DOM objects. This may change in the future.
+        //
+        //        class Stack extends Array {
+        //            constructor() {
+        //                super();
+        //            }
+        //
+        //            top() {
+        //                return this[this.length - 1];
+        //            }
+        //        }
+        //
+        //        var stack = new Stack();
+        //        stack.push('world');
+        //        stack.push('hello');
+        //        log(stack.top());
+        //        log(stack.length);
+    </script>
+    <!-- // [END code-block] -->
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-53563471-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- Built with love using Web Starter Kit -->
+  </body>
+</html>

--- a/classes-es6/index.html
+++ b/classes-es6/index.html
@@ -133,11 +133,15 @@ limitations under the License.
         // ===============================================================
 
         // Classes support extending other classes, but can also extend
-        // other objects. Let's extend the Polygon class to create a new
-        // derived class called Square.
+        // other objects. Whatever you extend must be a constructor.
+        //
+        // Let's extend the Polygon class to create a new derived class
+        // called Square.
         class Square extends Polygon {
             constructor(length) {
-                // The reserved 'super' keyword allows access to parent methods.
+                // The reserved 'super' keyword is for making super-constructor
+                // calls and allows access to parent methods.
+                //
                 // Here, it will call the parent class' constructor with lengths
                 // provided for the Polygon's width and height
                 super(length, length);
@@ -195,8 +199,8 @@ limitations under the License.
             }
         }
 
-        // Similar to earlier methods in our other examples, super() calls to a
-        // parent class can also be made from inside a static method:
+        // super.prop in this example is used for accessing super-properties from
+        // a parent class. This works fine in static methods too:
         class BiggerTripple extends Tripple {
             static tripple(n) {
                 return super.tripple(n) * super.tripple(n);
@@ -210,26 +214,8 @@ limitations under the License.
         // log(tp.tripple()); tp.tripple is not a function
 
 
-        // Example 6: Subclassing built-in classes
+        // Example 6: Subclassing built-in classes and DOM
         // ===============================================================
-        // Note: At this time (Chrome 42), V8 supports subclassing built-ins but
-        // will not support subclassing arrays until Chrome 43.
-        //
-        //        class Stack extends Array {
-        //            constructor() {
-        //                super();
-        //            }
-        //
-        //            top() {
-        //                return this[this.length - 1];
-        //            }
-        //        }
-        //
-        //        var stack = new Stack();
-        //        stack.push('world');
-        //        stack.push('hello');
-        //        log(stack.top());
-        //        log(stack.length);
 
         // Extend Date built-in
         class myDate extends Date {
@@ -280,6 +266,25 @@ limitations under the License.
         player.lyrics = 'Never gonna give you up';
         document.querySelector('body').appendChild(player);
         log(player.lyrics);
+
+        // Note: At this time (Chrome 42), V8 supports subclassing built-ins but
+        // will not support subclassing arrays until Chrome 43.
+        //
+        //        class Stack extends Array {
+        //            constructor() {
+        //                super();
+        //            }
+        //
+        //            top() {
+        //                return this[this.length - 1];
+        //            }
+        //        }
+        //
+        //        var stack = new Stack();
+        //        stack.push('world');
+        //        stack.push('hello');
+        //        log(stack.top());
+        //        log(stack.length);
     </script>
     <!-- // [END code-block] -->
 

--- a/classes-es6/index.html
+++ b/classes-es6/index.html
@@ -64,7 +64,7 @@ limitations under the License.
         <li>Extending an existing class</li>
         <li>Subclassing methods of a parent class</li>
         <li>Defining static methods</li>
-        <li>Subclassing built-ins (not yet supported)</li>
+        <li>Subclassing built-ins</li>
        </ul>
     </p>
 
@@ -212,8 +212,8 @@ limitations under the License.
 
         // Example 6: Subclassing built-in classes
         // ===============================================================
-        // Note: At this time (Chrome 42), V8 does not support subclassing built-ins
-        // and DOM objects. This may change in the future.
+        // Note: At this time (Chrome 42), V8 supports subclassing built-ins but
+        // will not support subclassing arrays until Chrome 43.
         //
         //        class Stack extends Array {
         //            constructor() {
@@ -230,6 +230,56 @@ limitations under the License.
         //        stack.push('hello');
         //        log(stack.top());
         //        log(stack.length);
+
+        // Extend Date built-in
+        class myDate extends Date {
+            constructor() {
+                super();
+            }
+
+            getFormattedDate() {
+                var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                return this.getDate() + "-" + months[this.getMonth()] + "-" + this.getFullYear();
+            }
+        }
+
+        var aDate = new myDate();
+        log(aDate.getTime());
+        log(aDate.getFormattedDate());
+
+        // Extend Uint8Array
+        class ExtendedUint8Array extends Uint8Array {
+            constructor() {
+                super(10);
+                this[0] = 255;
+                this[1] = 0xFFA;
+            }
+        }
+
+        var eua = new ExtendedUint8Array();
+        log(eua.byteLength);
+
+        // Extend DOM Audio element
+        class myAudio extends Audio {
+            constructor() {
+                super();
+                this._lyrics = '';
+            }
+
+            get lyrics() {
+                return this._lyrics;
+            }
+
+            set lyrics(str) {
+                this._lyrics = str;
+            }
+        }
+
+        var player = new myAudio();
+        player.controls = true;
+        player.lyrics = 'Never gonna give you up';
+        document.querySelector('body').appendChild(player);
+        log(player.lyrics);
     </script>
     <!-- // [END code-block] -->
 


### PR DESCRIPTION
reviewers: @jeffposnick
Also welcome feedback from: @rauschma

Limitations noted in the intent-to-ship, which impact the scope of what was implemented here:

> - At this time we do not support subclassing built-ins and DOM objects (I've added a sample, but commented out)
> - Current ES6 specification (in particular, [[CreateAction]] hook that takes arguments) makes design of subclassable exotic (in particular DOM) objects unclear. We intend to work with involved parties on resolving this difficulty, but for now we add an extra limitation to calls to super constructor in subclasses: if a subclass constructor calls a superclass constructor via ‘super(...)’ call, that call must be the first statement of constructor’s body, and arguments to ‘super(...)’ call can not refer to ‘this’. 
>   We intend to lift this restriction in the future, once we clarify the design for exotic objects’ subclassing.

Note: these samples are intentional minimal to lower the friction involved in getting beginners on-board with the syntax. 
