### PR TITLE
web-bluetooth: Use gatt.connect instead of connectGATT

### DIFF
--- a/web-bluetooth/battery-level.js
+++ b/web-bluetooth/battery-level.js
@@ -7,7 +7,7 @@ function onButtonClick() {
   .then(device => {
     log('> Found ' + device.name);
     log('Connecting to GATT Server...');
-    return device.connectGATT();
+    return device.gatt.connect();
   })
   .then(server => {
     log('Getting Battery Service...');

--- a/web-bluetooth/characteristic-properties.js
+++ b/web-bluetooth/characteristic-properties.js
@@ -13,7 +13,7 @@ function onFormSubmit() {
 
   log('Requesting Bluetooth Device...');
   navigator.bluetooth.requestDevice({filters: [{services: [serviceUuid]}]})
-  .then(device => device.connectGATT())
+  .then(device => device.gatt.connect())
   .then(server => server.getPrimaryService(serviceUuid))
   .then(service => service.getCharacteristic(characteristicUuid))
   .then(characteristic => {

--- a/web-bluetooth/get-characteristics.js
+++ b/web-bluetooth/get-characteristics.js
@@ -8,7 +8,7 @@ function onFormSubmit() {
 
   log('Requesting Bluetooth Device...');
   navigator.bluetooth.requestDevice({filters: [{services: [serviceUuid]}]})
-  .then(device => device.connectGATT())
+  .then(device => device.gatt.connect())
   .then(server => server.getPrimaryService(serviceUuid))
   .then(service => service.getCharacteristics())
   .then(characteristics => {

--- a/web-bluetooth/notifications.js
+++ b/web-bluetooth/notifications.js
@@ -14,7 +14,7 @@ function onStartButtonClick() {
 
   log('Requesting Bluetooth Device...');
   navigator.bluetooth.requestDevice({filters: [{services: [serviceUuid]}]})
-  .then(device => device.connectGATT())
+  .then(device => device.gatt.connect())
   .then(server => server.getPrimaryService(serviceUuid))
   .then(service => service.getCharacteristic(characteristicUuid))
   .then(characteristic => {

--- a/web-bluetooth/reset-energy.js
+++ b/web-bluetooth/reset-energy.js
@@ -6,7 +6,7 @@ function onButtonClick() {
   .then(device => {
     log('> Found ' + device.name);
     log('Connecting to GATT Server...');
-    return device.connectGATT();
+    return device.gatt.connect();
   })
   .then(server => {
     log('Getting Heart Rate Service...');


### PR DESCRIPTION
R=@jeffposnick

The warning is shown when use connectGATT, it's deprecated.

Warning message:

> 'BluetoothDevice.connectGATT' is deprecated and will be removed in M52, around August 2016. Please use 'BluetoothDevice.gatt.connect' instead. See https://www.chromestatus.com/feature/5264933985976320 for more details.
