### PR TITLE
Added Web Bluetooth Sample

### DIFF
--- a/web-bluetooth/README.md
+++ b/web-bluetooth/README.md
@@ -1,0 +1,5 @@
+Web Bluetooth Sample
+====================
+See https://googlechrome.github.io/samples/web-bluetooth/index.html for a live demo.
+
+Learn more at http://www.chromestatus.com/feature/5264933985976320

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -9,8 +9,8 @@ feature_id: 5264933985976320
 <p>This sample illustrates the use of the Web Bluetooth API to retrieve battery
 information from a nearby Bluetooth Device advertising Battery information with
 Bluetooth Low Energy. You may want to try this demo with the BLE Peripheral
-Simulator App from the <a href="_blank"
-target="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
 Play Store</a>.</p>
 
 <button>Get Bluetooth Device Battery</button>
@@ -27,19 +27,20 @@ function onButtonClick() {
   .then(device => {
     log('> Found ' + device.name);
     log('Connecting to GATT Server...');
-    return device.connectGATT()
+    return device.connectGATT();
   })
   .then(server => {
     log('Getting Battery Service...');
-    return server.getPrimaryService('battery_service')
+    return server.getPrimaryService('battery_service');
   })
   .then(service => {
+    if (!service) throw 'Battery Service not found';
     log('Getting Battery Level Characteristic...');
-    return service.getCharacteristic('battery_level')
+    return service.getCharacteristic('battery_level');
   })
   .then(characteristic => {
      log('Reading Battery Level...');
-     return characteristic.readValue()
+     return characteristic.readValue();
   })
   .then(buffer => {
     let data = new DataView(buffer);
@@ -51,13 +52,14 @@ function onButtonClick() {
   });
 };
 {% endcapture %}
-{% include js_snippet.html js=js title='Javascript Snippet' %}
+{% include js_snippet.html js=js %}
 
 <script>
 document.querySelector('button').addEventListener('click', function() {
   document.querySelector('#log').textContent = '';
   if (!navigator.bluetooth) {
     log('Web Bluetooth API is not available.');
+    log('Please make sure you run Chrome OS M45 and Web Bluetooth flag is enabled.');
   } else {
     onButtonClick();
   }

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -4,7 +4,7 @@ chrome_version: 45
 feature_id: 5264933985976320
 ---
 
-<p><a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth API</a> gives you access to user-selected Bluetooth devices over GATT. It is partially implemented in Chrome OS behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.</p>
+<p>The <a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth API</a> aims to discover and communicate with devices over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT). It is currently only partially implemented in Chrome OS behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.</p>
 
 <p>This sample illustrates the use of the Web Bluetooth API to retrieve battery
 information from a nearby Bluetooth Device advertising Battery information with
@@ -23,7 +23,7 @@ function onButtonClick() {
   'use strict';
 
   log('Requesting Bluetooth Device...');
-  navigator.bluetooth.requestDevice({filters: [{services: ['battery_service']}]})
+  navigator.bluetooth.requestDevice({filters:[{services:['battery_service']}]})
   .then(device => {
     log('> Found ' + device.name);
     log('Connecting to GATT Server...');

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -1,0 +1,66 @@
+---
+feature_name: Web Bluetooth
+chrome_version: 45
+feature_id: 5264933985976320
+---
+
+<p><a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth API</a> gives you access to user-selected Bluetooth devices over GATT. It is partially implemented in Chrome OS behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.</p>
+
+<p>This sample illustrates the use of the Web Bluetooth API to retrieve battery
+information from a nearby Bluetooth Device advertising Battery information with
+Bluetooth Low Energy. You may want to try this demo with the BLE Peripheral
+Simulator App from the <a href="_blank"
+target="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a>.</p>
+
+<button>Get Bluetooth Device Battery</button>
+{% capture initial_output_content %}
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% capture js %}
+function onButtonClick() {
+  'use strict';
+
+  log('Requesting Bluetooth Device...');
+  navigator.bluetooth.requestDevice({filters: [{services: ['battery_service']}]})
+  .then(device => {
+    log('> Found ' + device.name);
+    log('Connecting to GATT Server...');
+    return device.connectGATT()
+  })
+  .then(server => {
+    log('Getting Battery Service...');
+    return server.getPrimaryService('battery_service')
+  })
+  .then(service => {
+    log('Getting Battery Level Characteristic...');
+    return service.getCharacteristic('battery_level')
+  })
+  .then(characteristic => {
+     log('Reading Battery Level...');
+     return characteristic.readValue()
+  })
+  .then(buffer => {
+    let data = new DataView(buffer);
+    let batteryLevel = data.getUint8(0);
+    log('> Battery Level is ' + batteryLevel + '%');
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+};
+{% endcapture %}
+{% include js_snippet.html js=js title='Javascript Snippet' %}
+
+<script>
+document.querySelector('button').addEventListener('click', function() {
+  document.querySelector('#log').textContent = '';
+  if (!navigator.bluetooth) {
+    log('Web Bluetooth API is not available.');
+  } else {
+    onButtonClick();
+  }
+});
+log = ChromeSamples.log;
+</script>


### PR DESCRIPTION
This "Read BLE Battery" sample will go with the upcoming "web/updates" article on the Web Bluetooth API.

Note: You can easily play with this on Chrome OS Dev Channel at https://beaufortfrancois.github.io/samples/web-bluetooth

@scheib Can you review this simple code?
