### PR TITLE
Top-level index.html redirect to chromestatus.com/features

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head>
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0;URL='https://www.chromestatus.com/features'">
+</head>
+</html>


### PR DESCRIPTION
R: @PaulKinlan @gauntface @addyosmani @ebidel

@ebidel is going to be putting together a real samples landing page (see GoogleChrome/chromium-dashboard#216)

In the meantime, re: #37, here's a redirect to the main chromestatus.com features list. Once the samples landing page is created, we can update the redirect to point there instead.
