### PR TITLE
Add description to web bluetooth samples index page.

### DIFF
--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -4,13 +4,12 @@ chrome_version: 45
 feature_id: 5264933985976320
 ---
 
-<p>The following samples show you some of the ways that you can use the Web Bluetooth API:</p>
-<ul>
-  <li><a href="device-info.html">Device Info</a></li>
-  <li><a href="battery-level.html">Battery Level</a></li>
-  <li><a href="reset-energy.html">Reset Energy</a></li>
-  <li><a href="characteristic-properties.html">Characteristic Properties</a></li>
-  <li><a href="notifications.html">Notifications</a></li>
-  <li><a href="device-disconnect.html">Device Disconnect</a></li>
-  <li><a href="get-characteristics.html">Get Characteristics</a></li>
-</ul>
+<p>The following samples show you some of the ways that you can use the <a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth API</a>:</p>
+
+<p><a href="device-info.html">Device Info</a> - retrieve basic device information from a BLE Device.</p>
+<p><a href="battery-level.html">Battery Level</a> - retrieve battery information from a BLE Device advertising Battery information.</p>
+<p><a href="reset-energy.html">Reset Energy</a> - reset energy expended from a BLE Device advertising Heart Rate.</p>
+<p><a href="characteristic-properties.html">Characteristic Properties</a> - display all properties of a specific characteristic from a BLE Device.</p>
+<p><a href="notifications.html">Notifications</a> - start and stop characteristic notifications from a BLE Device.</p>
+<p><a href="device-disconnect.html">Device Disconnect</a> - disconnect and get notified from a disconnection of a BLE Device after connecting to it.</p>
+<p><a href="get-characteristics.html">Get Characteristics</a> - get all characteristics of an advertised service from a BLE Device.</p>


### PR DESCRIPTION
I've simply added description to make "Web Bluetooth Samples" page easier to read.

![screenshot 2016-03-01 at 3 25 11 pm](https://cloud.githubusercontent.com/assets/634478/13429722/d33e84c2-dfc1-11e5-9bb7-8aba3e7c04f1.png)

R=@jeffposnick
