### PR TITLE
Update PaymentRequest API for Chrome Dev 53.0.2763.0

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -2,21 +2,15 @@ function onBuyClicked() {
   var supportedInstruments = ['https://android.com/pay'];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -57,11 +51,16 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) { // eslint-disable-line no-negated-condition
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -1,5 +1,15 @@
 function onBuyClicked() {
-  var supportedInstruments = ['https://android.com/pay'];
+  var supportedInstruments = [
+    {
+      supportedMethods: ['https://android.com/pay'],
+      data: {
+        'gateway': 'stripe',
+        // Place your own Stripe publishable key here.
+        'stripe:publishableKey': 'pk_test_VKUbaXb3LHE7GdxyOBMNwXqa',
+        'stripe:version': '2016-03-07'
+      }
+    }
+  ];
 
   var details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
@@ -15,17 +25,8 @@ function onBuyClicked() {
     ]
   };
 
-  var schemeData = {
-    'https://android.com/pay': {
-      'gateway': 'stripe',
-       // Place your own Stripe publishable key here.
-      'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
-      'stripe:version': '2016-03-07'
-    }
-  };
-
   try {
-    new PaymentRequest(supportedInstruments, details, null, schemeData) // eslint-disable-line no-undef
+    new PaymentRequest(supportedInstruments, details) // eslint-disable-line no-undef
         .show()
         .then(function(instrumentResponse) {
           // Simulate server-side processing with a 2 second delay.
@@ -34,7 +35,10 @@ function onBuyClicked() {
                 .then(function() {
                   document.getElementById('result').innerHTML =
                       'methodName: ' + instrumentResponse.methodName +
-                      '<br>details:<br>' +
+                      '<br>totalAmount: ' +
+                      JSON.stringify(
+                          instrumentResponse.totalAmount, undefined, 2) +
+                      '<br>details: ' +
                       JSON.stringify(instrumentResponse.details, undefined, 2);
                 })
                 .catch(function(err) {

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -11,21 +11,15 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ]
   };
@@ -57,11 +51,16 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) { // eslint-disable-line no-negated-condition
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -1,14 +1,10 @@
 function onBuyClicked() {
-  var supportedInstruments = [
-    'visa',
-    'mastercard',
-    'amex',
-    'discover',
-    'maestro',
-    'diners',
-    'jcb',
-    'unionpay'
-  ];
+  var supportedInstruments = [{
+    supportedMethods: [
+      'amex', 'diners', 'discover', 'jcb', 'maestro', 'mastercard', 'unionpay',
+      'visa'
+    ]
+  }];
 
   var details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
@@ -34,7 +30,10 @@ function onBuyClicked() {
                 .then(function() {
                   document.getElementById('result').innerHTML =
                       'methodName: ' + instrumentResponse.methodName +
-                      '<br>details:<br>' +
+                      '<br>totalAmount: ' +
+                      JSON.stringify(
+                          instrumentResponse.totalAmount, undefined, 2) +
+                      '<br>details: ' +
                       JSON.stringify(instrumentResponse.details, undefined, 2);
                 })
                 .catch(function(err) {

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -1,14 +1,10 @@
 function onBuyClicked() {
-  var supportedInstruments = [
-    'visa',
-    'mastercard',
-    'amex',
-    'discover',
-    'maestro',
-    'diners',
-    'jcb',
-    'unionpay'
-  ];
+  var supportedInstruments = [{
+    supportedMethods: [
+      'amex', 'diners', 'discover', 'jcb', 'maestro', 'mastercard', 'unionpay',
+      'visa'
+    ]
+  }];
 
   var details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
@@ -42,12 +38,14 @@ function onBuyClicked() {
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
-                  '<br>shippingAddress:<br>' +
+                  '<br>shippingAddress: ' +
                   JSON.stringify(
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>details:<br>' +
+                  '<br>totalAmount: ' +
+                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
+                  '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })
             .catch(function(err) {

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -1,14 +1,10 @@
 function onBuyClicked() {
-  var supportedInstruments = [
-    'visa',
-    'mastercard',
-    'amex',
-    'discover',
-    'maestro',
-    'diners',
-    'jcb',
-    'unionpay'
-  ];
+  var supportedInstruments = [{
+    supportedMethods: [
+      'amex', 'diners', 'discover', 'jcb', 'maestro', 'mastercard', 'unionpay',
+      'visa'
+    ]
+  }];
 
   var details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
@@ -45,12 +41,14 @@ function onBuyClicked() {
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
-                  '<br>shippingAddress:<br>' +
+                  '<br>shippingAddress: ' +
                   JSON.stringify(
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>details:<br>' +
+                  '<br>totalAmount: ' +
+                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
+                  '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })
             .catch(function(err) {

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -11,35 +11,27 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
       },
       {
-        id: 'shipping',
         label: 'Free shipping worldwide',
         amount: {currency: 'USD', value: '0.00'}
-      },
-      {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
       }
     ],
-    shippingOptions: [
-      {
-        id: 'freeWorldwideShipping',
-        label: 'Free shipping worldwide',
-        amount: {currency: 'USD', value: '0.00'}
-      }
-    ]
+    shippingOptions: [{
+      id: 'freeWorldwideShipping',
+      label: 'Free shipping worldwide',
+      amount: {currency: 'USD', value: '0.00'},
+      selected: true
+    }]
   };
 
   var options = {requestShipping: true};
@@ -54,8 +46,9 @@ function onBuyClicked() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
                   '<br>shippingAddress:<br>' +
-                  JSON.stringify(toDictionary(request.shippingAddress),
-                                 undefined, 2) +
+                  JSON.stringify(
+                      toDictionary(instrumentResponse.shippingAddress),
+                      undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
                   '<br>details:<br>' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
@@ -74,21 +67,25 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) { // eslint-disable-line no-negated-condition
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }
 
 function toDictionary(addr) {
   var dict = {};
   if (addr) {
-    dict.regionCode = addr.regionCode;
-    dict.administrativeArea = addr.administrativeArea;
-    dict.locality = addr.locality;
+    dict.country = addr.country;
+    dict.region = addr.region;
+    dict.city = addr.city;
     dict.dependentLocality = addr.dependentLocality;
     dict.addressLine = addr.addressLine;
     dict.postalCode = addr.postalCode;
@@ -96,6 +93,8 @@ function toDictionary(addr) {
     dict.languageCode = addr.languageCode;
     dict.organization = addr.organization;
     dict.recipient = addr.recipient;
+    dict.careOf = addr.careOf;
+    dict.phone = addr.phone;
   }
   return dict;
 }

--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -1,0 +1,30 @@
+---
+feature_name: PaymentRequest
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<ul>
+  <li><a href="credit-cards/">Credit cards</a> - a sample that accepts credit
+    card payments and does not request shipping information.</li>
+
+  <li><a href="android-pay/">Android Pay</a> - a sample that accepts Android Pay
+    payments and does not request shipping information.</li>
+
+  <li><a href="free-shipping/">Free shipping</a> - a sample that accepts credit
+    card payments and provides free shipping worldwide.</li>
+
+  <li><a href="shipping-options/">Shipping options</a> - a sample that accepts
+    credit card payments and provides a couple of shipping options regardless of
+    shipping address.</li>
+
+  <li><a href="dynamic-shipping/">Dynamic shipping</a> - a sample that accepts
+    credit card payments and varies the availability and price of shipping
+    options depending on the shipping address.</li>
+</ul>

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -1,14 +1,10 @@
 function onBuyClicked() {
-  var supportedInstruments = [
-    'visa',
-    'mastercard',
-    'amex',
-    'discover',
-    'maestro',
-    'diners',
-    'jcb',
-    'unionpay'
-  ];
+  var supportedInstruments = [{
+    supportedMethods: [
+      'amex', 'diners', 'discover', 'jcb', 'maestro', 'mastercard', 'unionpay',
+      'visa'
+    ]
+  }];
 
   var details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
@@ -59,12 +55,14 @@ function onBuyClicked() {
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
-                  '<br>shippingAddress:<br>' +
+                  '<br>shippingAddress: ' +
                   JSON.stringify(
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>details:<br>' +
+                  '<br>totalAmount: ' +
+                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
+                  '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })
             .catch(function(err) {

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -11,28 +11,27 @@ function onBuyClicked() {
   ];
 
   var details = {
-    items: [
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
       {
-        id: 'original',
         label: 'Original donation amount',
         amount: {currency: 'USD', value: '65.00'}
       },
       {
-        id: 'discount',
         label: 'Friends and family discount',
         amount: {currency: 'USD', value: '-10.00'}
       },
       {
-        id: 'total',
-        label: 'Donation',
-        amount: {currency: 'USD', value: '55.00'}
+        label: 'Standard shipping',
+        amount: {currency: 'USD', value: '0.00'}
       }
     ],
     shippingOptions: [
       {
         id: 'standard',
         label: 'Standard shipping',
-        amount: {currency: 'USD', value: '0.00'}
+        amount: {currency: 'USD', value: '0.00'},
+        selected: true
       },
       {
         id: 'express',
@@ -61,8 +60,9 @@ function onBuyClicked() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
                   '<br>shippingAddress:<br>' +
-                  JSON.stringify(toDictionary(request.shippingAddress),
-                                 undefined, 2) +
+                  JSON.stringify(
+                      toDictionary(instrumentResponse.shippingAddress),
+                      undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
                   '<br>details:<br>' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
@@ -81,45 +81,47 @@ function onBuyClicked() {
 }
 
 var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window && navigator.userAgent.match(/Android/i)) {
-  buyButton.addEventListener('click', onBuyClicked);
-} else {
-  buyButton.setAttribute('style', 'display: none;');
+buyButton.setAttribute('style', 'display: none;');
+if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now. ' +
       'Enable chrome://flags/#enable-experimental-web-platform-features');
+} else if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus(
+      'PaymentRequest is supported only on Android for now.');
+} else if (!navigator.userAgent.match(/Chrome\/53/i)) { // eslint-disable-line no-negated-condition
+  ChromeSamples.setStatus('These tests are for Chrome Dev 53.');
+} else {
+  buyButton.setAttribute('style', 'display: inline;');
+  buyButton.addEventListener('click', onBuyClicked);
 }
 
 function updateDetails(details, shippingOption, resolve, reject) {
   var selectedShippingOption;
+  var otherShippingOption;
   if (shippingOption === 'standard') {
     selectedShippingOption = details.shippingOptions[0];
-    details.items[details.items.length - 1].amount.value = '55.00';
+    otherShippingOption = details.shippingOptions[1];
+    details.total.amount.value = '55.00';
   } else if (shippingOption === 'express') {
     selectedShippingOption = details.shippingOptions[1];
-    details.items[details.items.length - 1].amount.value = '67.00';
+    otherShippingOption = details.shippingOptions[0];
+    details.total.amount.value = '67.00';
   } else {
     reject('Unknown shipping option \'' + shippingOption + '\'');
     return;
   }
-  if (details.items.length === 3) {
-    details.items.splice(-1, 0, selectedShippingOption);
-  } else if (details.items.length === 4) {
-    details.items.splice(-2, 1, selectedShippingOption);
-  } else {
-    reject('There should ever be only 3 or 4 line items. ' +
-           'Don\'t know how to handle ' + details.items.length.toString());
-    return;
-  }
+  selectedShippingOption.selected = true;
+  otherShippingOption.selected = false;
+  details.displayItems.splice(2, 1, selectedShippingOption);
   resolve(details);
 }
 
 function toDictionary(addr) {
   var dict = {};
   if (addr) {
-    dict.regionCode = addr.regionCode;
-    dict.administrativeArea = addr.administrativeArea;
-    dict.locality = addr.locality;
+    dict.country = addr.country;
+    dict.region = addr.region;
+    dict.city = addr.city;
     dict.dependentLocality = addr.dependentLocality;
     dict.addressLine = addr.addressLine;
     dict.postalCode = addr.postalCode;
@@ -127,6 +129,8 @@ function toDictionary(addr) {
     dict.languageCode = addr.languageCode;
     dict.organization = addr.organization;
     dict.recipient = addr.recipient;
+    dict.careOf = addr.careOf;
+    dict.phone = addr.phone;
   }
   return dict;
 }


### PR DESCRIPTION
The 'items' field has been split into 'total' and 'displayItems'. Both
of these fields no longer require 'id'.

The 'shippingOptions' field now lets developers explicitly control which
shipping option is currently selected via the 'selected' boolean field.
'shippingOptions' still requires 'id', so the browser can tell the
website which shipping option the user ended up selecting.

The 'shippingAddress' is now also returned inside of the
'instrumentResponse'. Some of its fields have been renamed to be more
developer friendly and new fields have been added.
- 'region' -> 'country'
- 'administrativeArea' -> 'region'
- 'locality' -> 'city'
- New field 'careOf'
- New field 'phone'

This patch also includes an update to feature detection with more
detailed status message and a note that these tests are for Chrome 53.
Chrome 52 has an older version of PaymentRequest, but there's no sense
in keeping multiple version of examples here.
