### PR TITLE
WindowClient.navigate() sample

### DIFF
--- a/service-worker/README.md
+++ b/service-worker/README.md
@@ -43,6 +43,11 @@ take control of the page that just registered it.
 - [Using `window.caches`](https://googlechrome.github.io/samples/service-worker/window-caches/index.html) -
 a sample showing how `window.caches` provides access to the Cache Storage API.
 
+- [Using `WindowClient.navigate()`](https://googlechrome.github.io/samples/service-worker/windowclient-navigate/index.html) -
+a sample showing how a service worker can cause web page clients it controls to
+navigate to a given URL.
+
+
 # Related samples
 
 - Instructions for [registering for Push Messages and showing Notifications](https://github.com/GoogleChrome/samples/tree/gh-pages/push-messaging-and-notifications).

--- a/service-worker/windowclient-navigate/README.md
+++ b/service-worker/windowclient-navigate/README.md
@@ -1,0 +1,5 @@
+Service Worker Sample: Custom Offline Page
+===
+See https://googlechrome.github.io/samples/service-worker/custom-offline-page/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/6561526227927040

--- a/service-worker/windowclient-navigate/activated.html
+++ b/service-worker/windowclient-navigate/activated.html
@@ -1,0 +1,25 @@
+---
+feature_name: "Service Worker: WindowClient.navigate()"
+chrome_version: 49
+feature_id: 5314750808326144
+---
+
+<h3>Background</h3>
+<p>
+  If you're seeing this page, you've most likely been navigated here from
+  <a href="index.html">index.html</a> following the service worker activation.
+</p>
+
+<p>
+  The service worker called <code>client.navigate('activated.html')</code> on
+  each window that it controlled, which caused all of them to navigate to this
+  page.
+</p>
+
+<p>
+  When you revisit <a href="index.html">index.html</a>, you'll remain on that
+  page, since the <code>activate</code> event is only fired once for each
+  service worker version.
+</p>
+
+{% include js_snippet.html filename='service-worker.js' displayonly=true title="Service Worker's JavaScript" %}

--- a/service-worker/windowclient-navigate/index.html
+++ b/service-worker/windowclient-navigate/index.html
@@ -1,0 +1,31 @@
+---
+feature_name: "Service Worker: WindowClient.navigate()"
+chrome_version: 49
+feature_id: 5314750808326144
+---
+
+<h3>Background</h3>
+<p>
+  <code>WindowClient.navigate()</code> allows a service worker to cause a web
+  page to navigate to a specific URL.
+</p>
+
+<p>
+  This sample shows how <code>WindowClient.navigate()</code> can be called
+  within a service worker's <code>activate</code> handler, to navigate to
+  <code>activated.html</code>. If your browser supports service workers, and
+  supports <code>WindowClient.navigate()</code>, then you'll be automatically
+  navigated away from this page once the service worker activates.
+</p>
+
+<p>
+  Note that the <code>activate</code> event is only fired once per version of
+  a given service worker registration. If you'd like to trigger it again to
+  test out the <code>WindowClient.navigate()</code> behavior, you can revisit
+  this page in a Chrome
+  <a href="https://support.google.com/chrome/answer/95464?source=gsearch&hl=en">Incognito window</a>, which will trigger a fresh
+  service worker registration.
+</p>
+
+{% include js_snippet.html filename='index.js' title="This Page's JavaScript" %}
+{% include js_snippet.html filename='service-worker.js' displayonly=true title="Service Worker's JavaScript" %}

--- a/service-worker/windowclient-navigate/index.html
+++ b/service-worker/windowclient-navigate/index.html
@@ -6,7 +6,7 @@ feature_id: 5314750808326144
 
 <h3>Background</h3>
 <p>
-  <code>WindowClient.navigate()</code> allows a service worker to cause a web
+  <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/WindowClient">WindowClient</a>.navigate()</code> allows a service worker to cause a web
   page to navigate to a specific URL.
 </p>
 

--- a/service-worker/windowclient-navigate/index.js
+++ b/service-worker/windowclient-navigate/index.js
@@ -1,0 +1,3 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker.js');
+}

--- a/service-worker/windowclient-navigate/service-worker.js
+++ b/service-worker/windowclient-navigate/service-worker.js
@@ -1,0 +1,13 @@
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim().then(() => {
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Clients/matchAll
+    return self.clients.matchAll({type: 'window'});
+  }).then(clients => {
+    return clients.map(client => {
+      // Check to make sure WindowClient.navigate() is supported.
+      if ('navigate' in client) {
+        return client.navigate('activated.html');
+      }
+    });
+  }));
+});


### PR DESCRIPTION
R: @addyosmani @gauntface @jakearchibald @beaufortfrancois etc.

This is a sample for `WindowClient.navigate()`, shipping in [Chrome 49](https://www.chromestatus.com/feature/5314750808326144).

You can view a live version of this sample at https://jeffy.info/samples/service-worker/windowclient-navigate/
