### PR TITLE
Reverts a few body styles

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2,8 +2,6 @@ body {
   background-color: #ffffff;
   box-sizing: border-box;
   font-family: sans-serif;
-  margin: 0 auto;
-  max-width: 800px;
 }
 
 @media screen and (min-width: 832px) {


### PR DESCRIPTION
R: @beaufortfrancois 

I'm not sure how these extra styles ended up being applied to `body` (they got picked up in this merge: https://github.com/GoogleChrome/samples/commit/d1fc4d9fadaef5fb65c56f50b88627cab9470f36), but I don't think they're intentional and removing them makes things look a bit better on smaller viewports.
