### PR TITLE
Swap around if/else logic around titles in templates

### DIFF
--- a/_includes/css_snippet.html
+++ b/_includes/css_snippet.html
@@ -1,11 +1,13 @@
 {% if include.css %}
-<style>{{ include.css }}</style>
-{% if include.title != "" %}
-<h3>{{ include.title }}</h3>
-{% elsif include.title == null %}
-<h3>CSS Snippet</h3>
-{% endif %}
-{% highlight css %}
-{{ include.css }}
-{% endhighlight %}
+  <style>{{ include.css }}</style>
+
+  {% if include.title == null %}
+    <h3>CSS Snippet</h3>
+  {% elsif include.title != "" %}
+    <h3>{{ include.title }}</h3>
+  {% endif %}
+
+  {% highlight css %}
+    {{ include.css }}
+  {% endhighlight %}
 {% endif %}

--- a/_includes/html_snippet.html
+++ b/_includes/html_snippet.html
@@ -1,11 +1,13 @@
 {% if include.html %}
-{{ include.html }}
-{% if include.title != "" %}
-<h3>{{ include.title }}</h3>
-{% elsif include.title == null %}
-<h3>HTML Snippet</h3>
-{% endif %}
-{% highlight html %}
-{{ include.html }}
-{% endhighlight %}
+  {{ include.html }}
+
+  {% if include.title == null %}
+    <h3>HTML Snippet</h3>
+  {% elsif include.title != "" %}
+    <h3>{{ include.title }}</h3>
+  {% endif %}
+
+  {% highlight html %}
+    {{ include.html }}
+  {% endhighlight %}
 {% endif %}

--- a/_includes/js_snippet.html
+++ b/_includes/js_snippet.html
@@ -1,11 +1,13 @@
 {% if include.js %}
-<script>{{ include.js }}</script>
-{% if include.title != "" %}
-<h3>{{ include.title }}</h3>
-{% elsif include.title == null %}
-<h3>JavaScript Snippet</h3>
-{% endif %}
-{% highlight js %}
-{{ include.js }}
-{% endhighlight %}
+  <script>{{ include.js }}</script>
+
+  {% if include.title == null %}
+    <h3>JavaScript Snippet</h3>
+  {% elsif include.title != "" %}
+    <h3>{{ include.title }}</h3>
+  {% endif %}
+
+  {% highlight js %}
+    {{ include.js }}
+  {% endhighlight %}
 {% endif %}


### PR DESCRIPTION
R: @beaufortfrancois 

I think the logic in https://github.com/GoogleChrome/samples/pull/156 needs to be tweaked a bit. I noticed that leaving out the snippet title parameter was leading to an empty `<h3>` as opposed to the default `<h3>`.

Compare https://jeffy.info/samples/report-validity/ (with this PR) to http://googlechrome.github.io/samples/report-validity/ (without this PR).

I'm also adding some indentation to make the logic clearer.
