### PR TITLE
Redirect to https://www.chromestatus.com/samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,6 @@
 <html>
 <head>
   <title>Redirecting...</title>
-  <meta http-equiv="refresh" content="0;URL='https://www.chromestatus.com/features'">
+  <meta http-equiv="refresh" content="0;URL='https://www.chromestatus.com/samples'">
 </head>
 </html>


### PR DESCRIPTION
R: @ebidel 

Change the https://googlechrome.github.io/samples/ top-level redirect to point to the new https://www.chromestatus.com/samples page.
