### PR TITLE
Rewrite of the SW post message example

### DIFF
--- a/service-worker/post-message/index.html
+++ b/service-worker/post-message/index.html
@@ -1,207 +1,136 @@
-<!doctype html>
-<!--
-Copyright 2014 Google Inc. All Rights Reserved.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+---
+feature_name: Service Worker postMessage()
+chrome_version: 45
+feature_id: 5163630974730240
+https_redirect: true
+---
 
-    <meta name="description" content="Sample of using postMessage to communicate with Service Workers.">
+<h3>Background</h3>
+<p>
+  This sample demonstrates basic Service Worker registration, in conjunction with using the
+  <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage"><code>postMessage</code></a>
+  interface to communicate with the service worker controlling the page.
+</p>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+<p>
+  The service worker's
+  <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-onmessage-attribute"><code>onmessage</code> handler</a>
+  behaves differently depending on the type of message it receives; there's an arbitrary set of
+  "commands" that this controlled page can send it to do things like determine whether the resource
+  at a given URL is present in the cache, add resources to the cache, or remove them.
+</p>
 
-    <title>Service Worker Sample: Posting Messages</title>
+<p>
+  Starting in Chrome 45, it's also possible for a service worker to initiate a message to one or
+  more of the clients (i.e. this page) that it controls. For the purposes of this example, as soon
+  as this service worker finishes its <code>activate</code> handler, it sends a message to all of
+  its clients letting it know that it's ready. This is roughly equivalent to listening for service
+  work lifecycle events on the underlying registration.
+</p>
 
-    <!-- Add to homescreen for Chrome on Android -->
-    <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
+{% capture initial_output_content %}
+<div id="commands" style="display: none">
+  <div>
+    <label for="url">Resource URL:</label>
+    <input id="url" type="text" size="50" value="https://www.google.com/">
+    <button id="add">Add to Cache</button>
+    <button id="delete">Delete from Cache</button>
+  </div>
+  <div>
+    <button id="list-contents">List Current Cache Contents</button>
+  </div>
+  <ul id="contents"></ul>
+</div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
 
