### PR TITLE
Travis CI config for Jekyll build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: "bundle exec jekyll build"


### PR DESCRIPTION
R: @PaulKinlan @addyosmani etc.

This is part of the [configuration process](https://help.github.com/articles/troubleshooting-github-pages-build-failures/#configuring-a-third-party-service-to-display-jekyll-build-error-messages) for setting up a Travis CI Jekyll build.
