### PR TITLE
Set output and highlight style display to block

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -16,7 +16,7 @@ h3 {
 .output {
   background-color: #f0f0f0;
   border-radius: 0.75em;
-  display: inline-block;
+  display: block;
   margin: 0.5em;
   padding: 0.5em;
 }
@@ -33,7 +33,7 @@ h3 {
 .highlight {
   border-radius: 0.75em;
   border: 1px solid #f0f0f0;
-  display: inline-block;
+  display: block;
   margin: 0.5em;
   overflow-x: auto;
   padding: 0.5em;


### PR DESCRIPTION
I think `inline-block` should not be the intended behaviour by default for `output` and `highlight`. This patch addresses this issue. 

@jeffposnick 
