### PR TITLE
FontFaceSet sample

### DIFF
--- a/font-face-set/README.md
+++ b/font-face-set/README.md
@@ -1,0 +1,5 @@
+CSS Font Loading API's FontFaceSet Sample
+===
+See https://googlechrome.github.io/samples/font-face-set/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/4594172182921216

--- a/font-face-set/demo.js
+++ b/font-face-set/demo.js
@@ -1,0 +1,26 @@
+// Load Bitter via JavaScript, as an alternative to CSS's @font-face rule.
+var bitterFontFace = new FontFace('Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(bitterFontFace);
+
+// The .ready promise resolves when all fonts that have been previously requested
+// are loaded and layout operations are complete.
+document.fonts.ready.then(function() {
+  // Our CSS sets visibility: hidden on the oxygen class initially,
+  // so let's make it visible now.
+  // This technique avoids displaying text until the font it requires is loaded.
+  // An alternative approach is used with the text styled with the bitter class,
+  // which is visible from the start using the default font,
+  // and then switches to the custom Bitter font once that's loaded.
+  document.querySelector('.oxygen').style.visibility = 'visible';
+
+  ChromeSamples.log('There are', document.fonts.size, 'FontFaces loaded.\n');
+
+  // document.fonts has a Set-like interface. Here, we're iterating over its values.
+  for (var fontFace of document.fonts.values()) {
+    ChromeSamples.log('FontFace:');
+    for (var property in fontFace) {
+      ChromeSamples.log('  ' + property + ': ' + fontFace[property]);
+    }
+    ChromeSamples.log('\n');
+  }
+});

--- a/font-face-set/demo.js
+++ b/font-face-set/demo.js
@@ -1,18 +1,18 @@
-// Load Bitter via JavaScript, as an alternative to CSS's @font-face rule.
+function logLoaded(fontFace) {
+  ChromeSamples.log(fontFace.family, 'loaded successfully.');
+}
+
+// Loading FontFaces via JavaScript is alternative to using CSS's @font-face rule.
 var bitterFontFace = new FontFace('Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
 document.fonts.add(bitterFontFace);
+bitterFontFace.loaded.then(logLoaded);
+var oxygenFontFace = new FontFace('Oxygen', 'url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(oxygenFontFace);
+oxygenFontFace.loaded.then(logLoaded);
 
 // The .ready promise resolves when all fonts that have been previously requested
 // are loaded and layout operations are complete.
 document.fonts.ready.then(function() {
-  // Our CSS sets visibility: hidden on the oxygen class initially,
-  // so let's make it visible now.
-  // This technique avoids displaying text until the font it requires is loaded.
-  // An alternative approach is used with the text styled with the bitter class,
-  // which is visible from the start using the default font,
-  // and then switches to the custom Bitter font once that's loaded.
-  document.querySelector('.oxygen').style.visibility = 'visible';
-
   ChromeSamples.log('There are', document.fonts.size, 'FontFaces loaded.\n');
 
   // document.fonts has a Set-like interface. Here, we're iterating over its values.

--- a/font-face-set/index.html
+++ b/font-face-set/index.html
@@ -1,0 +1,56 @@
+---
+feature_name: CSS Font Loading API's FontFaceSet
+chrome_version: 48
+feature_id: 4594172182921216
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet"><code>FontFaceSet</code></a>
+  is an interface defined as part of the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSS_Font_Loading_API">CSS Font Loading API</a>.
+  It's used to load font faces, and check the status of previously requested fonts. The
+  <code>FontFaceSet</code> interface for the current HTML page is available in JavaScript as
+  <code>document.fonts</code>.
+</p>
+
+<p>
+  This sample shows equivalent techniques for defining a new <code>FontFace</code> and adding it to
+  the page's <code>FontFaceSet</code>. One technique is to use the <code>FontFaceSet.add()</code>
+  method via JavaScript, and the other technique is to use CSS's <code>@font-face</code> rule.
+</p>
+
+<p>
+  The sample also shows alternative approaches to the initial display of text before the custom
+  fonts are loaded. In one case, the text is displayed unconditionally, but will start out being
+  displayed using the page's default font until the custom <code>FontFace</code> loads. In the other
+  case, the text is styled with <code>visibility: hidden</code> initially, and then after the
+  <code>document.fonts.ready</code>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"><code>Promise</code></a>
+  resolves, the text is displayed.
+</p>
+
+{% capture initial_output_content %}
+<p class="bitter">I'm using the font-family Bitter and am always visible!</p>
+<p class="oxygen">I'm using the font-family Oxygen and am visible once the font loads!</p>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% capture css %}
+@font-face {
+  font-family: Oxygen;
+  src: url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2);
+}
+
+.bitter {
+  font-family: Bitter;
+}
+
+.oxygen {
+  font-family: Oxygen;
+  visibility: hidden;
+}
+{% endcapture %}
+{% include css_snippet.html css=css %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/font-face-set/index.html
+++ b/font-face-set/index.html
@@ -15,40 +15,35 @@ feature_id: 4594172182921216
 </p>
 
 <p>
-  This sample shows equivalent techniques for defining a new <code>FontFace</code> and adding it to
-  the page's <code>FontFaceSet</code>. One technique is to use the <code>FontFaceSet.add()</code>
-  method via JavaScript, and the other technique is to use CSS's <code>@font-face</code> rule.
+  The sample illustrates constructing <code>FontFace</code> objects and explicitly adding them to
+  the page's <code>document.fonts</code> <code>FontFaceSet</code>, which is an alternative to the
+  more traditional approach of using CSS's
+  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face"><code>@font-face</code></a>
+  rule. It uses the
+  <a href="https://drafts.csswg.org/css-font-loading/#dom-fontface-loaded"><code>FontFace.loaded</code></a>
+  promise to keep track of when each individual font has been loaded.
 </p>
 
 <p>
-  The sample also shows alternative approaches to the initial display of text before the custom
-  fonts are loaded. In one case, the text is displayed unconditionally, but will start out being
-  displayed using the page's default font until the custom <code>FontFace</code> loads. In the other
-  case, the text is styled with <code>visibility: hidden</code> initially, and then after the
-  <code>document.fonts.ready</code>
-  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"><code>Promise</code></a>
-  resolves, the text is displayed.
+  The sample also shows off the newer
+  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set"><code>Set</code>-like</a>
+  functionality in <code>FontFaceSet</code>, by iterating over <code>document.fonts.values()</code>
+  once all the fonts are loaded, and displaying information about each <code>FontFace</code>.
 </p>
 
 {% capture initial_output_content %}
-<p class="bitter">I'm using the font-family Bitter and am always visible!</p>
-<p class="oxygen">I'm using the font-family Oxygen and am visible once the font loads!</p>
+<p class="bitter">I'm using the font-family Bitter!</p>
+<p class="oxygen">I'm using the font-family Oxygen!</p>
 {% endcapture %}
 {% include output_helper.html initial_output_content=initial_output_content %}
 
 {% capture css %}
-@font-face {
-  font-family: Oxygen;
-  src: url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2);
-}
-
 .bitter {
   font-family: Bitter;
 }
 
 .oxygen {
   font-family: Oxygen;
-  visibility: hidden;
 }
 {% endcapture %}
 {% include css_snippet.html css=css %}


### PR DESCRIPTION
R: @addyosmani @gauntface @beaufortfrancois 
CC: @toyoshim, who I believe worked on the Chrome implementation.

This is a sample for the `FontFaceSet` interface in M48, https://www.chromestatus.com/feature/4594172182921216

I'm not 100% sure that it illustrates all the best practices properly, so it would be great if @toyoshim could offer some advice/review. It's also attempting to show off a few different things at once (loading custom `FontFace`s via both JS and CSS, hiding text until the fonts have loaded, iterating over all the loaded `FontFace`s) so let me know if you feel like I should cut something out to make it more focused.

You can view a live version at https://jeffy.info/samples/font-face-set/
