### PR TITLE
Remove runtime HTTPS redirection

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,21 +22,6 @@ limitations under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ page.feature_name }} Sample{% endif %}</title>
     <script>
-      // If we're running on a real web server (as opposed to localhost, which is whitelisted),
-      // then change the protocol to HTTPS.
-      // See https://goo.gl/lq4gCo for an explanation as to why this is needed for some features.
-      (function() {
-        var isLocalhost = !!(window.location.hostname === 'localhost' ||
-          // [::1] is the IPv6 localhost address.
-          window.location.hostname === '[::1]' ||
-          // 127.0.0.1/8 is considered localhost for IPv4.
-          window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/));
-        if (window.location.protocol === 'http:' && !isLocalhost) {
-          // Redirect to https: if we're currently using http: and we're not on localhost.
-          window.location.protocol = 'https:';
-        }
-      })();
-
       // Add a global error event listener early on in the page load, to help ensure that browsers
       // which don't support specific functionality still end up displaying a meaningful message.
       window.addEventListener('error', function(error) {


### PR DESCRIPTION
R: @addyosmani @gauntface @beaufortfrancois etc.

As per https://github.com/blog/2186-https-for-github-pages we can enforce HTTPS for `gh-pages` on the repo-level (which I've turned on already).
