### PR TITLE
Call JSON.stringify() on non-string arguments while logging

### DIFF
--- a/_includes/output_helper.html
+++ b/_includes/output_helper.html
@@ -1,7 +1,11 @@
 <script>
   var ChromeSamples = {
     log: function() {
-      document.querySelector('#log').textContent += Array.prototype.join.call(arguments, '') + '\n';
+      var line = Array.prototype.slice.call(arguments).map(function(argument) {
+        return typeof argument === 'string' ? argument : JSON.stringify(argument);
+      }).join(' ');
+
+      document.querySelector('#log').textContent += line + '\n';
     },
 
     setStatus: function(status) {


### PR DESCRIPTION
R: @addyosmani 

Addresses the feedback you had in https://github.com/GoogleChrome/samples/pull/169 about logging.
