### PR TITLE
Add Device Information Advanced Sample

### DIFF
--- a/web-bluetooth/device-information-characteristics.html
+++ b/web-bluetooth/device-information-characteristics.html
@@ -1,0 +1,32 @@
+---
+feature_name: Web Bluetooth / Device Information Characteristics
+chrome_version: 50
+feature_id: 5264933985976320
+icon_url: icon.png
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to read <a
+target="_blank"
+href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.device_information.xml">Device
+Information Service</a> characteristics from a nearby Bluetooth Device.</p>
+
+<p>Note: The <a target="_blank" href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.serial_number_string.xml">Serial Number String</a> characteristic is <a target="_blank" href="https://github.com/WebBluetoothCG/registries/blob/7b46fd5d58ea98fa098372a774fd7b981f0bdb0d/gatt_blacklist.txt#L34-L36">blacklisted</a> and forbidden from being accessed.</p>
+
+<button>Get Bluetooth Device Information Characteristics</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='device-information-characteristics.js' %}
+
+<script>
+  document.querySelector('button').addEventListener('click', function() {
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/device-information-characteristics.js
+++ b/web-bluetooth/device-information-characteristics.js
@@ -1,0 +1,98 @@
+function onButtonClick() {
+  log('Requesting Bluetooth Device...');
+  navigator.bluetooth.requestDevice(
+    {filters: anyDevice(), optionalServices: ['device_information']})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Device Information Service...');
+    return server.getPrimaryService('device_information');
+  })
+  .then(service => {
+    log('Getting Device Information Characteristics...');
+    return service.getCharacteristics();
+  })
+  .then(characteristics => {
+    let queue = Promise.resolve();
+    let decoder = new TextDecoder('utf-8');
+    characteristics.forEach(characteristic => {
+      switch (characteristic.uuid) {
+
+        case BluetoothUUID.getCharacteristic('manufacturer_name_string'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> Manufacturer Name String: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('model_number_string'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> Model Number String: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('hardware_revision_string'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> Hardware Revision String: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('firmware_revision_string'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> Firmware Revision String: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('software_revision_string'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> Software Revision String: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('system_id'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> System ID: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('ieee_11073-20601_regulatory_certification_data_list'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> IEEE 11073-20601 Regulatory Certification Data List: ' +
+                decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getCharacteristic('pnp_id'):
+          queue = queue.then(_ => characteristic.readValue()).then(value => {
+            log('> PnP ID:');
+            log('  > Vendor ID Source: ' +
+                (value.getUint8(0) === 1 ? 'Bluetooth' : 'USB'));
+            log('  > Vendor ID: ' +
+                (value.getUint8(1) | value.getUint8(2) << 8));
+            log('  > Product ID: ' +
+                (value.getUint8(3) | value.getUint8(4) << 8));
+            log('  > Product Version: ' +
+                (value.getUint8(5) | value.getUint8(6) << 8));
+          });
+          break;
+
+        default: log('> Unknown Characteristic: ' + characteristic.uuid);
+      }
+    });
+    return queue;
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+/* Utils */
+
+function anyDevice() {
+  // This is the closest we can get for now to get all devices.
+  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
+  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      .map(c => ({namePrefix: c}))
+      .concat({name: ''});
+}

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -20,3 +20,4 @@ icon_url: icon.png
 <h3>Advanced</h3>
 
 <p><a href="gap-characteristics.html">GAP Characteristics</a> - get all GAP characteristics of a BLE Device.</p>
+<p><a href="device-information-characteristics.html">Device Information Characteristics</a> - get all Device Information characteristics of a BLE Device.</p>


### PR DESCRIPTION
In the same vein as the GAP Characteristics advanced sample, this one is about the generic Device Information Service which I've found being used in several BLE devices.
This sample features: 
- queuing promises
- get unsigned 16-bit integer
- a blacklisted characteristic
- trick to get all devices

R=@scheib @g-ortuno @jyasskin @jeffposnick 

![1](https://cloud.githubusercontent.com/assets/634478/15645090/d72e3524-2656-11e6-8f74-dad791a191d1.png)
