### PR TITLE
Base template/style tweaks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,7 +59,8 @@ limitations under the License.
     <p>
       Available in <a target="_blank" href="https://www.chromestatus.com/feature/{{ page.feature_id }}">Chrome {{ page.chrome_version }}+</a> |
       <a target="_blank" href="view-source:{{ site.gh_pages_url_prefix }}{{ page.url }}">View Source</a> |
-      <a target="_blank" href="{{ site.gh_url_prefix }}{{ page.url | remove_first: 'index.html' }}">View on GitHub</a>
+      <a target="_blank" href="{{ site.gh_url_prefix }}{{ page.url | remove_first: 'index.html' }}">View on GitHub</a> |
+      <a target="_blank" href="https://www.chromestatus.com/samples">Browse Samples</a>
     </p>
     {{ content }}
     {% for local_js_file in page.local_js_files %}<script src="{{ local_js_file }}"></script>{% endfor %}

--- a/styles/main.css
+++ b/styles/main.css
@@ -41,6 +41,10 @@ h3 {
   margin-top: 1em;
 }
 
+#status:empty, #log:empty, #content:empty {
+  display: none;
+}
+
 .highlight {
   border-radius: 0.75em;
   border: 1px solid #f0f0f0;


### PR DESCRIPTION
R: @ebidel @gauntface @beaufortfrancois @addyosmani

This adds a link to the new https://www.chromestatus.com/samples landing page at the top of each templated sample's page.

It also tweaks the shared styles to hide the output helper elements when they're empty, which fixes a small visual issue with the margins.
