### PR TITLE
Improve #log text in small viewports

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -39,6 +39,7 @@ h3 {
 
 #log {
   margin-top: 1em;
+  white-space: pre-wrap;
 }
 
 .highlight {


### PR DESCRIPTION
R=@jeffposnick

On mobile devices, I can't read the error messages in #log.
This small fix addresses this.
