### PR TITLE
Add Object.assign() sample (fixes #152)

### DIFF
--- a/object-assign-es6/README.md
+++ b/object-assign-es6/README.md
@@ -1,0 +1,6 @@
+Object.assign() (ES6) Sample
+===
+See https://googlechrome.github.io/samples/object-assign-es6/index.html for a live demo.
+
+<!-- TODO: Replace PLACEHOLDER with the id from the chromestatus.com URL. -->
+<!--Learn more at https://www.chromestatus.com/feature/PLACEHOLDER-->

--- a/object-assign-es6/index.html
+++ b/object-assign-es6/index.html
@@ -1,0 +1,46 @@
+---
+feature_name: ES6 Object.assign()
+chrome_version: 45
+feature_id: REPLACE_ME
+additional_head_content: <meta name="optional" value="optional">
+---
+
+<h3>Background</h3>
+<p><code>Object.assign()</code> copies the values (of all enumerable own properties) from one or more source objects to a target object. It is useful for merging objects or cloning them shallowly.</p>
+
+{% capture initial_output_content %}
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% capture js %}
+'use strict';
+
+// Merge an object
+let first = { name: "Tony" };
+let last = { lastName: "Stark" };
+let person = Object.assign(first, last);
+ChromeSamples.log(JSON.stringify(person));
+// {name: "Tony", lastName: "Stark"}
+ChromeSamples.log(JSON.stringify(first));
+// first = {name: "Tony", lastName: "Stark"} as the target also changed
+
+// Merge multiple sources
+let a = Object.assign({foo: 0}, {bar: 1}, {baz: 2});
+ChromeSamples.log(JSON.stringify(a));
+// {foo: 0, bar: 1, baz: 2}
+
+// Merge and overwrite equal keys
+let b = Object.assign({foo: 0}, {foo: 1}, {foo: 2});
+ChromeSamples.log(JSON.stringify(b));
+// {foo: 2}
+
+// Clone an object
+let obj = { person: "Thor Odinson"};
+let clone = Object.assign({}, obj);
+ChromeSamples.log(JSON.stringify(clone));
+// {person: "Thor Odinson"}
+
+{% endcapture %}
+{% include js_snippet.html js=js %}
+
+{% include css_snippet.html css=css %}

--- a/object-assign-es6/index.html
+++ b/object-assign-es6/index.html
@@ -2,11 +2,10 @@
 feature_name: ES6 Object.assign()
 chrome_version: 45
 feature_id: REPLACE_ME
-additional_head_content: <meta name="optional" value="optional">
 ---
 
 <h3>Background</h3>
-<p><code>Object.assign()</code> copies the values (of all enumerable own properties) from one or more source objects to a target object. It is useful for merging objects or cloning them shallowly.</p>
+<p><code>Object.assign()</code> copies the values (of all enumerable own properties) from one or more source objects to a target object. It has a signature of <code>Object.assign(target, ...sources)</code>. The target object is the first parameter and is also used as the return value. <code>Object.assign()</code> is useful for merging objects or cloning them shallowly.</p>
 
 {% capture initial_output_content %}
 {% endcapture %}
@@ -19,28 +18,26 @@ additional_head_content: <meta name="optional" value="optional">
 let first = { name: "Tony" };
 let last = { lastName: "Stark" };
 let person = Object.assign(first, last);
-ChromeSamples.log(JSON.stringify(person));
+ChromeSamples.log(person);
 // {name: "Tony", lastName: "Stark"}
-ChromeSamples.log(JSON.stringify(first));
+ChromeSamples.log(first);
 // first = {name: "Tony", lastName: "Stark"} as the target also changed
 
 // Merge multiple sources
 let a = Object.assign({foo: 0}, {bar: 1}, {baz: 2});
-ChromeSamples.log(JSON.stringify(a));
+ChromeSamples.log(a);
 // {foo: 0, bar: 1, baz: 2}
 
 // Merge and overwrite equal keys
 let b = Object.assign({foo: 0}, {foo: 1}, {foo: 2});
-ChromeSamples.log(JSON.stringify(b));
+ChromeSamples.log(b);
 // {foo: 2}
 
 // Clone an object
 let obj = { person: "Thor Odinson"};
 let clone = Object.assign({}, obj);
-ChromeSamples.log(JSON.stringify(clone));
+ChromeSamples.log(clone);
 // {person: "Thor Odinson"}
 
 {% endcapture %}
 {% include js_snippet.html js=js %}
-
-{% include css_snippet.html css=css %}


### PR DESCRIPTION
r: @jeffposnick 

Minor feedback on templating: I found myself needing to `JSON.stringify()` object output in order for it to display correctly in the ChromeSamples output area. To make it easier for someone to take the source and modify it for use in the console without this, we may want to make `ChromeSamples.log` a little smarter when it comes to type detection, but this may also be out of scope. 
