### PR TITLE
Added missing 'use strict' in bluetooth samples

### DIFF
--- a/web-bluetooth/characteristic-properties.js
+++ b/web-bluetooth/characteristic-properties.js
@@ -1,10 +1,12 @@
 function onFormSubmit() {
-  var serviceUuid = document.getElementById('service').value;
+  'use strict';
+
+  let serviceUuid = document.getElementById('service').value;
   if (serviceUuid.startsWith('0x')) {
     serviceUuid = parseInt(serviceUuid, 16);
   }
 
-  var characteristicUuid = document.getElementById('characteristic').value;
+  let characteristicUuid = document.getElementById('characteristic').value;
   if (characteristicUuid.startsWith('0x')) {
     characteristicUuid = parseInt(characteristicUuid, 16);
   }

--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -1,5 +1,7 @@
 function onFormSubmit() {
-  var filterService = document.getElementById('service').value;
+  'use strict';
+
+  let filterService = document.getElementById('service').value;
   if (filterService.startsWith('0x')) {
     filterService = parseInt(filterService, 16);
   }


### PR DESCRIPTION
R= @jeffposnick 

Based on @g-ortuno feedback, you'll find missing `"use strict"` for web-bluetooth samples.
