### PR TITLE
Added `clients.claim()` to the notification vibrate sample

### DIFF
--- a/vibration/sw.js
+++ b/vibration/sw.js
@@ -2,6 +2,10 @@ self.addEventListener('install', function() {
   self.skipWaiting();
 });
 
+self.addEventListener('activate', function(event) {
+  event.waitUntil(clients.claim());
+});
+
 self.addEventListener('notificationclick', function(event) {
   // Close the notification when it is clicked
   event.notification.close();


### PR DESCRIPTION
The notification sample didn't work on first page load because it waited for `serviceWorker.ready` without having `clients.claim()` in the worker.

R: @jeffposnick @PaulKinlan 
