### PR TITLE
Fix for mixed content error

### DIFF
--- a/service-worker/offline-analytics/index.html
+++ b/service-worker/offline-analytics/index.html
@@ -93,8 +93,8 @@ limitations under the License.
       <div id="status"></div>
 
       <ul id="images" style="display: none">
-        <li><img src="http://www.chromium.org/_/rsrc/1302286216006/config/customLogo.gif"></li>
-        <li><img src="http://www.chromium.org/_/rsrc/1365117468642/chromium-projects/chrome-64.png"></li>
+        <li><img src="https://www.chromium.org/_/rsrc/1302286216006/config/customLogo.gif"></li>
+        <li><img src="https://www.chromium.org/_/rsrc/1365117468642/chromium-projects/chrome-64.png"></li>
       </ul>
     </div>
 


### PR DESCRIPTION
It was working fine on localhost, but I got error on remote server:

> Mixed Content: The page at 'https://googlechrome.github.io/samples/service-worker/offline-analytics/index.html' was loaded over HTTPS, but requested an insecure image 'http://www.chromium.org/_/rsrc/1302286216006/config/customLogo.gif'. This content should also be served over HTTPS.
