### PR TITLE
HTMLMediaElement.play() promise interface

### DIFF
--- a/play-return-promise/README.md
+++ b/play-return-promise/README.md
@@ -1,0 +1,5 @@
+HTMLMediaElement.play() Returns a Promise Sample
+===
+See https://googlechrome.github.io/samples/play-return-promise/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/5920584248590336

--- a/play-return-promise/demo.js
+++ b/play-return-promise/demo.js
@@ -1,0 +1,16 @@
+function startPlayback() {
+  return document.querySelector('#music').play();
+}
+
+ChromeSamples.log('Attempting to start playback automatically...');
+
+startPlayback().then(function() {
+  ChromeSamples.log('The play() Promise resolved! Rock on!');
+}).catch(function(error) {
+  ChromeSamples.log('The play() Promise rejected!\nUse the Play button instead.\n' + error);
+
+  var playButton = document.querySelector('#play');
+  // The user interaction requirement will be met if playback starts via a click event.
+  playButton.addEventListener('click', startPlayback);
+  playButton.hidden = false;
+});

--- a/play-return-promise/demo.js
+++ b/play-return-promise/demo.js
@@ -2,15 +2,18 @@ function startPlayback() {
   return document.querySelector('#music').play();
 }
 
-ChromeSamples.log('Attempting to start playback automatically...');
+ChromeSamples.log('Attempting to play automatically...');
 
 startPlayback().then(function() {
-  ChromeSamples.log('The play() Promise resolved! Rock on!');
+  ChromeSamples.log('The play() Promise fulfilled! Rock on!');
 }).catch(function(error) {
-  ChromeSamples.log('The play() Promise rejected!\nUse the Play button instead.\n' + error);
+  ChromeSamples.log('The play() Promise rejected!');
+  ChromeSamples.log('Use the Play button instead.');
+  ChromeSamples.log(error);
 
   var playButton = document.querySelector('#play');
-  // The user interaction requirement will be met if playback starts via a click event.
+  // The user interaction requirement is met if
+  // playback is triggered via a click event.
   playButton.addEventListener('click', startPlayback);
   playButton.hidden = false;
 });

--- a/play-return-promise/index.html
+++ b/play-return-promise/index.html
@@ -1,0 +1,26 @@
+---
+feature_name: HTMLMediaElement.play() Returns a Promise
+chrome_version: 50
+feature_id: 5920584248590336
+---
+
+<h3>Background</h3>
+<p>
+  Many mobile browsers prevent JavaScript from initiating playback of media elements
+  unless it's in response to user interaction.
+</p>
+<p>
+  It's historically been difficult to detect failed playbacks due to mobile browser
+  restrictions, but the new
+  <a href="http://www.html5rocks.com/en/tutorials/es6/promises/"><code>Promise</code></a>-based
+  interface to the <code>play()</code> method provides a friendly way of detecting whether
+  playback succeeded or failed.
+</p>
+
+{% capture initial_output_content %}
+<audio id="music" src="../audio/techno.wav"></audio>
+<button id="play" hidden>Play</button>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/play-return-promise/index.html
+++ b/play-return-promise/index.html
@@ -17,10 +17,12 @@ feature_id: 5920584248590336
   playback succeeded or failed.
 </p>
 
-{% capture initial_output_content %}
+{% capture html %}
 <audio id="music" src="../audio/techno.wav"></audio>
 <button id="play" hidden>Play</button>
 {% endcapture %}
-{% include output_helper.html initial_output_content=initial_output_content %}
 
+{% include output_helper.html %}
+
+{% include html_snippet.html html=html %}
 {% include js_snippet.html filename='demo.js' %}


### PR DESCRIPTION
R: @addyosmani @PaulKinlan @gauntface @beaufortfrancois @ebidel etc.

Here's the code sample for the [HTMLMediaElement.play() returns a promise](https://www.chromestatus.com/feature/5920584248590336) feature in M50.

It makes use of an existing audio file that we have rights for and which was used for another sample.

You can view a live version at https://jeffy.info/samples/play-return-promise/

There's a separate /web/updates/ article planned with more information.
