### PR TITLE
Update PaymentRequest API for Chrome Dev 53.0.2763.0

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -2,21 +2,15 @@ function onBuyClicked() {
   var supportedInstruments = ['https://android.com/pay'];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -57,11 +51,16 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) {
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -11,21 +11,15 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -57,11 +51,16 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) {
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -11,21 +11,15 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -49,8 +43,9 @@ function onBuyClicked() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
                   '<br>shippingAddress:<br>' +
-                  JSON.stringify(toDictionary(request.shippingAddress),
-                                 undefined, 2) +
+                  JSON.stringify(
+                      toDictionary(instrumentResponse.shippingAddress),
+                      undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
                   '<br>details:<br>' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
@@ -69,41 +64,39 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) {
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }
 
 function updateDetails(details, shippingAddress, resolve, reject) {
-  if (shippingAddress.regionCode === 'US') {
+  if (shippingAddress.country === 'US') {
     var shippingOption = {
       id: '',
       label: '',
-      amount: {currency: 'USD', value: '0.00'}
+      amount: {currency: 'USD', value: '0.00'},
+      selected: true
     };
-    if (shippingAddress.administrativeArea === 'CA') {
+    if (shippingAddress.region === 'CA') {
       shippingOption.id = 'ca';
       shippingOption.label = 'Free shipping in California';
-      details.items[details.items.length - 1].amount.value = '55.00';
+      details.total.amount.value = '55.00';
     } else {
       shippingOption.id = 'us';
       shippingOption.label = 'Standard shipping in US';
       shippingOption.amount.value = '5.00';
-      details.items[details.items.length - 1].amount.value = '60.00';
+      details.total.amount.value = '60.00';
     }
-    if (details.items.length === 3) {
-      details.items.splice(-1, 0, shippingOption);
-    } else if (details.items.length === 4) {
-      details.items.splice(-2, 1, shippingOption);
-    } else {
-      reject('There should ever be only 3 or 4 line items. ' +
-             'Don\'t know how to handle ' + details.items.length.toString());
-      return;
-    }
+    details.displayItems.splice(2, 1, shippingOption);
     details.shippingOptions = [shippingOption];
   } else {
     delete details.shippingOptions;
@@ -114,9 +107,9 @@ function updateDetails(details, shippingAddress, resolve, reject) {
 function toDictionary(addr) {
   var dict = {};
   if (addr) {
-    dict.regionCode = addr.regionCode;
-    dict.administrativeArea = addr.administrativeArea;
-    dict.locality = addr.locality;
+    dict.country = addr.country;
+    dict.region = addr.region;
+    dict.city = addr.city;
     dict.dependentLocality = addr.dependentLocality;
     dict.addressLine = addr.addressLine;
     dict.postalCode = addr.postalCode;
@@ -124,6 +117,8 @@ function toDictionary(addr) {
     dict.languageCode = addr.languageCode;
     dict.organization = addr.organization;
     dict.recipient = addr.recipient;
+    dict.careOf = addr.careOf;
+    dict.phone = addr.phone;
   }
   return dict;
 }

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -11,35 +11,27 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
       },
       {
-        id: 'shipping',
         label: 'Free shipping worldwide',
         amount: {currency: 'USD', value: '0.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ],
-    shippingOptions: [
-      {
-        id: 'freeWorldwideShipping',
-        label: 'Free shipping worldwide',
-        amount: {currency: 'USD', value: '0.00'}
-      }
-    ]
+    shippingOptions: [{
+      id: 'freeWorldwideShipping',
+      label: 'Free shipping worldwide',
+      amount: {currency: 'USD', value: '0.00'},
+      selected: true
+    }]
   };
 
   var options = {requestShipping: true};
@@ -54,8 +46,9 @@ function onBuyClicked() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
                   '<br>shippingAddress:<br>' +
-                  JSON.stringify(toDictionary(request.shippingAddress),
-                                 undefined, 2) +
+                  JSON.stringify(
+                      toDictionary(instrumentResponse.shippingAddress),
+                      undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
                   '<br>details:<br>' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
@@ -74,21 +67,25 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) {
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }
 
 function toDictionary(addr) {
   var dict = {};
   if (addr) {
-    dict.regionCode = addr.regionCode;
-    dict.administrativeArea = addr.administrativeArea;
-    dict.locality = addr.locality;
+    dict.country = addr.country;
+    dict.region = addr.region;
+    dict.city = addr.city;
     dict.dependentLocality = addr.dependentLocality;
     dict.addressLine = addr.addressLine;
     dict.postalCode = addr.postalCode;
@@ -96,6 +93,8 @@ function toDictionary(addr) {
     dict.languageCode = addr.languageCode;
     dict.organization = addr.organization;
     dict.recipient = addr.recipient;
+    dict.careOf = addr.careOf;
+    dict.phone = addr.phone;
   }
   return dict;
 }


### PR DESCRIPTION
The 'items' field has been split into 'total' and 'displayItems'. Both
of these fields no longer require 'id'.

The 'shippingOptions' field now lets developers explicitly control which
shipping option is currently selected via the 'selected' boolean field.
'shippingOptions' still requires 'id', so the browser can tell the
website which shipping option the user ended up selecting.

The 'shippingAddress' is now also returned inside of the
'instrumentResponse'. Some of its fields have been renamed to be more
developer friendly and new fields have been added.
- 'region' -> 'country'
- 'administrativeArea' -> 'region'
- 'locality' -> 'city'
- New field 'careOf'
- New field 'phone'

This patch also includes an update to feature detection with more
detailed status message and a note that these tests are for Chrome 53.
Chrome 52 has an older version of PaymentRequest, but there's no sense
in keeping multiple version of examples here.
