### PR TITLE
Redirect to HTTPS for all pages using the new templates.

### DIFF
--- a/_includes/https_redirect.html
+++ b/_includes/https_redirect.html
@@ -1,8 +1,0 @@
-<script>
-  // If we're running on a real web server (as opposed to localhost on a custom port,
-  // which is whitelisted), then change the protocol to HTTPS.
-  // See https://goo.gl/lq4gCo for an explanation.
-  if ((!location.port || location.port == "80") && location.protocol != 'https:') {
-    location.protocol = 'https:';
-  }
-</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,14 @@ limitations under the License.
     <meta name="description" content="Sample illustrating the use of {{ page.feature_name }}.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ page.feature_name }} Sample{% endif %}</title>
-    {% if page.https_redirect %}{% include https_redirect.html %}{% endif %}
+    <script>
+      // If we're running on a real web server (as opposed to localhost on a custom port,
+      // which is whitelisted), then change the protocol to HTTPS.
+      // See https://goo.gl/lq4gCo for an explanation as to why this is needed for some features.
+      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
     {% assign sub_dirs = page.url | split: '/' | size | minus: 2 %}
     {% capture relative_path_to_root %}{% for i in (1..sub_dirs) %}../{% endfor %}{% endcapture %}
     <link rel="icon" href="{{ relative_path_to_root }}images/favicon.ico">

--- a/service-worker/post-message/index.html
+++ b/service-worker/post-message/index.html
@@ -2,7 +2,6 @@
 feature_name: Service Worker postMessage()
 chrome_version: 45
 feature_id: 5163630974730240
-https_redirect: true
 ---
 
 <h3>Background</h3>


### PR DESCRIPTION
R: @PaulKinlan @wibblymat _et alii_

It was previous opt-in for pages using the new templates (via `https_redirect: true`), but there's no reason not to enable it by default for everything on the templates.

(As far as I can tell, you can't opt-in to [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) for GitHub pages, but if anyone knows how, that would be a nice alternative. I'd be a little concerned that some of our older samples might have mixed-content issues if HSTS were possible, so that would require some scrubbing first.)
