### PR TITLE
Require >= v39 of the github-pages gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'github-pages'
+gem 'github-pages', '>=39'
 gem 'jekyll-sitemap'


### PR DESCRIPTION
R: @addyosmani @beaufortfrancois @gauntface 

An older version of the `github-pages` gem was getting pulled into our [recent Travis CI](https://travis-ci.org/GoogleChrome/samples/builds/82536811) builds for some reason. (Caching?)

This explicitly requires at least the current version, 39, of the gem. The build seems happy with this change.
