### PR TITLE
Network Information API updates

### DIFF
--- a/network-information/README.md
+++ b/network-information/README.md
@@ -1,4 +1,4 @@
-Network Information Sample
+Network Information API Sample
 ===
 See https://googlechrome.github.io/samples/network-information/index.html for a live demo.
 

--- a/network-information/demo.js
+++ b/network-information/demo.js
@@ -1,0 +1,18 @@
+function logConnectionType() {
+  var connectionType = 'not supported';
+  var downlinkMax = 'not supported';
+
+  if ('connection' in navigator) {
+    connectionType = navigator.connection.type;
+
+    if ('downlinkMax' in navigator.connection) {
+      downlinkMax = navigator.connection.downlinkMax;
+    }
+  }
+
+  ChromeSamples.log('Current connection type: ' + connectionType +
+    ' (downlink max: ' + downlinkMax + ')');
+}
+
+logConnectionType();
+navigator.connection.addEventListener('change', logConnectionType);

--- a/network-information/index.html
+++ b/network-information/index.html
@@ -1,95 +1,33 @@
-<!doctype html>
-<!--
-Copyright 2014 Google Inc. All Rights Reserved.
+---
+feature_name: Network Information API
+chrome_version: 48
+feature_id: 6338383617982464
+---
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+<h3>Background</h3>
+<p>
+  This demo illustrates the use of the
+  <a href="http://w3c.github.io/netinfo/">Network Information API</a>
+  to retrieve the current network type and monitor for network type changes.
+</p>
 
-    http://www.apache.org/licenses/LICENSE-2.0
+<p>
+  The Network Information API is
+  <a href="https://code.google.com/p/chromium/issues/detail?id=368358#c18">not currently available</a>
+  on all platforms. For best results, try this demo using Chrome on Android, iOS, or ChromeOS.
+</p>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<p>
+  While the Network Information API was initially added to
+  <a href="https://www.chromestatus.com/feature/6338383617982464">Chrome 38</a>, this sample
+  illustrates additional functionality that was added in
+  <a href="https://www.chromestatus.com/feature/5857463882481664">Chrome 48</a>. The updates include
+  a new <code>connection.downlinkMax</code> attribute, support for the
+  <code>'wimax'</code> connection type, and <code>connection.onchange</code> event listener.
+  The older <code>connection.ontypechange</code> event listener will be deprecated in a future
+  release.
+</p>
 
-    <meta name="description" content="Sample illustrating the use of Network Information.">
+{% include output_helper.html %}
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <title>Network Information Sample</title>
-
-    <!-- Add to homescreen for Chrome on Android -->
-    <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" sizes="192x192" href="../images/touch/chrome-touch-icon-192x192.png">
-
-    <!-- Add to homescreen for Safari on iOS -->
-    <meta name="apple-mobile-web-app-title" content="Network Information Sample">
-
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <link rel="apple-touch-icon-precomposed" href="../images/apple-touch-icon-precomposed.png">
-
-    <!-- Tile icon for Win8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
-    <meta name="msapplication-TileColor" content="#3372DF">
-
-    <link rel="icon" href="../images/favicon.ico">
-
-    <link rel="stylesheet" href="../styles/main.css">
-  </head>
-
-  <body>
-    <h1>Network Information Sample</h1>
-    <p>Available in <a href="https://www.chromestatus.com/feature/6338383617982464">Chrome 38+</a> (Android, iOS, ChromeOS)</p>
-
-    <p>
-      This demo illustrates the use of the <a href="http://w3c.github.io/netinfo/">Network Information API</a>
-      to retrieve the current network type and monitor for network type changes.
-    </p>
-
-    <p>
-      The Network Information API is <a href="https://code.google.com/p/chromium/issues/detail?id=368358#c18">not initially available</a>
-      on all platforms. For best results, try this demo using Chrome on Android, iOS, or ChromeOS.
-    </p>
-
-    <p>On supported devices, changing your network connection will update the type on this page.</p>
-
-    <!-- // [START code-block] -->
-    <div class="output">
-      <p>Your current network type is <strong id="type"></strong>.</p>
-    </div>
-
-    <script>
-      function updateDisplayedType() {
-        var type = 'unknown';
-        if ('connection' in navigator) {
-          type = navigator.connection.type;
-        }
-        document.querySelector('#type').textContent = type;
-      }
-
-      updateDisplayedType();
-      navigator.connection.addEventListener('typechange', updateDisplayedType);
-    </script>
-    <!-- // [END code-block] -->
-
-    <script>
-      /* jshint ignore:start */
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-53563471-1', 'auto');
-      ga('send', 'pageview');
-      /* jshint ignore:end */
-    </script>
-    <!-- Built with love using Web Starter Kit -->
-  </body>
-</html>
+{% include js_snippet.html filename='demo.js' %}

--- a/network-information/index.html
+++ b/network-information/index.html
@@ -14,7 +14,7 @@ feature_id: 6338383617982464
 <p>
   The Network Information API is
   <a href="https://code.google.com/p/chromium/issues/detail?id=368358#c18">not currently available</a>
-  on all platforms. For best results, try this demo using Chrome on Android, iOS, or ChromeOS.
+  on all platforms. For best results, try this demo using Chrome on Android, or ChromeOS.
 </p>
 
 <p>


### PR DESCRIPTION
R: @addyosmani @gauntface @beaufortfrancois 
CC: @jkarlin

This updates our existing Network Information API sample from the M38 era to include the new M48 functionality (https://www.chromestatus.com/feature/6338383617982464).

A live version of the updates can be found at https://jeffy.info/samples/network-information/, but as with the initial sample, you'll need an Android/iOS/Chrome OS device for the output to be meaningful.
