### PR TITLE
Adds a 'error' event handler to window

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,8 +41,7 @@ limitations under the License.
       // which don't support specific functionality still end up displaying a meaningful message.
       window.addEventListener('error', function(error) {
         if (ChromeSamples && ChromeSamples.setStatus) {
-          ChromeSamples.setStatus(error.message +
-            ' (Your browser does not currently support this feature.)');
+          ChromeSamples.setStatus(error.message + ' (Your browser may not support this feature.)');
           error.preventDefault();
         }
       });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,6 +36,16 @@ limitations under the License.
           window.location.protocol = 'https:';
         }
       })();
+
+      // Add a global error event listener early on in the page load, to help ensure that browsers
+      // which don't support specific functionality still end up displaying a meaningful message.
+      window.addEventListener('error', function(error) {
+        if (ChromeSamples && ChromeSamples.setStatus) {
+          ChromeSamples.setStatus(error.message +
+            ' (Your browser does not currently support this feature.)');
+          error.preventDefault();
+        }
+      });
     </script>
     {% assign sub_dirs = page.url | split: '/' | size | minus: 2 %}
     {% capture relative_path_to_root %}{% for i in (1..sub_dirs) %}../{% endfor %}{% endcapture %}

--- a/rest-parameters-es6/index.html
+++ b/rest-parameters-es6/index.html
@@ -80,7 +80,11 @@ function sortArguments() {
 }
 
 // throws a TypeError: arguments.sort is not a function
-ChromeSamples.log(sortArguments(5,3,7,1));
+try {
+  ChromeSamples.log(sortArguments(5,3,7,1));
+} catch(error) {
+  console.warn(error);
+}
 
 /*
 We could alternatively have used Array.from here:

--- a/rest-parameters-es6/index.html
+++ b/rest-parameters-es6/index.html
@@ -83,7 +83,7 @@ function sortArguments() {
 try {
   ChromeSamples.log(sortArguments(5,3,7,1));
 } catch(error) {
-  console.warn(error);
+  ChromeSamples.log(error.message);
 }
 
 /*


### PR DESCRIPTION
R: @addyosmani @gauntface @beaufortfrancois 

This isn't a fool-proof solution, but for any samples that include the output helper template, this will end up logging something meaningful when you try out a feature that's not supported in your current browser.

![image](https://cloud.githubusercontent.com/assets/1749548/10319171/dbb1747a-6c3a-11e5-91fc-c90c0f699bba.png)

Closes #218 
