### PR TITLE
Check for Android and use latest PaymentRequest API

### DIFF
--- a/paymentrequest/README.md
+++ b/paymentrequest/README.md
@@ -1,0 +1,20 @@
+# PaymentRequest Recipes
+
+- [Credit cards](https://googlechrome.github.io/samples/paymentrequest/credit-cards/index.html) -
+a sample that accepts credit card payments and does not request shipping
+information.
+
+- [Android Pay](https://googlechrome.github.io/samples/paymentrequest/android-pay/index.html) -
+a sample that accepts Android Pay payments and does not request shipping
+information.
+
+- [Free shipping](https://googlechrome.github.io/samples/paymentrequest/free-shipping/index.html) -
+a sample that accepts credit card payments and provides free shipping worldwide.
+
+- [Shipping options](https://googlechrome.github.io/samples/paymentrequest/shipping-options/index.html) -
+a sample that accepts credit card payments and provides a couple of shipping
+options regardless of shipping address.
+
+- [Dynamic shipping options](https://googlechrome.github.io/samples/paymentrequest/dynamic-shipping/index.html) -
+a sample that accepts credit card payments and varies the availability and price
+of shipping options depending on the shipping address.

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -6,17 +6,17 @@ function onBuyClicked() {
       {
         id: 'original',
         label: 'Original donation amount',
-        amount: {currencyCode: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'}
       },
       {
         id: 'discount',
         label: 'Friends and family discount',
-        amount: {currencyCode: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'}
       },
       {
         id: 'total',
         label: 'Donation',
-        amount: {currencyCode: 'USD', value: '55.00'}
+        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -57,7 +57,7 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -31,8 +31,7 @@ function onBuyClicked() {
   };
 
   try {
-    // eslint-disable-next-line no-undef
-    new PaymentRequest(supportedInstruments, details, null, schemeData)
+    new PaymentRequest(supportedInstruments, details, null, schemeData) // eslint-disable-line no-undef
         .show()
         .then(function(instrumentResponse) {
           // Simulate server-side processing with a 2 second delay.

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -1,0 +1,66 @@
+function onBuyClicked() {
+  var supportedInstruments = ['https://android.com/pay'];
+
+  var details = {
+    items: [
+      {
+        id: 'original',
+        label: 'Original donation amount',
+        amount: {currencyCode: 'USD', value: '65.00'}
+      },
+      {
+        id: 'discount',
+        label: 'Friends and family discount',
+        amount: {currencyCode: 'USD', value: '-10.00'}
+      },
+      {
+        id: 'total',
+        label: 'Donation',
+        amount: {currencyCode: 'USD', value: '55.00'}
+      }
+    ]
+  };
+
+  var schemeData = {
+    'https://android.com/pay': {
+      'gateway': 'stripe',
+       // Place your own Stripe publishable key here.
+      'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
+      'stripe:version': '2016-03-07'
+    }
+  };
+
+  try {
+    // eslint-disable-next-line no-undef
+    new PaymentRequest(supportedInstruments, details, null, schemeData)
+        .show()
+        .then(function(instrumentResponse) {
+          // Simulate server-side processing with a 2 second delay.
+          window.setTimeout(function() {
+            instrumentResponse.complete(true)
+                .then(function() {
+                  document.getElementById('result').innerHTML =
+                      'methodName: ' + instrumentResponse.methodName +
+                      '<br>details:<br>' +
+                      JSON.stringify(instrumentResponse.details, undefined, 2);
+                })
+                .catch(function(err) {
+                  ChromeSamples.setStatus(err.message);
+                });
+          }, 2000);
+        })
+        .catch(function(err) {
+          ChromeSamples.setStatus(err.message);
+        });
+  } catch (e) {
+    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+  }
+}
+
+var buyButton = document.getElementById('buyButton');
+if ('PaymentRequest' in window) {
+  buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+}

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -52,7 +52,7 @@ function onBuyClicked() {
           ChromeSamples.setStatus(err.message);
         });
   } catch (e) {
-    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+    ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
@@ -61,5 +61,7 @@ if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');
-  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now. ' +
+      'Enable chrome://flags/#enable-experimental-web-platform-features');
 }

--- a/paymentrequest/android-pay/index.html
+++ b/paymentrequest/android-pay/index.html
@@ -1,0 +1,24 @@
+---
+feature_name: PaymentRequest Android Pay
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts Android Pay payments and does not request shipping
+  information.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -31,8 +31,7 @@ function onBuyClicked() {
   };
 
   try {
-    // eslint-disable-next-line no-undef
-    new PaymentRequest(supportedInstruments, details)
+    new PaymentRequest(supportedInstruments, details) // eslint-disable-line no-undef
         .show()
         .then(function(instrumentResponse) {
           // Simulate server-side processing with a 2 second delay.

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -15,17 +15,17 @@ function onBuyClicked() {
       {
         id: 'original',
         label: 'Original donation amount',
-        amount: {currencyCode: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'}
       },
       {
         id: 'discount',
         label: 'Friends and family discount',
-        amount: {currencyCode: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'}
       },
       {
         id: 'total',
         label: 'Donation',
-        amount: {currencyCode: 'USD', value: '55.00'}
+        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -52,14 +52,16 @@ function onBuyClicked() {
           ChromeSamples.setStatus(err.message);
         });
   } catch (e) {
-    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+    ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');
-  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now. ' +
+      'Enable chrome://flags/#enable-experimental-web-platform-features');
 }

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -1,0 +1,66 @@
+function onBuyClicked() {
+  var supportedInstruments = [
+    'visa',
+    'mastercard',
+    'amex',
+    'discover',
+    'maestro',
+    'diners',
+    'jcb',
+    'unionpay'
+  ];
+
+  var details = {
+    items: [
+      {
+        id: 'original',
+        label: 'Original donation amount',
+        amount: {currencyCode: 'USD', value: '65.00'}
+      },
+      {
+        id: 'discount',
+        label: 'Friends and family discount',
+        amount: {currencyCode: 'USD', value: '-10.00'}
+      },
+      {
+        id: 'total',
+        label: 'Donation',
+        amount: {currencyCode: 'USD', value: '55.00'}
+      }
+    ]
+  };
+
+  try {
+    // eslint-disable-next-line no-undef
+    new PaymentRequest(supportedInstruments, details)
+        .show()
+        .then(function(instrumentResponse) {
+          // Simulate server-side processing with a 2 second delay.
+          window.setTimeout(function() {
+            instrumentResponse.complete(true)
+                .then(function() {
+                  document.getElementById('result').innerHTML =
+                      'methodName: ' + instrumentResponse.methodName +
+                      '<br>details:<br>' +
+                      JSON.stringify(instrumentResponse.details, undefined, 2);
+                })
+                .catch(function(err) {
+                  ChromeSamples.setStatus(err.message);
+                });
+          }, 2000);
+        })
+        .catch(function(err) {
+          ChromeSamples.setStatus(err.message);
+        });
+  } catch (e) {
+    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+  }
+}
+
+var buyButton = document.getElementById('buyButton');
+if ('PaymentRequest' in window) {
+  buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+}

--- a/paymentrequest/credit-cards/index.html
+++ b/paymentrequest/credit-cards/index.html
@@ -1,0 +1,24 @@
+---
+feature_name: PaymentRequest Credit Cards
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts credit card payments and does not request shipping
+  information.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -33,8 +33,7 @@ function onBuyClicked() {
   var options = {requestShipping: true};
 
   try {
-    // eslint-disable-next-line no-undef
-    var request = new PaymentRequest(supportedInstruments, details, options);
+    var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
 
     request.addEventListener('shippingaddresschange', function(evt) {
       evt.updateWith(new Promise(function(resolve, reject) {

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -64,16 +64,18 @@ function onBuyClicked() {
       ChromeSamples.setStatus(err.message);
     });
   } catch (e) {
-    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+    ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');
-  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now. ' +
+      'Enable chrome://flags/#enable-experimental-web-platform-features');
 }
 
 function updateDetails(details, shippingAddress, resolve, reject) {

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -15,17 +15,17 @@ function onBuyClicked() {
       {
         id: 'original',
         label: 'Original donation amount',
-        amount: {currencyCode: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'}
       },
       {
         id: 'discount',
         label: 'Friends and family discount',
-        amount: {currencyCode: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'}
       },
       {
         id: 'total',
         label: 'Donation',
-        amount: {currencyCode: 'USD', value: '55.00'}
+        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -83,7 +83,7 @@ function updateDetails(details, shippingAddress, resolve, reject) {
     var shippingOption = {
       id: '',
       label: '',
-      amount: {currencyCode: 'USD', value: '0.00'}
+      amount: {currency: 'USD', value: '0.00'}
     };
     if (shippingAddress.administrativeArea === 'CA') {
       shippingOption.id = 'ca';

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -1,0 +1,128 @@
+function onBuyClicked() {
+  var supportedInstruments = [
+    'visa',
+    'mastercard',
+    'amex',
+    'discover',
+    'maestro',
+    'diners',
+    'jcb',
+    'unionpay'
+  ];
+
+  var details = {
+    items: [
+      {
+        id: 'original',
+        label: 'Original donation amount',
+        amount: {currencyCode: 'USD', value: '65.00'}
+      },
+      {
+        id: 'discount',
+        label: 'Friends and family discount',
+        amount: {currencyCode: 'USD', value: '-10.00'}
+      },
+      {
+        id: 'total',
+        label: 'Donation',
+        amount: {currencyCode: 'USD', value: '55.00'}
+      }
+    ]
+  };
+
+  var options = {requestShipping: true};
+
+  try {
+    // eslint-disable-next-line no-undef
+    var request = new PaymentRequest(supportedInstruments, details, options);
+
+    request.addEventListener('shippingaddresschange', function(evt) {
+      evt.updateWith(new Promise(function(resolve, reject) {
+        updateDetails(details, request.shippingAddress, resolve, reject);
+      }));
+    });
+
+    request.show().then(function(instrumentResponse) {
+      // Simulate server-side processing with a 2 second delay.
+      window.setTimeout(function() {
+        instrumentResponse.complete(true)
+            .then(function() {
+              document.getElementById('result').innerHTML =
+                  'shippingOption: ' + request.shippingOption +
+                  '<br>shippingAddress:<br>' +
+                  JSON.stringify(toDictionary(request.shippingAddress),
+                                 undefined, 2) +
+                  '<br>methodName: ' + instrumentResponse.methodName +
+                  '<br>details:<br>' +
+                  JSON.stringify(instrumentResponse.details, undefined, 2);
+            })
+            .catch(function(err) {
+              ChromeSamples.setStatus(err.message);
+            });
+      }, 2000);
+    })
+    .catch(function(err) {
+      ChromeSamples.setStatus(err.message);
+    });
+  } catch (e) {
+    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+  }
+}
+
+var buyButton = document.getElementById('buyButton');
+if ('PaymentRequest' in window) {
+  buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+}
+
+function updateDetails(details, shippingAddress, resolve, reject) {
+  if (shippingAddress.regionCode === 'US') {
+    var shippingOption = {
+      id: '',
+      label: '',
+      amount: {currencyCode: 'USD', value: '0.00'}
+    };
+    if (shippingAddress.administrativeArea === 'CA') {
+      shippingOption.id = 'ca';
+      shippingOption.label = 'Free shipping in California';
+      details.items[details.items.length - 1].amount.value = '55.00';
+    } else {
+      shippingOption.id = 'us';
+      shippingOption.label = 'Standard shipping in US';
+      shippingOption.amount.value = '5.00';
+      details.items[details.items.length - 1].amount.value = '60.00';
+    }
+    if (details.items.length === 3) {
+      details.items.splice(-1, 0, shippingOption);
+    } else if (details.items.length === 4) {
+      details.items.splice(-2, 1, shippingOption);
+    } else {
+      reject('There should ever be only 3 or 4 line items. ' +
+             'Don\'t know how to handle ' + details.items.length.toString());
+      return;
+    }
+    details.shippingOptions = [shippingOption];
+  } else {
+    delete details.shippingOptions;
+  }
+  resolve(details);
+}
+
+function toDictionary(addr) {
+  var dict = {};
+  if (addr) {
+    dict.regionCode = addr.regionCode;
+    dict.administrativeArea = addr.administrativeArea;
+    dict.locality = addr.locality;
+    dict.dependentLocality = addr.dependentLocality;
+    dict.addressLine = addr.addressLine;
+    dict.postalCode = addr.postalCode;
+    dict.sortingCode = addr.sortingCode;
+    dict.languageCode = addr.languageCode;
+    dict.organization = addr.organization;
+    dict.recipient = addr.recipient;
+  }
+  return dict;
+}

--- a/paymentrequest/dynamic-shipping/index.html
+++ b/paymentrequest/dynamic-shipping/index.html
@@ -1,0 +1,24 @@
+---
+feature_name: PaymentRequest Dynamic Shipping
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts credit card payments and varies the availability and price
+  of shipping options depending on the shipping address.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -1,0 +1,100 @@
+function onBuyClicked() {
+  var supportedInstruments = [
+    'visa',
+    'mastercard',
+    'amex',
+    'discover',
+    'maestro',
+    'diners',
+    'jcb',
+    'unionpay'
+  ];
+
+  var details = {
+    items: [
+      {
+        id: 'original',
+        label: 'Original donation amount',
+        amount: {currencyCode: 'USD', value: '65.00'}
+      },
+      {
+        id: 'discount',
+        label: 'Friends and family discount',
+        amount: {currencyCode: 'USD', value: '-10.00'}
+      },
+      {
+        id: 'shipping',
+        label: 'Free shipping worldwide',
+        amount: {currencyCode: 'USD', value: '0.00'}
+      },
+      {
+        id: 'total',
+        label: 'Donation',
+        amount: {currencyCode: 'USD', value: '55.00'}
+      }
+    ],
+    shippingOptions: [
+      {
+        id: 'freeWorldwideShipping',
+        label: 'Free shipping worldwide',
+        amount: {currencyCode: 'USD', value: '0.00'}
+      }
+    ]
+  };
+
+  var options = {requestShipping: true};
+
+  try {
+    // eslint-disable-next-line no-undef
+    var request = new PaymentRequest(supportedInstruments, details, options);
+    request.show().then(function(instrumentResponse) {
+      // Simulate server-side processing with a 2 second delay.
+      window.setTimeout(function() {
+        instrumentResponse.complete(true)
+            .then(function() {
+              document.getElementById('result').innerHTML =
+                  'shippingOption: ' + request.shippingOption +
+                  '<br>shippingAddress:<br>' +
+                  JSON.stringify(toDictionary(request.shippingAddress),
+                                 undefined, 2) +
+                  '<br>methodName: ' + instrumentResponse.methodName +
+                  '<br>details:<br>' +
+                  JSON.stringify(instrumentResponse.details, undefined, 2);
+            })
+            .catch(function(err) {
+              ChromeSamples.setStatus(err.message);
+            });
+      }, 2000);
+    })
+    .catch(function(err) {
+      ChromeSamples.setStatus(err.message);
+    });
+  } catch (e) {
+    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+  }
+}
+
+var buyButton = document.getElementById('buyButton');
+if ('PaymentRequest' in window) {
+  buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+}
+
+function toDictionary(addr) {
+  var dict = {};
+  if (addr) {
+    dict.regionCode = addr.regionCode;
+    dict.administrativeArea = addr.administrativeArea;
+    dict.locality = addr.locality;
+    dict.dependentLocality = addr.dependentLocality;
+    dict.addressLine = addr.addressLine;
+    dict.postalCode = addr.postalCode;
+    dict.sortingCode = addr.sortingCode;
+    dict.languageCode = addr.languageCode;
+    dict.organization = addr.organization;
+    dict.recipient = addr.recipient;
+  }
+  return dict;
+}

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -45,8 +45,7 @@ function onBuyClicked() {
   var options = {requestShipping: true};
 
   try {
-    // eslint-disable-next-line no-undef
-    var request = new PaymentRequest(supportedInstruments, details, options);
+    var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
     request.show().then(function(instrumentResponse) {
       // Simulate server-side processing with a 2 second delay.
       window.setTimeout(function() {

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -15,29 +15,29 @@ function onBuyClicked() {
       {
         id: 'original',
         label: 'Original donation amount',
-        amount: {currencyCode: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'}
       },
       {
         id: 'discount',
         label: 'Friends and family discount',
-        amount: {currencyCode: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'}
       },
       {
         id: 'shipping',
         label: 'Free shipping worldwide',
-        amount: {currencyCode: 'USD', value: '0.00'}
+        amount: {currency: 'USD', value: '0.00'}
       },
       {
         id: 'total',
         label: 'Donation',
-        amount: {currencyCode: 'USD', value: '55.00'}
+        amount: {currency: 'USD', value: '55.00'}
       }
     ],
     shippingOptions: [
       {
         id: 'freeWorldwideShipping',
         label: 'Free shipping worldwide',
-        amount: {currencyCode: 'USD', value: '0.00'}
+        amount: {currency: 'USD', value: '0.00'}
       }
     ]
   };

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -69,16 +69,18 @@ function onBuyClicked() {
       ChromeSamples.setStatus(err.message);
     });
   } catch (e) {
-    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+    ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');
-  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now. ' +
+      'Enable chrome://flags/#enable-experimental-web-platform-features');
 }
 
 function toDictionary(addr) {

--- a/paymentrequest/free-shipping/index.html
+++ b/paymentrequest/free-shipping/index.html
@@ -1,0 +1,23 @@
+---
+feature_name: PaymentRequest Free Shipping
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts credit card payments and provides free shipping worldwide.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -76,16 +76,18 @@ function onBuyClicked() {
       ChromeSamples.setStatus(err.message);
     });
   } catch (e) {
-    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+    ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
   buyButton.addEventListener('click', onBuyClicked);
 } else {
   buyButton.setAttribute('style', 'display: none;');
-  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now. ' +
+      'Enable chrome://flags/#enable-experimental-web-platform-features');
 }
 
 function updateDetails(details, shippingOption, resolve, reject) {

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -15,29 +15,29 @@ function onBuyClicked() {
       {
         id: 'original',
         label: 'Original donation amount',
-        amount: {currencyCode: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'}
       },
       {
         id: 'discount',
         label: 'Friends and family discount',
-        amount: {currencyCode: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'}
       },
       {
         id: 'total',
         label: 'Donation',
-        amount: {currencyCode: 'USD', value: '55.00'}
+        amount: {currency: 'USD', value: '55.00'}
       }
     ],
     shippingOptions: [
       {
         id: 'standard',
         label: 'Standard shipping',
-        amount: {currencyCode: 'USD', value: '0.00'}
+        amount: {currency: 'USD', value: '0.00'}
       },
       {
         id: 'express',
         label: 'Express shipping',
-        amount: {currencyCode: 'USD', value: '12.00'}
+        amount: {currency: 'USD', value: '12.00'}
       }
     ]
   };

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -45,8 +45,7 @@ function onBuyClicked() {
   var options = {requestShipping: true};
 
   try {
-    // eslint-disable-next-line no-undef
-    var request = new PaymentRequest(supportedInstruments, details, options);
+    var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
 
     request.addEventListener('shippingoptionchange', function(evt) {
       evt.updateWith(new Promise(function(resolve, reject) {

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -1,0 +1,131 @@
+function onBuyClicked() {
+  var supportedInstruments = [
+    'visa',
+    'mastercard',
+    'amex',
+    'discover',
+    'maestro',
+    'diners',
+    'jcb',
+    'unionpay'
+  ];
+
+  var details = {
+    items: [
+      {
+        id: 'original',
+        label: 'Original donation amount',
+        amount: {currencyCode: 'USD', value: '65.00'}
+      },
+      {
+        id: 'discount',
+        label: 'Friends and family discount',
+        amount: {currencyCode: 'USD', value: '-10.00'}
+      },
+      {
+        id: 'total',
+        label: 'Donation',
+        amount: {currencyCode: 'USD', value: '55.00'}
+      }
+    ],
+    shippingOptions: [
+      {
+        id: 'standard',
+        label: 'Standard shipping',
+        amount: {currencyCode: 'USD', value: '0.00'}
+      },
+      {
+        id: 'express',
+        label: 'Express shipping',
+        amount: {currencyCode: 'USD', value: '12.00'}
+      }
+    ]
+  };
+
+  var options = {requestShipping: true};
+
+  try {
+    // eslint-disable-next-line no-undef
+    var request = new PaymentRequest(supportedInstruments, details, options);
+
+    request.addEventListener('shippingoptionchange', function(evt) {
+      evt.updateWith(new Promise(function(resolve, reject) {
+        updateDetails(details, request.shippingOption, resolve, reject);
+      }));
+    });
+
+    request.show().then(function(instrumentResponse) {
+      // Simulate server-side processing with a 2 second delay.
+      window.setTimeout(function() {
+        instrumentResponse.complete(true)
+            .then(function() {
+              document.getElementById('result').innerHTML =
+                  'shippingOption: ' + request.shippingOption +
+                  '<br>shippingAddress:<br>' +
+                  JSON.stringify(toDictionary(request.shippingAddress),
+                                 undefined, 2) +
+                  '<br>methodName: ' + instrumentResponse.methodName +
+                  '<br>details:<br>' +
+                  JSON.stringify(instrumentResponse.details, undefined, 2);
+            })
+            .catch(function(err) {
+              ChromeSamples.setStatus(err.message);
+            });
+      }, 2000);
+    })
+    .catch(function(err) {
+      ChromeSamples.setStatus(err.message);
+    });
+  } catch (e) {
+    ChromeSamples.status('Developer mistake: \'' + e.message + '\'');
+  }
+}
+
+var buyButton = document.getElementById('buyButton');
+if ('PaymentRequest' in window) {
+  buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('PaymentRequest is not supported on this platform.');
+}
+
+function updateDetails(details, shippingOption, resolve, reject) {
+  var selectedShippingOption;
+  if (shippingOption === 'standard') {
+    selectedShippingOption = details.shippingOptions[0];
+    details.items[details.items.length - 1].amount.value = '55.00';
+  } else if (shippingOption === 'express') {
+    selectedShippingOption = details.shippingOptions[1];
+    details.items[details.items.length - 1].amount.value = '67.00';
+  } else {
+    reject('Unknown shipping option \'' + shippingOption + '\'');
+    return;
+  }
+  if (details.items.length === 3) {
+    details.items.splice(-1, 0, selectedShippingOption);
+  } else if (details.items.length === 4) {
+    details.items.splice(-2, 1, selectedShippingOption);
+  } else {
+    reject('There should ever be only 3 or 4 line items. ' +
+           'Don\'t know how to handle ' + details.items.length.toString());
+    return;
+  }
+  resolve(details);
+}
+
+function toDictionary(addr) {
+  var dict = {};
+  if (addr) {
+    dict.regionCode = addr.regionCode;
+    dict.administrativeArea = addr.administrativeArea;
+    dict.locality = addr.locality;
+    dict.dependentLocality = addr.dependentLocality;
+    dict.addressLine = addr.addressLine;
+    dict.postalCode = addr.postalCode;
+    dict.sortingCode = addr.sortingCode;
+    dict.languageCode = addr.languageCode;
+    dict.organization = addr.organization;
+    dict.recipient = addr.recipient;
+  }
+  return dict;
+}

--- a/paymentrequest/shipping-options/index.html
+++ b/paymentrequest/shipping-options/index.html
@@ -1,0 +1,24 @@
+---
+feature_name: PaymentRequest Shipping Options
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts credit card payments and provides a couple of shipping
+  options regardless of shipping address.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}


### PR DESCRIPTION
PaymentRequest is implemented only on Android for now. This patch adds a check for Android operating system in the user agent identifier string. If the OS is not Android, the live demo is disabled with a corresponding message.

Also in this patch, the dictionary key `currencyCode` is changed to `currency` in order to match the latest spec.
