### PR TITLE
Switched to https://www.chromestatus.com instead of http

### DIFF
--- a/beacon/README.md
+++ b/beacon/README.md
@@ -2,4 +2,4 @@ Beacon Sample
 ===
 See https://googlechrome.github.io/samples/beacon for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5517433905348608
+Learn more at https://www.chromestatus.com/feature/5517433905348608

--- a/classes-es6/README.md
+++ b/classes-es6/README.md
@@ -2,4 +2,4 @@ Classes (ES6) Sample
 ===
 See https://googlechrome.github.io/samples/classes-es6/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/4633745457938432
+Learn more at https://www.chromestatus.com/feature/4633745457938432

--- a/collections-iterators-es6/README.md
+++ b/collections-iterators-es6/README.md
@@ -3,6 +3,6 @@ Collections and Iterators (ES6) Sample
 See https://googlechrome.github.io/samples/collections-iterators-es6/index.html for a live demo.
 
 Learn more about:
-  - [for...of Iterators](http://www.chromestatus.com/feature/4696563918045184)
-  - [Maps](http://www.chromestatus.com/feature/4818609708728320)
-  - [Sets](http://www.chromestatus.com/feature/4916191365693440)
+  - [for...of Iterators](https://www.chromestatus.com/feature/4696563918045184)
+  - [Maps](https://www.chromestatus.com/feature/4818609708728320)
+  - [Sets](https://www.chromestatus.com/feature/4916191365693440)

--- a/computed-properties-es6/index.html
+++ b/computed-properties-es6/index.html
@@ -50,7 +50,7 @@ limitations under the License.
     <h1>Computed Property Names (ES6) Sample</h1>
 
     <!--
-    <p>Available in <a href="http://www.chromestatus.com/feature/PLACEHOLDER">Chrome PLACEHOLDER+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/PLACEHOLDER">Chrome PLACEHOLDER+</a></p>
     -->
     <p>ES6 Computed property names allow you to dynamically create property names using an expression in brackets (<code>[ ]</code>) similar to <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">property accessors</a>. Below, computed property names are demonstrated using Object Literals, ES6 Classes and ES6 Symbols.
     </p>

--- a/csp-upgrade-insecure-requests/index.html
+++ b/csp-upgrade-insecure-requests/index.html
@@ -60,7 +60,7 @@ limitations under the License.
   <body>
     <h1>Upgrade Insecure Requests Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6534575509471232">Chrome 43+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6534575509471232">Chrome 43+</a></p>
 
     <p>
       The "<a href="https://w3c.github.io/webappsec/specs/upgrade/">Upgrade Insecure Requests</a>"

--- a/css-shapes/README.md
+++ b/css-shapes/README.md
@@ -2,4 +2,4 @@ CSS Shapes Level 1 Sample
 ===
 See https://googlechrome.github.io/samples/css-shapes for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5163890719588352
+Learn more at https://www.chromestatus.com/feature/5163890719588352

--- a/css-shapes/index.html
+++ b/css-shapes/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>CSS Shapes Level 1 Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/5163890719588352">Chrome 37+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5163890719588352">Chrome 37+</a></p>
 
     <style>
       .shape {

--- a/cut-and-copy/README.md
+++ b/cut-and-copy/README.md
@@ -2,4 +2,4 @@ Cut and Copy Sample
 ===
 See https://googlechrome.github.io/samples/cut-and-copy/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5223997243392000
+Learn more at https://www.chromestatus.com/feature/5223997243392000

--- a/cut-and-copy/index.html
+++ b/cut-and-copy/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>Cut and Copy Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/5223997243392000">Chrome 43+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5223997243392000">Chrome 43+</a></p>
 
     <!-- // [START code-block] -->
     <h2>Simple Cut Example</h2>

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -2,4 +2,4 @@
 ===
 See https://googlechrome.github.io/samples/dialog/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5770237022568448
+Learn more at https://www.chromestatus.com/feature/5770237022568448

--- a/dialog/index.html
+++ b/dialog/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>&lt;dialog&gt; Element Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/5770237022568448">Chrome 37+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5770237022568448">Chrome 37+</a></p>
 
     <!-- // [START code-block] -->
     <p>This button will open a native &lt;dialog&gt; element: <button id="show">Open Dialog</button></p>

--- a/encoding-api/README.md
+++ b/encoding-api/README.md
@@ -2,4 +2,4 @@ Encoding API Sample
 ===
 See https://googlechrome.github.io/samples/encoding-api/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5714368087982080
+Learn more at https://www.chromestatus.com/feature/5714368087982080

--- a/encoding-api/index.html
+++ b/encoding-api/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>Encoding API Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/5714368087982080">Chrome 38+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5714368087982080">Chrome 38+</a></p>
 
     <p>The JavaScript Encoding API allows developers to encode and decode strings using a wide range of character encodings.</p>
 

--- a/extended-object-literals-es6/README.md
+++ b/extended-object-literals-es6/README.md
@@ -2,4 +2,4 @@ Extended Object Literals (ES6) Sample
 ===
 See https://googlechrome.github.io/samples/extended-object-literals-es6/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/4873630588600320
+Learn more at https://www.chromestatus.com/feature/4873630588600320

--- a/extended-object-literals-es6/index.html
+++ b/extended-object-literals-es6/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>Extended Object Literals (ES6) Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/4873630588600320">Chrome 42+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/4873630588600320">Chrome 42+</a></p>
 
     <p>Extended Object Literals simplify object creation and composition by reducing the required amount of typing with some syntactic sugar.</p>
     <p>With this, object literals are now syntactically similar to ES6’s new class syntax and have less duplication in common use-cases like constructor function.</p>

--- a/fetch-api/README.md
+++ b/fetch-api/README.md
@@ -11,7 +11,7 @@ Fetch API Samples
 * [Response body stream](https://googlechrome.github.io/samples/fetch-api/fetch-response-stream.html)
 * [Fetch success/error handlers](https://googlechrome.github.io/samples/fetch-api/fetch-success-error-handlers.html)
 
-Learn more at http://www.chromestatus.com/feature/6730533392351232
+Learn more at https://www.chromestatus.com/feature/6730533392351232
 
 ### Third party demos
 

--- a/fetch-api/fetch-html.html
+++ b/fetch-api/fetch-html.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API HTML Sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <div class="output">
     <pre id="log"></pre>

--- a/fetch-api/fetch-json.html
+++ b/fetch-api/fetch-json.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API JSON Sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <div class="output">
     <pre id="log"></pre>

--- a/fetch-api/fetch-post.html
+++ b/fetch-api/fetch-post.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API POST Sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <textarea autofocus id="gist" id="" cols="80" rows="10">
 // Enter some JavaScript here

--- a/fetch-api/fetch-reddit.html
+++ b/fetch-api/fetch-reddit.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API Reddit Sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <p>This is an example of fetching some data (Reddit subreddits) which is then used to
     populate a menu allowing a user to make another fetch (for the subreddit content).</p>

--- a/fetch-api/fetch-response-metadata.html
+++ b/fetch-api/fetch-response-metadata.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API Response Metadata Sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <div class="output">
     <pre id="log"></pre>

--- a/fetch-api/fetch-success-error-handlers.html
+++ b/fetch-api/fetch-success-error-handlers.html
@@ -48,7 +48,7 @@ limitations under the License.
 <body>
 <h1>Fetch API success and error handlers sample</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6730533392351232">Chrome 42+</a></p>
 
 <div class="output">
     <pre id="log"></pre>

--- a/file-constructor/README.md
+++ b/file-constructor/README.md
@@ -2,4 +2,4 @@ File Constructor Sample
 ===
 See https://googlechrome.github.io/samples/file-constructor/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5731244088229888
+Learn more at https://www.chromestatus.com/feature/5731244088229888

--- a/file-constructor/index.html
+++ b/file-constructor/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>File Constructor Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/5731244088229888">Chrome 38+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5731244088229888">Chrome 38+</a></p>
 
     <p>
       This demo illustrates the use of the

--- a/generators/README.md
+++ b/generators/README.md
@@ -2,4 +2,4 @@ Generators (ES6) Sample
 ===
 See https://googlechrome.github.io/samples/generators/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/4959347197083648
+Learn more at https://www.chromestatus.com/feature/4959347197083648

--- a/generators/index.html
+++ b/generators/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>Generators (ES6) Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/4959347197083648">Chrome 39+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/4959347197083648">Chrome 39+</a></p>
 
     <p>
       <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">Generators</a>

--- a/image-rendering-pixelated/README.md
+++ b/image-rendering-pixelated/README.md
@@ -3,4 +3,4 @@ Pixelated Image Rendering Sample
 
 See https://googlechrome.github.io/samples/image-rendering-pixelated/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5118058116939776
+Learn more at https://www.chromestatus.com/feature/5118058116939776

--- a/multi-column-css/README.md
+++ b/multi-column-css/README.md
@@ -2,4 +2,4 @@ Multi-column CSS Sample
 ===
 See https://googlechrome.github.io/samples/multi-column-css/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6526151266664448
+Learn more at https://www.chromestatus.com/feature/6526151266664448

--- a/network-information/README.md
+++ b/network-information/README.md
@@ -2,4 +2,4 @@ Network Information Sample
 ===
 See https://googlechrome.github.io/samples/network-information/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6338383617982464
+Learn more at https://www.chromestatus.com/feature/6338383617982464

--- a/network-information/index.html
+++ b/network-information/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>Network Information Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/6338383617982464">Chrome 38+</a> (Android, iOS, ChromeOS)</p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6338383617982464">Chrome 38+</a> (Android, iOS, ChromeOS)</p>
 
     <p>
       This demo illustrates the use of the <a href="http://w3c.github.io/netinfo/">Network Information API</a>

--- a/picture-element/README.md
+++ b/picture-element/README.md
@@ -2,4 +2,4 @@ Picture Element Sample
 ===
 See https://googlechrome.github.io/samples/picture-element for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5910974510923776
+Learn more at https://www.chromestatus.com/feature/5910974510923776

--- a/picture-element/index.html
+++ b/picture-element/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>&lt;picture&gt; Element Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/5910974510923776">Chrome 38+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5910974510923776">Chrome 38+</a></p>
 
     <p>The <code>&lt;picture></code> element informs Chrome which version of
     an image resource to fetch based on some criteria, such as the browser

--- a/push-messaging-and-notifications/README.md
+++ b/push-messaging-and-notifications/README.md
@@ -1,7 +1,7 @@
 Push Messaging and Notification Sample
 ===
 
-Learn more at http://www.chromestatus.com/feature/5416033485586432 and http://www.chromestatus.com/feature/5480344312610816
+Learn more at https://www.chromestatus.com/feature/5416033485586432 and https://www.chromestatus.com/feature/5480344312610816
 
 To use this sample please do the following:
 

--- a/push-messaging-and-notifications/index.html
+++ b/push-messaging-and-notifications/index.html
@@ -50,7 +50,7 @@ limitations under the License.
   <body>
     <h1>Push Messaging &amp; Notifications</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/5416033485586432">Chrome 42+</a> &amp; <a href="http://www.chromestatus.com/feature/5480344312610816">Chrome 42+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5416033485586432">Chrome 42+</a> &amp; <a href="https://www.chromestatus.com/feature/5480344312610816">Chrome 42+</a></p>
 
     <p>To use this sample please do the following:</p>
 

--- a/screen-orientation/README.md
+++ b/screen-orientation/README.md
@@ -2,4 +2,4 @@ Screen Orientation Sample
 ===
 See https://googlechrome.github.io/samples/screen-orientation/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6191285283061760
+Learn more at https://www.chromestatus.com/feature/6191285283061760

--- a/screen-orientation/index.html
+++ b/screen-orientation/index.html
@@ -47,7 +47,7 @@ limitations under the License.
 
   <body>
     <h1>Screen Orientation Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/6191285283061760">Chrome 38+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6191285283061760">Chrome 38+</a></p>
 
     <p>Screen Orientation API gives ability to read the screen orientation and lock it. It can be used to adapt the layout of a web app, e.g.
     from vertical to horizontal grid.</p>

--- a/service-worker/custom-offline-page/README.md
+++ b/service-worker/custom-offline-page/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Custom Offline Page
 ===
 See https://googlechrome.github.io/samples/service-worker/custom-offline-page/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/custom-offline-page/index.html
+++ b/service-worker/custom-offline-page/index.html
@@ -50,7 +50,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Custom Offline Page</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration. During the installation step, a

--- a/service-worker/fallback-response/README.md
+++ b/service-worker/fallback-response/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Fallback Response
 ===
 See https://googlechrome.github.io/samples/service-worker/fallback-response/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/fallback-response/index.html
+++ b/service-worker/fallback-response/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Fallback Response</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, with the service worker providing fallback

--- a/service-worker/immediate-control/README.md
+++ b/service-worker/immediate-control/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Immediate Control
 ===
 See https://googlechrome.github.io/samples/service-worker/immediate-control/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/immediate-control/index.html
+++ b/service-worker/immediate-control/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
   <h1>Service Worker Sample: Immediate Control</h1>
 
-  <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 42+</a></p>
+  <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 42+</a></p>
 
   <p>
     This sample is a modified version of the

--- a/service-worker/mock-responses/README.md
+++ b/service-worker/mock-responses/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Mock Responses
 ===
 See https://googlechrome.github.io/samples/service-worker/mock-responses/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Mock Responses</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, with the service worker's fetch handler

--- a/service-worker/multiple-handlers/README.md
+++ b/service-worker/multiple-handlers/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Multiple Fetch Handlers
 ===
 See https://googlechrome.github.io/samples/service-worker/multiple-handlers/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/multiple-handlers/index.html
+++ b/service-worker/multiple-handlers/index.html
@@ -56,7 +56,7 @@ limitations under the License.
 <body>
 <h1>Service Worker Sample: Multiple Fetch Handlers</h1>
 
-<p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+<p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
 <p>
   This sample demonstrates best practices for registering multiple <code>fetch</code> event

--- a/service-worker/offline-analytics/README.md
+++ b/service-worker/offline-analytics/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Read-through Caching (w/Offline Analytics)
 ===
 See https://googlechrome.github.io/samples/service-worker/offline-analytics/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/offline-analytics/index.html
+++ b/service-worker/offline-analytics/index.html
@@ -53,7 +53,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Read-through Caching (w/Offline Analytics)</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, in conjunction with read-through

--- a/service-worker/post-message/README.md
+++ b/service-worker/post-message/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Posting Messages
 ===
 See https://googlechrome.github.io/samples/service-worker/post-message/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/prefetch/README.md
+++ b/service-worker/prefetch/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Prefetching Resources During Registration
 ===
 See https://googlechrome.github.io/samples/service-worker/prefetch/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/prefetch/index.html
+++ b/service-worker/prefetch/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Pre-fetching Resources During Registration</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, in conjunction with pre-fetching of a list

--- a/service-worker/read-through-caching/README.md
+++ b/service-worker/read-through-caching/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Read-through Caching
 ===
 See https://googlechrome.github.io/samples/service-worker/read-through-caching/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/read-through-caching/index.html
+++ b/service-worker/read-through-caching/index.html
@@ -53,7 +53,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Read-through Caching</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, in conjunction with read-through

--- a/service-worker/registration-events/README.md
+++ b/service-worker/registration-events/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Detailed Registration
 ===
 See https://googlechrome.github.io/samples/service-worker/registration-events/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/registration-events/index.html
+++ b/service-worker/registration-events/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
   <h1>Service Worker Sample: Detailed Registration</h1>
 
-  <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+  <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
   <p>
     This sample provides some insight into the events involved in a typical service worker registration.

--- a/service-worker/registration/README.md
+++ b/service-worker/registration/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Basic Registration
 ===
 See https://googlechrome.github.io/samples/service-worker/registration/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/registration/index.html
+++ b/service-worker/registration/index.html
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Basic Registration</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 39+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 39+</a></p>
 
     <p>
       This sample demonstrates the most basic service worker registration scenario. The script

--- a/service-worker/selective-caching/README.md
+++ b/service-worker/selective-caching/README.md
@@ -2,4 +2,4 @@ Service Worker Sample: Selective Caching
 ===
 See https://googlechrome.github.io/samples/service-worker/selective-caching/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6561526227927040
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/selective-caching/index.html
+++ b/service-worker/selective-caching/index.html
@@ -60,7 +60,7 @@ limitations under the License.
   <body>
     <h1>Service Worker Sample: Selective Caching</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6561526227927040">Chrome 40+</a></p>
 
     <p>
       This sample demonstrates basic service worker registration, in conjunction with selective

--- a/spread-operator/README.md
+++ b/spread-operator/README.md
@@ -2,4 +2,4 @@ Spread Calls Sample
 ===
 See https://googlechrome.github.io/samples/spread-operator/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6031334694715392
+Learn more at https://www.chromestatus.com/feature/6031334694715392

--- a/web-animations/README.md
+++ b/web-animations/README.md
@@ -2,4 +2,4 @@ Web Animations Sample
 ===
 See https://googlechrome.github.io/samples/web-animations/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/4854343836631040
+Learn more at https://www.chromestatus.com/feature/4854343836631040

--- a/web-animations/index.html
+++ b/web-animations/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>Web Animations Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/4854343836631040">Chrome 36+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/4854343836631040">Chrome 36+</a></p>
 
     <p>
       This demo shows simple animations with <a href="http://updates.html5rocks.com/2014/05/Web-Animations---element-animate-is-now-in-Chrome-36">Web Animations</a> and the <code>element.animate()</code> method.

--- a/web-application-manifest/README.md
+++ b/web-application-manifest/README.md
@@ -2,4 +2,4 @@ Web Application Manifest Sample
 ===
 See https://googlechrome.github.io/samples/web-application-manifest/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/6488656873259008
+Learn more at https://www.chromestatus.com/feature/6488656873259008

--- a/web-application-manifest/index.html
+++ b/web-application-manifest/index.html
@@ -36,7 +36,7 @@ limitations under the License.
 
   <body>
     <h1>Web Application Manifest Sample</h1>
-    <p>Available in <a href="http://www.chromestatus.com/feature/6488656873259008">Chrome 39+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/6488656873259008">Chrome 39+</a></p>
 
     <h3>Hey! I'm a web app!</h3>
 

--- a/web-bluetooth/README.md
+++ b/web-bluetooth/README.md
@@ -2,4 +2,4 @@ Web Bluetooth Samples
 =====================
 See https://googlechrome.github.io/samples/web-bluetooth/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5264933985976320
+Learn more at https://www.chromestatus.com/feature/5264933985976320

--- a/webaudio-audiocontext-close/README.md
+++ b/webaudio-audiocontext-close/README.md
@@ -2,4 +2,4 @@ WebAudio AudioContext close Sample
 ===
 See https://googlechrome.github.io/samples/webaudio-audiocontext-close/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5411681005993984
+Learn more at https://www.chromestatus.com/feature/5411681005993984

--- a/webaudio-audiocontext-close/index.html
+++ b/webaudio-audiocontext-close/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>WebAudio AudioContext close Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/5411681005993984">Chrome 43+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5411681005993984">Chrome 43+</a></p>
 
     <p>
       The <code>AudioContext.close</code> method closes the audio context, stopping audio operations, and releases any system resources in use.

--- a/webaudio-audionode-disconnect/README.md
+++ b/webaudio-audionode-disconnect/README.md
@@ -2,4 +2,4 @@ WebAudio AudioNode selective disconnect Sample
 ===
 See https://googlechrome.github.io/samples/webaudio-audionode-disconnect/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/4793068276416512
+Learn more at https://www.chromestatus.com/feature/4793068276416512

--- a/webaudio-audionode-disconnect/index.html
+++ b/webaudio-audionode-disconnect/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>WebAudio AudioNode selective disconnect Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/4793068276416512">Chrome 43+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/4793068276416512">Chrome 43+</a></p>
 
     <p>
       The overloaded method <code>AudioNode.disconnect</code> supports disconnecting either all connections, or a single connection (see the <a href="https://webaudio.github.io/web-audio-api/#idl-def-AudioNode">audio node spec</a>).

--- a/webaudio-offlinecontext-rendering/README.md
+++ b/webaudio-offlinecontext-rendering/README.md
@@ -2,4 +2,4 @@ WebAudio Offline context rendering promise Sample
 ===
 See https://googlechrome.github.io/samples/webaudio-offlinecontext-rendering/index.html for a live demo.
 
-Learn more at http://www.chromestatus.com/feature/5692188675538944
+Learn more at https://www.chromestatus.com/feature/5692188675538944

--- a/webaudio-offlinecontext-rendering/index.html
+++ b/webaudio-offlinecontext-rendering/index.html
@@ -48,7 +48,7 @@ limitations under the License.
   <body>
     <h1>WebAudio Offline context rendering promise Sample</h1>
 
-    <p>Available in <a href="http://www.chromestatus.com/feature/5692188675538944">Chrome 42+</a></p>
+    <p>Available in <a href="https://www.chromestatus.com/feature/5692188675538944">Chrome 42+</a></p>
 
     <p>
       The <code>OfflineAudioContext.startRendering</code> method renders audio to an <code>AudioBuffer</code> potentially faster than real-time.


### PR DESCRIPTION
In order to avoid an unnecessary HTTP 302 Redirect, I ran `git grep -l 'http://www.chromestatus.com' | xargs sed -i 's/http:\/\/www.chromestatus.com/https:\/\/www.chromestatus.com/g'` in the repository.

R=@jeffposnick
