### PR TITLE
bluetooth: Add Link Loss Sample

### DIFF
--- a/web-bluetooth/_includes/value-to-device-type.html
+++ b/web-bluetooth/_includes/value-to-device-type.html
@@ -1,5 +1,5 @@
 <script>
-var valueToDeviceType = {
+const valueToDeviceType = {
      0: 'Unknown',
     64: 'Generic Phone',
    128: 'Generic Computer',

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -21,3 +21,4 @@ icon_url: icon.png
 
 <p><a href="gap-characteristics.html">GAP Characteristics</a> - get all GAP characteristics of a BLE Device.</p>
 <p><a href="device-information-characteristics.html">Device Information Characteristics</a> - get all Device Information characteristics of a BLE Device.</p>
+<p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device.</p>

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -21,4 +21,4 @@ icon_url: icon.png
 
 <p><a href="gap-characteristics.html">GAP Characteristics</a> - get all GAP characteristics of a BLE Device.</p>
 <p><a href="device-information-characteristics.html">Device Information Characteristics</a> - get all Device Information characteristics of a BLE Device.</p>
-<p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device.</p>
+<p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device (readValue & writeValue).</p>

--- a/web-bluetooth/link-loss.html
+++ b/web-bluetooth/link-loss.html
@@ -7,7 +7,7 @@ icon_url: icon.png
 
 {% include_relative _includes/intro.html %}
 
-<p>This sample illustrates the use of the Web Bluetooth API to set the standardized <a
+<p>This sample illustrates the use of the Web Bluetooth API to read and write the standardized <a
 target="_blank"
 href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.alert_level.xml">Alert Level</a> characteristic from a nearby Bluetooth
 Device used to expose the current link loss alert level that determines how the
@@ -20,6 +20,7 @@ Play Store</a> and advertise the pre-configured Link Loss service.</p>
 
 <p>
   <select id="alertLevelValue">
+    <option selected disabled hidden>Choose...</option>
     <option value="0x00">0x00 (No Alert)</option>
     <option value="0x01">0x01 (Mild Alert)</option>
     <option value="0x02">0x02 (High Alert)</option>

--- a/web-bluetooth/link-loss.html
+++ b/web-bluetooth/link-loss.html
@@ -11,14 +11,17 @@ icon_url: icon.png
 target="_blank"
 href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.alert_level.xml">Alert Level</a> characteristic from a nearby Bluetooth
 Device used to expose the current link loss alert level that determines how the
-device alerts when the link is lost.</p>
+device alerts when the link is lost. You may want to try this demo with the nRF
+Master Control App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp">Google
+Play Store</a> and advertise the pre-configured Link Loss service.</p>
 
 <button id="readButton">Get Bluetooth Device Alert Level</button>
 
 <p>
   <select id="alertLevelValue">
     <option value="0x00">0x00 (No Alert)</option>
-    <option value="0x01">0x01 (Mid Alert)</option>
+    <option value="0x01">0x01 (Mild Alert)</option>
     <option value="0x02">0x02 (High Alert)</option>
   </select>
   <button id="writeButton" disabled>Set Alert Level</button>

--- a/web-bluetooth/link-loss.html
+++ b/web-bluetooth/link-loss.html
@@ -1,0 +1,43 @@
+---
+feature_name: Web Bluetooth / Link Loss
+chrome_version: 50
+feature_id: 5264933985976320
+icon_url: icon.png
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to set the standardized <a
+target="_blank"
+href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.alert_level.xml">Alert Level</a> characteristic from a nearby Bluetooth
+Device used to expose the current link loss alert level that determines how the
+device alerts when the link is lost.</p>
+
+<button id="readButton">Get Bluetooth Device Alert Level</button>
+
+<p>
+  <select id="alertLevelValue">
+    <option value="0x00">0x00 (No Alert)</option>
+    <option value="0x01">0x01 (Mid Alert)</option>
+    <option value="0x02">0x02 (High Alert)</option>
+  </select>
+  <button id="writeButton" disabled>Set Alert Level</button>
+</p>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='link-loss.js' %}
+
+<script>
+  document.querySelector('#readButton').addEventListener('click', function() {
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onReadButtonClick();
+    }
+  });
+  document.querySelector('#writeButton').addEventListener('click', function() {
+    onWriteButtonClick();
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/link-loss.js
+++ b/web-bluetooth/link-loss.js
@@ -23,7 +23,7 @@ function onReadButtonClick() {
     return characteristic.readValue();
   })
   .then(value => {
-    log('> Alert Level changed to: ' + getAlertLevel(value));
+    log('> Alert Level: ' + getAlertLevel(value));
   })
   .catch(error => {
     document.querySelector('#writeButton').disabled = true;
@@ -39,7 +39,7 @@ function onWriteButtonClick() {
   let value = [document.querySelector('#alertLevelValue').value];
   alertLevelCharacteristic.writeValue(new Uint8Array([value]))
   .then(_ => {
-    log('> Alert Level: ' +
+    log('> Alert Level changed to: ' +
         getAlertLevel(alertLevelCharacteristic.value));
   })
   .catch(error => {

--- a/web-bluetooth/link-loss.js
+++ b/web-bluetooth/link-loss.js
@@ -23,7 +23,7 @@ function onReadButtonClick() {
     return characteristic.readValue();
   })
   .then(value => {
-    log('> Alert Level: ' + getAlertLevel(value));
+    log('> Alert Level changed to: ' + getAlertLevel(value));
   })
   .catch(error => {
     document.querySelector('#writeButton').disabled = true;
@@ -51,13 +51,14 @@ function onWriteButtonClick() {
 
 const valueToAlertLevel = {
     0x00: 'No Alert',
-    0x01: 'Mid Alert',
+    0x01: 'Mild Alert',
     0x02: 'High Alert',
 };
 
 function getAlertLevel(value) {
   let v = value.getUint8(0);
-  return v + (v in valueToAlertLevel ? ' (' + valueToAlertLevel[v] + ')' : '');
+  return v + (v in valueToAlertLevel ?
+      ' (' + valueToAlertLevel[v] + ')' : 'Unknown');
 }
 
 function anyDevice() {

--- a/web-bluetooth/link-loss.js
+++ b/web-bluetooth/link-loss.js
@@ -2,8 +2,7 @@ var alertLevelCharacteristic;
 
 function onReadButtonClick() {
   log('Requesting Bluetooth Device...');
-  navigator.bluetooth.requestDevice(
-    {filters: anyDevice(), optionalServices: ['link_loss']})
+  navigator.bluetooth.requestDevice({filters: [{services: ['link_loss']}]})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();
@@ -36,7 +35,7 @@ function onWriteButtonClick() {
     return;
   }
   log('Setting Alert Level...');
-  let value = [document.querySelector('#alertLevelValue').value];
+  let value = document.querySelector('#alertLevelValue').value;
   alertLevelCharacteristic.writeValue(new Uint8Array([value]))
   .then(_ => {
     log('> Alert Level changed to: ' +
@@ -50,21 +49,13 @@ function onWriteButtonClick() {
 /* Utils */
 
 const valueToAlertLevel = {
-    0x00: 'No Alert',
-    0x01: 'Mild Alert',
-    0x02: 'High Alert',
+  0x00: 'No Alert',
+  0x01: 'Mild Alert',
+  0x02: 'High Alert'
 };
 
 function getAlertLevel(value) {
   let v = value.getUint8(0);
   return v + (v in valueToAlertLevel ?
       ' (' + valueToAlertLevel[v] + ')' : 'Unknown');
-}
-
-function anyDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/link-loss.js
+++ b/web-bluetooth/link-loss.js
@@ -1,0 +1,69 @@
+var alertLevelCharacteristic;
+
+function onReadButtonClick() {
+  log('Requesting Bluetooth Device...');
+  navigator.bluetooth.requestDevice(
+    {filters: anyDevice(), optionalServices: ['link_loss']})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Link Loss Service...');
+    return server.getPrimaryService('link_loss');
+  })
+  .then(service => {
+    log('Getting Alert Level Characteristic...');
+    return service.getCharacteristic('alert_level');
+  })
+  .then(characteristic => {
+    alertLevelCharacteristic = characteristic;
+    document.querySelector('#writeButton').disabled = false;
+    log('Reading Alert Level...');
+    return characteristic.readValue();
+  })
+  .then(value => {
+    log('> Alert Level: ' + getAlertLevel(value));
+  })
+  .catch(error => {
+    document.querySelector('#writeButton').disabled = true;
+    log('Argh! ' + error);
+  });
+}
+
+function onWriteButtonClick() {
+  if (!alertLevelCharacteristic) {
+    return;
+  }
+  log('Setting Alert Level...');
+  let value = [document.querySelector('#alertLevelValue').value];
+  alertLevelCharacteristic.writeValue(new Uint8Array([value]))
+  .then(_ => {
+    log('> Alert Level: ' +
+        getAlertLevel(alertLevelCharacteristic.value));
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+/* Utils */
+
+const valueToAlertLevel = {
+    0x00: 'No Alert',
+    0x01: 'Mid Alert',
+    0x02: 'High Alert',
+};
+
+function getAlertLevel(value) {
+  let v = value.getUint8(0);
+  return v + (v in valueToAlertLevel ? ' (' + valueToAlertLevel[v] + ')' : '');
+}
+
+function anyDevice() {
+  // This is the closest we can get for now to get all devices.
+  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
+  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      .map(c => ({namePrefix: c}))
+      .concat({name: ''});
+}


### PR DESCRIPTION
This sample illustrates the use of the Web Bluetooth API to set the standardized `Alert Level` characteristic from a nearby Bluetooth Device used to expose the current link loss alert level that determines how the device alerts when the link is lost.

Featured: 
- read & write on the same `characteristic`
- `characteristic.value` updated after `characteristic.write` 
- ~~trick to get all devices~~

R=@scheib @jyasskin @g-ortuno @jeffposnick 

![screenshot 2016-06-03 at 12 07 35 pm](https://cloud.githubusercontent.com/assets/634478/15775726/d643ace0-2983-11e6-9434-ac07f69fef52.png)
