### PR TITLE
High Resolution Time Stamp for Events Sample

### DIFF
--- a/event-timestamp/README.md
+++ b/event-timestamp/README.md
@@ -1,0 +1,5 @@
+High Resolution Time Stamp for Events Sample
+===
+See https://googlechrome.github.io/samples/event-timestamp/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/5523910145605632

--- a/event-timestamp/demo.js
+++ b/event-timestamp/demo.js
@@ -1,6 +1,24 @@
+var dateNowAtLoad = Date.now();
+var offsetFromEpoch;
+
 var previousX = 0;
 var previousY = 0;
 var previousT = 0;
+
+function calculateDateForTimestamp(timestamp) {
+  if (offsetFromEpoch === undefined) {
+    // When we don't yet know what the offset should be, use a simple heuristic:
+    // If the timestamp value is less than the time this JS was first loaded,
+    // then it's almost certainly a DOMHighResTimeStamp. Adding timestamp to
+    // performance.timing.navigationStart should give a value relative to
+    // the epoch, which could be passed in to the Date constructor.
+    // Otherwise, it's a DOMTimeStamp, and is already relative to the epoch.
+    offsetFromEpoch = (timestamp < dateNowAtLoad) ?
+      performance.timing.navigationStart : 0;
+  }
+
+  return new Date(offsetFromEpoch + timestamp);
+}
 
 // While a 'mousemove' listener is being used for the purposes of this
 // example, the new timeStamp resolution applies to all Event types.
