### PR TITLE
Service worker "kill switch" sample

### DIFF
--- a/service-worker/README.md
+++ b/service-worker/README.md
@@ -43,6 +43,10 @@ take control of the page that just registered it.
 - [Using `window.caches`](https://googlechrome.github.io/samples/service-worker/window-caches/index.html) -
 a sample showing how `window.caches` provides access to the Cache Storage API.
 
+- ["Kill Switch"](https://googlechrome.github.io/samples/service-worker/kill-switch/index.html) -
+a sample showing how to register a "kill switch" `fetch` event handler that unregisters the active
+service worker when users visit a specific URL.
+
 # Related samples
 
 - Instructions for [registering for Push Messages and showing Notifications](https://github.com/GoogleChrome/samples/tree/gh-pages/push-messaging-and-notifications).

--- a/service-worker/kill-switch/README.md
+++ b/service-worker/kill-switch/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Kill Switch
+===
+See https://googlechrome.github.io/samples/service-worker/kill-switch/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/kill-switch/index.html
+++ b/service-worker/kill-switch/index.html
@@ -1,0 +1,61 @@
+---
+feature_name: "Service Worker Sample: Kill Switch"
+chrome_version: 45
+feature_id: 6561526227927040
+---
+
+<h3>Background</h3>
+<p>
+  This samples demonstrates one approach to implementing a service worker
+  "<a href="https://en.wikipedia.org/wiki/Kill_switch">kill switch</a>". This pages registers a
+  service worker that has an undesirable <code>fetch</code> handler, which unconditionally
+  returns useless HTML in response to every fetch request. This simulates the "worst case scenario"
+  for a buggy or poorly implemented service worker. <strong>Once you reload this page, you'll see the
+  undesirable service worker in action.</strong>
+</p>
+
+<p>
+  Before getting into the technical details of the kill switch, it's worth pointing out that even
+  in this "worst case scenario", browsers offer built-in remediations that might prove sufficient.
+  One remediation is to
+  <a href="https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache">shift-reload</a>, which will
+  bypass the service worker and serve the page directly from the network.
+</p>
+
+<p>
+  Another remediation is simply to update your service worker script to resolve the bug, and
+  redeploy it to your web server. As soon as the service worker script is expired from a
+  browser's HTTP cache, the updated service worker script will end up being registered. You
+  can use the <a href="../immediate-control/">immediate control</a> pattern in your updated script
+  to ensure that the newly registered service worker takes control over existing tabs. Even if
+  you've inadvertently set the HTTP cache control headers to expire at some point in the far future,
+  a cached copy of the service worker script older than
+  <a href="https://github.com/slightlyoff/ServiceWorker/issues/514">24 hours</a> is automatically
+  ignored, and a call to <code>navigator.serviceWorker.register()</code> will fetch a fresh copy
+  from the network at that point. So the worst-case scenario is that users might have to wait a day
+  until their previously cached service worker script expires.
+</p>
+
+<p>
+  That being said, overly cautious developers might want to add in "kill switch" functionality
+  to their service worker, just in case. One approach to doing this is to call
+  <code>addEventListener('fetch', ...)</code> as early as possible in your service worker script,
+  and register a <code>fetch</code> event listener that will check the request for a special
+  URL pattern. If the request URL matches, it will call <code>event.respondWith()</code> to handle
+  the event (preventing any other <code>fetch</code> event listeners from executing), and
+  use <code>registration.unregister()</code> to deactivate itself.
+</p>
+
+<p>
+  At this point, the service worker will not longer control the pages under its previous scope,
+  but you need to be careful that the buggy service worker doesn't just get registered again.
+  For the purposes of this demo, this page will re-register the same service worker each time you
+  return, but in a real-world scenario you'd probably want to either temporarily remove the
+  <code>navigator.serviceWorker.register()</code> call from your pages, or change the service worker
+  script URL to include versioning information (e.g. <code>'service-worker.js?v=2'</code>) so that
+  the older, buggy script isn't immediately reused from the HTTP cache.
+</p>
+
+{% include js_snippet.html filename='index.js' title="This Page's JavaScript" %}
+{% include js_snippet.html filename='sw-kill-switch.js' displayonly=true title="\"Kill Switch\"'s JavaScript" %}
+{% include js_snippet.html filename='service-worker.js' displayonly=true title="Service Worker's JavaScript" %}

--- a/service-worker/kill-switch/index.js
+++ b/service-worker/kill-switch/index.js
@@ -1,0 +1,3 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker.js');
+}

--- a/service-worker/kill-switch/service-worker.js
+++ b/service-worker/kill-switch/service-worker.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// fetch event handlers are run sequentially, in the order that addEventListener('fetch', fn)
+// is executed, until one of them calls event.respondWith() and returns a response to the page.
+// For the kill switch to be effective, we need the addEventListener('fetch', fn) that
+// registers the switch to execute first, before any other fetch event handlers are registered.
+// Putting the importScripts() at the top of this file accomplishes that.
+importScripts('sw-kill-switch.js');
+
+let HTML_RESPONSE = `<html>
+  <head>
+    <title>Oops!</title>
+  </head>
+  <body>
+    <h1>Ooops!</h1>
+    <p>This response is returned for <em>every</em> request in the service worker's scope.</p>
+    <p>
+      You should visit <a href="${self.KILL_SWITCH_URL_FRAGMENT}">the kill switch page</a>
+      (any URL containing <code>${self.KILL_SWITCH_URL_FRAGMENT}</code>) to unregister
+      the service worker and get back to normal!
+    </p>
+  </body>
+</html>`;
+
+// This is a deliberately dangerous fetch handler, used as an example of how a developer might
+// accidentally register a service worker that has unintended consequences.
+self.addEventListener('fetch', event => {
+  event.respondWith(new Response(HTML_RESPONSE, {headers: {'Content-Type': 'text/html'}}));
+});

--- a/service-worker/kill-switch/sw-kill-switch.js
+++ b/service-worker/kill-switch/sw-kill-switch.js
@@ -1,0 +1,34 @@
+(global => {
+  // Explicitly set this value on the ServiceWorkerGlobalScope so that we can use it as
+  // self.KILL_SWITCH_URL_FRAGMENT within the main service-worker.js file.
+  global.KILL_SWITCH_URL_FRAGMENT = 'unregister-service-worker';
+
+  const HTML_RESPONSE = `<html>
+  <head>
+    <title>Service Worker Unregistered</title>
+  </head>
+  <body>
+    <h1>Service Worker Unregistered</h1>
+    <p>
+      The offending service worker has been unregistered,
+      and you can return to <a href="index.html">the main page</a>.
+    </p>
+  </body>
+</html>`;
+
+  // This fetch event listener should be added as early as possible, so that it gets
+  // "first crack" at handling the event.
+  global.addEventListener('fetch', event => {
+    if (event.request.url.includes(global.KILL_SWITCH_URL_FRAGMENT)) {
+      // Call event.respondWith() conditionally, based on the request URL.
+      // The first fetch event handler that calls event.respondWith() "wins", and returns the
+      // response to the controlled page. No other fetch event handlers will run.
+      event.respondWith(
+        // registration.unregister() will unregister the current service worker.
+        global.registration.unregister().then(
+          // After the service worker unregisters, return an HTML response.
+          () => new Response(HTML_RESPONSE, {headers: {'Content-Type': 'text/html'}}))
+      );
+    }
+  });
+})(self);


### PR DESCRIPTION
R: @addyosmani @gauntface @wibblymat @jakearchibald @slightlyoff

From time to time folks ask about implementing a service worker "kill switch". I've tried to distill some best practices into a modular sample, and include information about why adding in a "kill switch" might not be necessary (shift-reloads, 24 hour max SW.js cache lifetime).

Curious to hear whether folks find this sample useful and sufficiently motivated/explained.

You can play around with a live version of the code at https://jeffy.info/samples/service-worker/kill-switch/