-    <!-- Add to homescreen for Safari on iOS -->
-    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Posting Messages">
+{% capture js %}
+function showCommands() {
+  document.querySelector('#add').addEventListener('click', function() {
+    sendMessage({
+      command: 'add',
+      url: document.querySelector('#url').value
+    }).then(function() {
+      // If the promise resolves, just display a success message.
+      ChromeSamples.setStatus('Added to cache.');
+    }).catch(ChromeSamples.setStatus); // If the promise rejects, show the error.
+  });
 
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
+  document.querySelector('#delete').addEventListener('click', function() {
+    sendMessage({
+      command: 'delete',
+      url: document.querySelector('#url').value
+    }).then(function() {
+      // If the promise resolves, just display a success message.
+      ChromeSamples.setStatus('Deleted from cache.');
+    }).catch(ChromeSamples.setStatus); // If the promise rejects, show the error.
+  });
 
-    <!-- Tile icon for Win8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
-    <meta name="msapplication-TileColor" content="#3372DF">
+  document.querySelector('#list-contents').addEventListener('click', function() {
+    sendMessage({command: 'keys'})
+      .then(function(data) {
+        var contentsElement = document.querySelector('#contents');
+        // Clear out the existing items from the list.
+        while (contentsElement.firstChild) {
+          contentsElement.removeChild(contentsElement.firstChild);
+        }
 
-    <link rel="icon" href="../../images/favicon.ico">
-
-    <script>
-      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
-      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
-      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
-        location.protocol = 'https:';
-      }
-    </script>
-
-    <link rel="stylesheet" href="../../styles/main.css">
-  </head>
-
-  <body>
-    <h1>Service Worker Sample: Posting Messages</h1>
-
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
-
-    <p>
-      This sample demonstrates basic Service Worker registration, in conjunction with using the
-      <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage"><code>postMessage</code></a>
-      interface to communicate with the service worker controlling the page. Note that while the service worker can
-      reply to messages sent from a controlled page, it's currently not possible for the service worker to originate a
-      message. (The Push API specification, which is closely related to service workers, is currently being developed,
-      and covers some of the use cases in which a service worker creates a message displayed to an end user.)
-    </p>
-
-    <p>
-      The service worker's
-      <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-onmessage-attribute"><code>onmessage</code> handler</a>
-      behaves differently depending on the type of message it receives; there's an arbitrary set of "commands" that this
-      controlled page can send it to do things like determine whether the resource at a given URL is present in the
-      cache, add resources to the cache, or remove them. Since the controlled page doesn't have access to the service
-      worker's cache, using this type of message passing is a common way to get insight into the cache's contents.
-    </p>
-
-    <p>
-      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
-      the registered Service Worker to view logging statements for the various actions the
-      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
-    </p>
-
-    <div class="output">
-      <div id="status"></div>
-
-      <div id="commands" style="display: none">
-        <div>
-          <label for="url">Resource URL:</label>
-          <input id="url" type="text" size="50" value="https://www.google.com/">
-          <button id="add">Add to Cache</button>
-          <button id="delete">Delete from Cache</button>
-        </div>
-        <div>
-          <button id="list-contents">List Cache Contents</button>
-        </div>
-        <ul id="contents"></ul>
-      </div>
-    </div>
-
-    <script>
-      function setStatus(statusMessage) {
-        document.querySelector('#status').textContent = statusMessage;
-      }
-
-      function showCommands() {
-        document.querySelector('#add').addEventListener('click', function() {
-          sendMessage({
-            command: 'add',
-            url: document.querySelector('#url').value
-          }).then(function() {
-            // If the promise resolves, just display a success message.
-            setStatus('Added to cache.');
-          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
+        // Add each cached URL to the list, one by one.
+        data.urls.forEach(function(url) {
+          var liElement = document.createElement('li');
+          liElement.textContent = url;
+          contentsElement.appendChild(liElement);
         });
+      }).catch(ChromeSamples.setStatus); // If the promise rejects, show the error.
+  });
 
-        document.querySelector('#delete').addEventListener('click', function() {
-          sendMessage({
-            command: 'delete',
-            url: document.querySelector('#url').value
-          }).then(function() {
-            // If the promise resolves, just display a success message.
-            setStatus('Deleted from cache.');
-          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
-        });
+  document.querySelector('#commands').style.display = 'block';
+}
 
-        document.querySelector('#list-contents').addEventListener('click', function() {
-          sendMessage({
-            command: 'keys'
-          }).then(function(data) {
-            var contentsElement = document.querySelector('#contents');
-            // Clear out the existing items from the list.
-            while (contentsElement.firstChild) {
-              contentsElement.removeChild(contentsElement.firstChild);
-            }
-
-            // Add each cached URL to the list, one by one.
-            data.urls.forEach(function(url) {
-              var liElement = document.createElement('li');
-              liElement.textContent = url;
-              contentsElement.appendChild(liElement);
-            });
-          }).catch(setStatus); // If the promise rejects, then setStatus will be called with the error.
-        });
-
-        document.querySelector('#commands').style.display = 'block';
-      }
-
-      function sendMessage(message) {
-        // This wraps the message posting/response in a promise, which will resolve if the response doesn't
-        // contain an error, and reject with the error if it does. If you'd prefer, it's possible to call
-        // controller.postMessage() and set up the onmessage handler independently of a promise, but this is
-        // a convenient wrapper.
-        return new Promise(function(resolve, reject) {
-          var messageChannel = new MessageChannel();
-          messageChannel.port1.onmessage = function(event) {
-            if (event.data.error) {
-              reject(event.data.error);
-            } else {
-              resolve(event.data);
-            }
-          };
-
-          // This sends the message data as well as transferring messageChannel.port2 to the service worker.
-          // The service worker can then use the transferred port to reply via postMessage(), which
-          // will in turn trigger the onmessage handler on messageChannel.port1.
-          // See https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage
-          navigator.serviceWorker.controller.postMessage(message, [messageChannel.port2]);
-        });
-      }
-
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('./service-worker.js', {scope: './'}).then(function() {
-            // Registration was successful. Now, check to see whether the Service Worker is controlling the page.
-            if (navigator.serviceWorker.controller) {
-              // If .controller is set, then this page is being actively controlled by the Service Worker.
-              // Show the interface for sending messages to the service worker.
-              showCommands();
-            } else {
-              // If .controller isn't set, then prompt the user to reload the page so that the Service Worker can take
-              // control. Until that happens, the Service Worker's message handler won't be used.
-              document.querySelector('#status').textContent =
-                'Please reload this page to allow the service worker to take control.';
-            }
-        }).catch(function(error) {
-          // Something went wrong during registration. The service-worker.js file
-          // might be unavailable or contain a syntax error.
-          document.querySelector('#status').textContent = error;
-        });
+function sendMessage(message) {
+  // This wraps the message posting/response in a promise, which will resolve if the response doesn't
+  // contain an error, and reject with the error if it does. If you'd prefer, it's possible to call
+  // controller.postMessage() and set up the onmessage handler independently of a promise, but this is
+  // a convenient wrapper.
+  return new Promise(function(resolve, reject) {
+    var messageChannel = new MessageChannel();
+    messageChannel.port1.onmessage = function(event) {
+      if (event.data.error) {
+        reject(event.data.error);
       } else {
-        // The current browser doesn't support Service Workers.
-        var aElement = document.createElement('a');
-        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
-        aElement.textContent = 'Service Workers are not supported in the current browser.';
-        document.querySelector('#status').appendChild(aElement);
+        resolve(event.data);
       }
-    </script>
+    };
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-53563471-1', 'auto');
-      ga('send', 'pageview');
-    </script>
-    <!-- Built with love using Web Starter Kit -->
-  </body>
-</html>
+    // This sends the message data as well as transferring messageChannel.port2 to the service worker.
+    // The service worker can then use the transferred port to reply via postMessage(), which
+    // will in turn trigger the onmessage handler on messageChannel.port1.
+    // See https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage
+    navigator.serviceWorker.controller.postMessage(message, [messageChannel.port2]);
+  });
+}
+
+if ('serviceWorker' in navigator) {
+  // Set up a listener for messages posted from the service worker.
+  // The service worker is set to post a message to all its clients once it's run its activation
+  // handler and taken control of the page, so you should see this message event fire once.
+  // You can force it to fire again by visiting this page in an Incognito window.
+  navigator.serviceWorker.addEventListener('message', function(event) {
+    ChromeSamples.setStatus(event.data);
+  });
+
+  navigator.serviceWorker.register('service-worker.js')
+    // Wait until the service worker is active.
+    .then(navigator.serviceWorker.ready)
+    // ...and then show the interface for the commands once it's ready.
+    .then(showCommands)
+    .catch(function(error) {
+      // Something went wrong during registration. The service-worker.js file
+      // might be unavailable or contain a syntax error.
+      ChromeSamples.setStatus(error);
+    });
+} else {
+  ChromeSamples.setStatus('Service workers are not supported in the current browser.');
+}
+{% endcapture %}
+{% include js_snippet.html js=js %}


### PR DESCRIPTION
R: @addyosmani @wibblymat
CC: @mattto @jakearchibald

This is a rewrite of the existing sample showing off how to use `postMessage()` to communicate between the service worker and a controlled page.

The biggest change is that it shows off the new `Client.postMessage()` and associated `navigator.serviceWorker.onmessage` handler, for messages initiated from the service worker, in addition to showing messages going in the other direction.

The original sample was written in the M40 timeframe, so there are a few things that have changed since then in general: `Cache.add()` doesn't need a polyfill anymore, and `clients.claim()` is a thing.

It moves to the new templates, so a lot of the HTML boilerplate is gone.

You can view a live example (best in M45) at https://jeffy.info/samples/service-worker/post-message/