@@ -19,7 +37,11 @@ window.addEventListener('mousemove', function(event) {
   // Multiply by 1000 to go from milliseconds to seconds.
   var velocityInPixelsPerSecond = Δd / Δt * 1000;
 
-  ChromeSamples.setStatus(velocityInPixelsPerSecond);
+  // Contrived example to illustrate how to convert event.timeStamp to a Date.
+  var date = calculateDateForTimestamp(event.timeStamp);
+
+  ChromeSamples.setStatus(velocityInPixelsPerSecond + ' as of ' +
+    date.toLocaleTimeString());
 
   previousX = event.screenX;
   previousY = event.screenY;

--- a/event-timestamp/demo.js
+++ b/event-timestamp/demo.js
@@ -1,47 +1,30 @@
-var offsetFromEpoch = 0;
-var previousX = 0;
-var previousY = 0;
-var previousT = 0;
+var previousX;
+var previousY;
+var previousT;
 
-window.addEventListener('load', function(event) {
-  // Use a simple heuristic to determine the offset from the epoch:
-  // If the timestamp value is less than the current time,
-  // then it's almost certainly a DOMHighResTimeStamp. Adding timestamp to
-  // performance.timing.navigationStart should give a value relative to
-  // the epoch, which could be passed in to the Date constructor.
-  // Otherwise, it's a DOMTimeStamp, and is already relative to the epoch.
-  if (event.timeStamp < Date.now()) {
-    offsetFromEpoch = performance.timing.navigationStart;
+window.addEventListener('mousemove', function(event) {
+  // Don't update velocity until we have an initial value for X, Y, and T.
+  if (!(previousX === undefined ||
+        previousY === undefined ||
+        previousT === undefined)) {
+    var Δx = event.screenX - previousX;
+    var Δy = event.screenY - previousY;
+    var Δd = Math.sqrt(Math.pow(Δx, 2) + Math.pow(Δy, 2));
+
+    // event.timeStamp will always represent a value in milliseconds.
+    // In supported browsers, the value will have a microsecond resolution, and
+    // therefore might include a fractional number of milliseconds.
+    // Older browsers only support a millisecond resolution, and the value will
+    // always be a whole number.
+    var Δt = event.timeStamp - previousT;
+
+    // Multiply by 1000 to go from milliseconds to seconds.
+    var velocityInPixelsPerSecond = Δd / Δt * 1000;
+
+    ChromeSamples.setStatus(velocityInPixelsPerSecond);
   }
-
-  // While a 'mousemove' listener is being used for the purposes of this
-  // example, the new timeStamp resolution applies to all Event types.
-  window.addEventListener('mousemove', calculateVelocity);
-});
-
-function calculateVelocity(event) {
-  var Δx = event.screenX - previousX;
-  var Δy = event.screenY - previousY;
-  var Δd = Math.sqrt(Math.pow(Δx, 2) + Math.pow(Δy, 2));
-
-  // event.timeStamp will always represent a value in milliseconds.
-  // In supported browsers, the value will have a microsecond resolution, and
-  // therefore might include a fractional number of milliseconds.
-  // Older browsers only support a millisecond resolution, and the value will
-  // always be a whole number.
-  var Δt = event.timeStamp - previousT;
-
-  // Multiply by 1000 to go from milliseconds to seconds.
-  var velocityInPixelsPerSecond = Δd / Δt * 1000;
-
-  // Contrived example to illustrate how to use offsetFromEpoch to get a Date
-  // that corresponds to event.timeStamp.
-  var date = new Date(event.timeStamp + offsetFromEpoch);
-
-  ChromeSamples.setStatus(velocityInPixelsPerSecond + ' as of ' +
-    date.toLocaleTimeString());
 
   previousX = event.screenX;
   previousY = event.screenY;
   previousT = event.timeStamp;
-}
+});

--- a/event-timestamp/demo.js
+++ b/event-timestamp/demo.js
@@ -1,0 +1,27 @@
+var previousX = 0;
+var previousY = 0;
+var previousT = 0;
+
+// While a 'mousemove' listener is being used for the purposes of this
+// example, the new timeStamp resolution applies to all Event types.
+window.addEventListener('mousemove', function(event) {
+  var Δx = event.screenX - previousX;
+  var Δy = event.screenY - previousY;
+  var Δd = Math.sqrt(Math.pow(Δx, 2) + Math.pow(Δy, 2));
+
+  // event.timeStamp will always represent a value in milliseconds.
+  // In supported browsers, the value will have a microsecond resolution, and
+  // therefore might include a fractional number of milliseconds.
+  // Older browsers only support a millisecond resolution, and the value will
+  // always be a whole number.
+  var Δt = event.timeStamp - previousT;
+
+  // Multiply by 1000 to go from milliseconds to seconds.
+  var velocityInPixelsPerSecond = Δd / Δt * 1000;
+
+  ChromeSamples.setStatus(velocityInPixelsPerSecond);
+
+  previousX = event.screenX;
+  previousY = event.screenY;
+  previousT = event.timeStamp;
+});

--- a/event-timestamp/index.html
+++ b/event-timestamp/index.html
@@ -1,0 +1,53 @@
+---
+feature_name: High Resolution Time Stamp for Events
+chrome_version: 49
+feature_id: 5523910145605632
+---
+
+<h3>Background</h3>
+<p>
+  The <a href="https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp"><code>timeStamp</code></a>
+  property of the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/Event"><code>Event</code></a>
+  interface indicates the time at which a given event took place.
+</p>
+
+<p>
+  Previously, this <code>timeStamp</code> value was represented as a
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMTimeStamp"><code>DOMTimeStamp</code></a>,
+  which was a whole number of milliseconds since the
+  <a href="https://en.wikipedia.org/wiki/Epoch_(reference_date)#Computing">system epoch</a>.
+</p>
+
+<p>
+  Starting with Chrome 49, <code>timeStamp</code> is a
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp"><code>DOMHighResTimeStamp</code></a>
+  value. This value is still a number of milliseconds, but with microsecond
+  resolution, meaning the value will include a decimal component.
+  Additionally, instead of the value being relative to the epoch, the value is
+  relative to the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/navigationStart"><code>PerformanceTiming.navigationStart</code></a>,
+  i.e. the time at which the user navigated to the page.
+</p>
+
+<p>
+  To convert the a <code>DOMHighResTimeStamp</code> value to an absolute number
+  of milliseconds since the epoch (e.g., to get a value to pass to the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"><code>Date()</code></a> constructor),
+  use <code>event.timeStamp + performance.timing.navigationStart</code>.
+</p>
+
+{% capture initial_output_content %}
+<p>
+  The following sample provides a rough approximation of mouse pointer velocity,
+  with a higher precision on browsers that support
+  <code>DOMHighResTimeStamp</code>. (In this contrived example, the difference
+  in resolution between <code>DOMHighResTimeStamp</code> and
+  <code>DOMTimeStamp</code> won't make a significantly affect the calculations,
+  since the change in pixel positions are relatively coarse.)
+</p>
+<p>Your mouse velocity, in pixels per second:</p>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}


### PR DESCRIPTION
R: @addyosmani @ebidel @beaufortfrancois @gauntface etc.
CC: @RByers

Here's the example for the new [High Resolution Time Stamp for Events](https://www.chromestatus.com/feature/5523910145605632) functionality in M49.

There's a live version deployed at https://jeffy.info/samples/event-timestamp/

I'd love to make sure @RByers doesn't have any issues with how I'm representing the information and example prior to merging.
