### PR TITLE
jshint-based linting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,13 @@
+{
+  "esnext": true,
+  "expr": true,
+  "globalstrict": true,
+  "strict": false,
+  "globals": {
+    "console": false,
+    "self": false,
+    "window": false,
+    "navigator": false,
+    "document": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ the functionality. The email address of the engineer who worked on a given featu
 the corresponding https://www.chromestatus.com/features entry. If you're unsure of the GitHub
 username corresponding to the engineer, an alternative is to email them a link to the pull request
 and ask for feedback directly.
+
+Style / Linting / CI
+===
+The samples ideally should follow the [Google JavaScript Style Guide](http://google.github.io/styleguide/javascriptguide.xml),
+though this is not automatically enforced. (See https://github.com/GoogleChrome/samples/issues/141)
+
+It's recommended that all new samples pass the [`jshint`](http://jshint.com/install/) linting
+process, using the customized [`.jshintrc`](.jshintrc) settings. To automate linting against
+JavaScript in the Jekyll-ized HTML output, [`linter.rb`](linter.rb) can be used. Regular
+contributors should set up a git pre-commit
+[hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to run [`linter.rb`](linter.rb)
+against all files that are being committed, via `ln -s -f ../../linter.rb .git/hooks/pre-commit`
+
+[Travis CI](https://travis-ci.org/GoogleChrome/samples) is currently being used to verify that the
+Jekyll build completes successfully, but doesn't currently lint/style check the full site.
+Once the all the older files in the project have been updated to pass `linter.rb` cleanly, that will
+be integrated into the Travis CI process.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ contributors should set up a git pre-commit
 [hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to run [`linter.rb`](linter.rb)
 against all files that are being committed, via `ln -s -f ../../linter.rb .git/hooks/pre-commit`
 
+Various IDEs offer real-time JSHint integration (e.g. via
+[SublimeLinter-jshint](https://github.com/SublimeLinter/SublimeLinter-jshint)) and using those
+integrations that can help avoid errors before anything gets checked in.
+
 [Travis CI](https://travis-ci.org/GoogleChrome/samples) is currently being used to verify that the
 Jekyll build completes successfully, but doesn't currently lint/style check the full site.
 Once the all the older files in the project have been updated to pass `linter.rb` cleanly, that will

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,12 +40,14 @@ limitations under the License.
     {{ content }}
     {% for local_js_file in page.local_js_files %}<script src="{{ local_js_file }}"></script>{% endfor %}
     <script>
+      /* jshint ignore:start */
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-53563471-1', 'auto');
       ga('send', 'pageview');
+      /* jshint ignore:end */
     </script>
   </body>
 </html>

--- a/linter.rb
+++ b/linter.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a script to lint one or more files for common errors.
+# It's ideal for using as part of a git pre-commit hook; use the following to set up the hook:
+#     ln -s -f ../../linter.rb .git/hooks/pre-commit
+# It can also be run manually, and takes file names (relative to the git root) as parameters.
+# The script checks for the following, and exits with a non-zero status if any condition fails:
+# - a successful Jekyll site build
+# - for each file, that all boilerplate content has been removed
+# - for each file, that the templated version of it under _site/ passes jshint
+
+# We need at least one file name as a parameter.
+files = ARGV.clone
+if files.length == 0
+  files = `git diff --cached --name-only --diff-filter=ACM`.split("\n")
+end
+fail('No files found in git diff, nor provided as command line parameters.') unless files.length > 0
+
+# Bail out if we can't perform a Jekyll site build.
+output = `bundle exec jekyll build`
+unless $?.success?
+  fail("Unable to perform Jekyll build:\n#{output}")
+end
+
+JS_HINT_EXTENSIONS = %w(.html .js)
+passed = true
+
+files.each do |file|
+  File.foreach(file) do |line|
+    # Make sure any boilerplate has been removed, unless we're checking one of the files in the
+    # starter directory, or checking this linter.rb file.
+    # We need to hardcode linter.rb instead of checking $PROGRAM_NAME, since this code may be run as
+    # .git/hooks/pre-commit
+    if line.match(/REPLACE_ME|PLACEHOLDER/) and
+        !File.absolute_path(file).match(Regexp.new("SAMPLE_STARTING_POINT|linter\.rb"))
+      puts("Boilerplate found in #{file}: #{line}")
+      passed = false
+    end
+  end
+
+  # Run jshint on any HTML or JS files that changed, using the fully built _site/ version.
+  if JS_HINT_EXTENSIONS.include?(File.extname(file))
+    output = `jshint --extract=auto _site/#{file}`
+    unless $?.success?
+      passed = false
+      puts(output)
+    end
+  end
+end
+
+if passed
+  puts('All checks passed.')
+else
+  fail('One or more errors were found.')
+end

--- a/linter.rb
+++ b/linter.rb
@@ -21,7 +21,7 @@
 # The script checks for the following, and exits with a non-zero status if any condition fails:
 # - a successful Jekyll site build
 # - for each file, that all boilerplate content has been removed
-# - for each file, that the templated version of it under _site/ passes jshint
+# - for each file, that the templated version of it under _site/ passes JSHint
 
 # We need at least one file name as a parameter.
 files = ARGV.clone


### PR DESCRIPTION
R: @addyosmani @PaulKinlan @gauntface _et alii_

This introduces a new `linter.rb` script, which can be run either manually or via `.git/hook/pre-commit` (recommended), and checks for the following:
- a successful Jekyll site build
- for each (committed) file, that all boilerplate content has been removed
- for each (committed) file, that the templated version of it under _site/ passes `jshint`

The idea is that for now this would be recommended for all new/modified files, and we'd also clean up the backlog/adjust `.jshintrc` to make `jshint` happy with everything. At that point, we can update Travis CI to automatically lint the full site as part of every PR.

Related to https://github.com/GoogleChrome/samples/issues/141, but not enough to close it out yet.
