### PR TITLE
Fix off by 1 error in generators example

### DIFF
--- a/generators/index.html
+++ b/generators/index.html
@@ -116,11 +116,10 @@ limitations under the License.
           }
 
           count++;
+          i++;
           // Wrap around to the beginning of the array if we've reach the end.
           if (i >= loremIpsumArray.length) {
             i = 0;
-          } else {
-            i++;
           }
 
           // uppercase is assigned the value passed into the .next() invoked following


### PR DESCRIPTION
The 300-px example printed "undefined" between each full cycle of "Lorem ipsum".
