### PR TITLE
Fix typo: "DevTool's" -> "DevTools"

### DIFF
--- a/subresource-integrity/index.html
+++ b/subresource-integrity/index.html
@@ -41,7 +41,7 @@ feature_id: 6183089948590080
   <code>&lt;link rel="stylesheet" href="incorrect_hash.css" integrity="sha256-OBVIOUSLY_INCORRECT_HASH"></code>
   Browsers that support subresource integrity will refuse to load the file, since the
   <code>integrity</code> value  doesn't correspond to the actual <code>sha256</code> hash of the
-  file. You'll see an error message logged in the DevTool's console. Browsers that don't support
+  file. You'll see an error message logged in the DevTools console. Browsers that don't support
   subresource integrity will, however, load the file, and in those browsers this paragraph will be
   pink.
 </p>


### PR DESCRIPTION
[DevTools](https://developer.chrome.com/devtools) is the official (abbreviated) name.
