### PR TITLE
put new.target sample in strict mode

### DIFF
--- a/new-target-es6/index.html
+++ b/new-target-es6/index.html
@@ -27,6 +27,7 @@ feature_id: 5210159227863040
 {% include output_helper.html %}
 
 {% capture js %}
+'use strict';
 class Parent {
   constructor() {
     // new.target is a constructor reference, and new.target.name is human-friendly name.


### PR DESCRIPTION
to work in current Chrome while waiting for sloppy-mode block scoping. [The sample](https://googlechrome.github.io/samples/new-target-es6/index.html) currently doesn't work without `#enable-javascript-harmony` enabled.
