### PR TITLE
IDB getAll() sample

### DIFF
--- a/idb-getall/README.md
+++ b/idb-getall/README.md
@@ -1,0 +1,5 @@
+IndexedDB getAll() Methods Sample
+===
+See https://googlechrome.github.io/samples/idb-getall/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/6537756637396992

--- a/idb-getall/demo.js
+++ b/idb-getall/demo.js
@@ -29,6 +29,8 @@ document.querySelector('#add').addEventListener('click', function(event) {
     var transaction = db.transaction(STORE_NAME, 'readwrite');
     var objectStore = transaction.objectStore(STORE_NAME);
     objectStore.put(Date.now());
+  }).catch(function(error) {
+    ChromeSamples.setStatus(error);
   });
 });
 
@@ -42,5 +44,7 @@ document.querySelector('#display').addEventListener('click', function(event) {
       ChromeSamples.setStatus('There are ' + timestamps.length + ' timestamps saved in IndexedDB: '
         + timestamps.join(', '));
     };
+  }).catch(function(error) {
+    ChromeSamples.setStatus(error);
   });
 });

--- a/idb-getall/demo.js
+++ b/idb-getall/demo.js
@@ -1,50 +1,41 @@
+var addButton = document.querySelector('#add');
+var displayButton = document.querySelector('#display');
+
 var DB_NAME = 'timestamps';
 var DB_VERSION = 1;
 var STORE_NAME = 'store';
-var dbInstance;
+var db;
 
