### PR TITLE
Remove adData

### DIFF
--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -26,10 +26,6 @@ function onFormSubmit() {
     log('> Id:               ' + device.id);
     log('> UUIDs:            ' + device.uuids.join('\n' + ' '.repeat(20)));
     log('> Connected:        ' + device.gatt.connected);
-    if (device.adData) {
-      log('> Tx Power:         ' + device.adData.txPower + ' dBm');
-      log('> RSSI:             ' + device.adData.rssi + ' dBm');
-    }
   })
   .catch(error => {
     log('Argh! ' + error);


### PR DESCRIPTION
As discussed in https://github.com/WebBluetoothCG/web-bluetooth/pull/235, the `adData` field is removed.

TBR=@jeffposnick
