### PR TITLE
bluetooth: Clean parseInt

### DIFF
--- a/web-bluetooth/characteristic-properties.js
+++ b/web-bluetooth/characteristic-properties.js
@@ -1,12 +1,12 @@
 function onButtonClick() {
   let serviceUuid = document.querySelector('#service').value;
   if (serviceUuid.startsWith('0x')) {
-    serviceUuid = parseInt(serviceUuid, 16);
+    serviceUuid = parseInt(serviceUuid);
   }
 
   let characteristicUuid = document.querySelector('#characteristic').value;
   if (characteristicUuid.startsWith('0x')) {
-    characteristicUuid = parseInt(characteristicUuid, 16);
+    characteristicUuid = parseInt(characteristicUuid);
   }
 
   log('Requesting Bluetooth Device...');

--- a/web-bluetooth/device-disconnect.js
+++ b/web-bluetooth/device-disconnect.js
@@ -21,7 +21,7 @@ function onScanButtonClick() {
 
   let filterService = document.querySelector('#service').value;
   if (filterService.startsWith('0x')) {
-    filterService = parseInt(filterService, 16);
+    filterService = parseInt(filterService);
   }
   if (filterService) {
     options.filters.push({services: [filterService]});

--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -3,7 +3,7 @@ function onButtonClick() {
 
   let filterService = document.querySelector('#service').value;
   if (filterService.startsWith('0x')) {
-    filterService = parseInt(filterService, 16);
+    filterService = parseInt(filterService);
   }
   if (filterService) {
     filters.push({services: [filterService]});

--- a/web-bluetooth/get-characteristics.js
+++ b/web-bluetooth/get-characteristics.js
@@ -1,12 +1,12 @@
 function onButtonClick() {
   let serviceUuid = document.querySelector('#service').value;
   if (serviceUuid.startsWith('0x')) {
-    serviceUuid = parseInt(serviceUuid, 16);
+    serviceUuid = parseInt(serviceUuid);
   }
 
   let characteristicUuid = document.querySelector('#characteristic').value;
   if (characteristicUuid.startsWith('0x')) {
-    characteristicUuid = parseInt(characteristicUuid, 16);
+    characteristicUuid = parseInt(characteristicUuid);
   }
 
   log('Requesting Bluetooth Device...');

--- a/web-bluetooth/notifications.js
+++ b/web-bluetooth/notifications.js
@@ -3,12 +3,12 @@ var myCharacteristic;
 function onStartButtonClick() {
   let serviceUuid = document.querySelector('#service').value;
   if (serviceUuid.startsWith('0x')) {
-    serviceUuid = parseInt(serviceUuid, 16);
+    serviceUuid = parseInt(serviceUuid);
   }
 
   let characteristicUuid = document.querySelector('#characteristic').value;
   if (characteristicUuid.startsWith('0x')) {
-    characteristicUuid = parseInt(characteristicUuid, 16);
+    characteristicUuid = parseInt(characteristicUuid);
   }
 
   log('Requesting Bluetooth Device...');


### PR DESCRIPTION
Since I only call `parseInt` when it starts with `0x`, I can omit radix as it's implied.

TBR=@jeffposnick
