### PR TITLE
Remove the device info and device class fields from BluetoothDevice

### DIFF
--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -26,12 +26,8 @@ function onFormSubmit() {
   .then(device => {
     log('> Name:             ' + device.name);
     log('> Id:               ' + device.id);
-    log('> Device Class:     ' + device.deviceClass);
-    log('> Vendor Id Source: ' + device.vendorIDSource);
-    log('> Vendor Id:        ' + device.vendorID);
-    log('> Product Id:       ' + device.productID);
-    log('> Product Version:  ' + device.productVersion);
     log('> UUIDs:            ' + device.uuids.join('\n' + ' '.repeat(20)));
+    log('> Connected:        ' + device.gatt.connected);
     if (device.adData) {
       log('> Tx Power:         ' + device.adData.txPower + ' dBm');
       log('> RSSI:             ' + device.adData.rssi + ' dBm');


### PR DESCRIPTION
According to https://github.com/WebBluetoothCG/web-bluetooth/pull/229,  device info and device class fields from BluetoothDevice will be removed from now on. Let's remove them from our "Device Info" sample.

![screenshot 2016-04-20 at 12 27 29 pm](https://cloud.githubusercontent.com/assets/634478/14671673/5e541966-06f3-11e6-8839-f9c294d08bff.png)

R=@jeffposnick
