### PR TITLE
Fix media query checking for absence of any fine pointer

### DIFF
--- a/media-hover-pointer/index.html
+++ b/media-hover-pointer/index.html
@@ -66,7 +66,7 @@ limitations under the License.
       .sized {
         font-size: 0.5em;
       }
-      @media not (any-pointer: fine) {
+      @media not all and (any-pointer: fine) {
         .sized {
           font-size: 2.0em;
         }


### PR DESCRIPTION
As per https://github.com/GoogleChrome/samples/issues/90#issuecomment-85559052 `not (any-pointer: fine)` does not seem to be evaluated correctly in browsers. however, the more verbose `not all and (any-pointer: fine)` works fine (can be verified by using desktop chrome with mouse (small button) and then turning on devtools device emulation (which fails the `any-pointer: fine` media feature test, so the larger font size per this media query kicks in)

Closes #90 