-// Simple Promise-based wrapper around getting an IndexedDB instance.
-function getDB() {
-  if (dbInstance) {
-    return Promise.resolve(dbInstance);
-  }
-
-  return new Promise(function(resolve) {
-    var request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onupgradeneeded = function() {
-      request.result.createObjectStore(STORE_NAME, {autoIncrement: true});
-    };
-
-    request.onsuccess = function() {
-      dbInstance = request.result;
-      resolve(dbInstance);
-    };
+var request = indexedDB.open(DB_NAME, DB_VERSION);
+request.onupgradeneeded = function() {
+  // Create a new object store if this is the first time we're using
+  // this DB_NAME/DB_VERSION combo.
+  request.result.createObjectStore(STORE_NAME, {autoIncrement: true});
+};
+request.onsuccess = function() {
+  db = request.result;
+  // Enable our buttons once the IndexedDB instance is available.
+  [addButton, displayButton].forEach(function(button) {
+    button.disabled = false;
   });
-}
+};
 
-
-document.querySelector('#add').addEventListener('click', function(event) {
-  getDB().then(function(db) {
-    var transaction = db.transaction(STORE_NAME, 'readwrite');
-    var objectStore = transaction.objectStore(STORE_NAME);
-    objectStore.put(Date.now());
-  }).catch(function(error) {
-    ChromeSamples.setStatus(error);
-  });
+addButton.addEventListener('click', function() {
+  var transaction = db.transaction(STORE_NAME, 'readwrite');
+  var objectStore = transaction.objectStore(STORE_NAME);
+  // Add the current timestamp to IndexedDB.
+  objectStore.put(Date.now()).onsuccess = function() {
+    ChromeSamples.setStatus('Added timestamp to IndexedDB.');
+  };
 });
 
-document.querySelector('#display').addEventListener('click', function(event) {
-  getDB().then(function(db) {
-    var transaction = db.transaction(STORE_NAME, 'readonly');
-    var objectStore = transaction.objectStore(STORE_NAME);
-    // IDBObjectStore.getAll() will return the full set of items in our store.
-    objectStore.getAll().onsuccess = function(event) {
-      var timestamps = event.target.result;
-      ChromeSamples.setStatus('There are ' + timestamps.length + ' timestamps saved in IndexedDB: '
-        + timestamps.join(', '));
-    };
-  }).catch(function(error) {
-    ChromeSamples.setStatus(error);
-  });
+displayButton.addEventListener('click', function() {
+  var transaction = db.transaction(STORE_NAME, 'readonly');
+  var objectStore = transaction.objectStore(STORE_NAME);
+  // IDBObjectStore.getAll() will return the full set of items in our store.
+  objectStore.getAll().onsuccess = function(event) {
+    var timestamps = event.target.result;
+    ChromeSamples.setStatus('There are ' + timestamps.length +
+      ' timestamps saved in IndexedDB: ' + timestamps.join(', '));
+  };
 });

--- a/idb-getall/demo.js
+++ b/idb-getall/demo.js
@@ -1,0 +1,46 @@
+var DB_NAME = 'timestamps';
+var DB_VERSION = 1;
+var STORE_NAME = 'store';
+var dbInstance;
+
+// Simple Promise-based wrapper around getting an IndexedDB instance.
+function getDB() {
+  if (dbInstance) {
+    return Promise.resolve(dbInstance);
+  }
+
+  return new Promise(function(resolve) {
+    var request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = function() {
+      request.result.createObjectStore(STORE_NAME, {autoIncrement: true});
+    };
+
+    request.onsuccess = function() {
+      dbInstance = request.result;
+      resolve(dbInstance);
+    };
+  });
+}
+
+
+document.querySelector('#add').addEventListener('click', function(event) {
+  getDB().then(function(db) {
+    var transaction = db.transaction(STORE_NAME, 'readwrite');
+    var objectStore = transaction.objectStore(STORE_NAME);
+    objectStore.put(Date.now());
+  });
+});
+
+document.querySelector('#display').addEventListener('click', function(event) {
+  getDB().then(function(db) {
+    var transaction = db.transaction(STORE_NAME, 'readonly');
+    var objectStore = transaction.objectStore(STORE_NAME);
+    // IDBObjectStore.getAll() will return the full set of items in our store.
+    objectStore.getAll().onsuccess = function(event) {
+      var timestamps = event.target.result;
+      ChromeSamples.setStatus('There are ' + timestamps.length + ' timestamps saved in IndexedDB: '
+        + timestamps.join(', '));
+    };
+  });
+});

--- a/idb-getall/demo.js
+++ b/idb-getall/demo.js
@@ -40,7 +40,7 @@ displayButton.addEventListener('click', function() {
   if ('getAll' in objectStore) {
     // IDBObjectStore.getAll() will return the full set of items in our store.
     objectStore.getAll().onsuccess = function(event) {
-      logTimestamps(event.target.result)
+      logTimestamps(event.target.result);
     };
   } else {
     // Fallback to the traditional cursor approach if getAll isn't supported.

--- a/idb-getall/demo.js
+++ b/idb-getall/demo.js
@@ -15,9 +15,8 @@ request.onupgradeneeded = function() {
 request.onsuccess = function() {
   db = request.result;
   // Enable our buttons once the IndexedDB instance is available.
-  [addButton, displayButton].forEach(function(button) {
-    button.disabled = false;
-  });
+  addButton.disabled = false;
+  displayButton.disabled = false;
 };
 
 addButton.addEventListener('click', function() {
@@ -36,6 +35,6 @@ displayButton.addEventListener('click', function() {
   objectStore.getAll().onsuccess = function(event) {
     var timestamps = event.target.result;
     ChromeSamples.setStatus('There are ' + timestamps.length +
-      ' timestamps saved in IndexedDB: ' + timestamps.join(', '));
+      ' timestamp(s) saved in IndexedDB: ' + timestamps.join(', '));
   };
 });

--- a/idb-getall/index.html
+++ b/idb-getall/index.html
@@ -31,8 +31,8 @@ feature_id: 6537756637396992
   You can use the buttons to add new timestamps to IndexedDB, and to display a full list of
   timestamps that were previously set using <code>IDBObjectStore.getAll()</code>.
 </p>
-<button id="add">Add Timestamp</button>
-<button id="display">Display Timestamps</button>
+<button id="add" disabled>Add Timestamp</button>
+<button id="display" disabled>Display Timestamps</button>
 {% endcapture %}
 {% include output_helper.html initial_output_content=initial_output_content %}
 

--- a/idb-getall/index.html
+++ b/idb-getall/index.html
@@ -1,0 +1,39 @@
+---
+feature_name: IndexedDB getAll() Methods
+chrome_version: 48
+feature_id: 6537756637396992
+---
+
+<h3>Background</h3>
+<p>
+  The
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">IndexedDB</a>
+  "batched get" API allows you to retrieve several keys or values from IndexedDB in a single method
+  call. The "batched get" methods include:
+</p>
+<ul>
+  <li>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/getAll"><code>IDBObjectStore.getAll()</code></a>
+  </li>
+  <li>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/getAllKeys"><code>IDBObjectStore.getAllKeys()</code></a>
+  </li>
+  <li>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAll"><code>IDBIndex.getAll()</code></a>
+  </li>
+  <li>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAllKeys"><code>IDBIndex.getAllKeys()</code></a>
+  </li>
+</ul>
+
+{% capture initial_output_content %}
+<p>
+  You can use the buttons to add new timestamps to IndexedDB, and to display a full list of
+  timestamps that were previously set using <code>IDBObjectStore.getAll()</code>.
+</p>
+<button id="add">Add Timestamp</button>
+<button id="display">Display Timestamps</button>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}


### PR DESCRIPTION
R: @addyosmani @gauntface @beaufortfrancois 
CC: @inexorabletash

This implements a basic sample to go along with the new M48 IndexedDB "batch get" methods (https://www.chromestatus.com/feature/6537756637396992).

I'm using a light Promise wrapper around getting the IndexedDB instance, but I don't think that's too distracting.

You can view a deployed version of this sample at https://jeffy.info/samples/idb-getall/
