### PR TITLE
bluetooth: Add automatic reconnect sample

### DIFF
--- a/web-bluetooth/automatic-reconnect.html
+++ b/web-bluetooth/automatic-reconnect.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Automatic Reconnect
+chrome_version: 50
+feature_id: 5264933985976320
+icon_url: icon.png
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to reconnect to a
+disconnected Bluetooth device using a simple <a
+href="https://en.wikipedia.org/wiki/Exponential_backoff">exponential backoff
+algorithm</a></p>
+
+<form>
+  <button>Scan</button>
+</form>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='automatic-reconnect.js' %}
+
+<script>
+  document.querySelector('button').addEventListener('click', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/automatic-reconnect.js
+++ b/web-bluetooth/automatic-reconnect.js
@@ -1,0 +1,64 @@
+var bluetoothDevice;
+
+function onButtonClick() {
+  bluetoothDevice = null;
+  log('Requesting any Bluetooth Device...');
+  navigator.bluetooth.requestDevice({filters: anyDevice()})
+  .then(device => {
+    bluetoothDevice = device;
+    bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
+    connect();
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function connect() {
+  exponentialBackoff(3 /* max retries */, 2 /* seconds delay */,
+    function toTry() {
+      time('Connecting to Bluetooth Device... ');
+      return bluetoothDevice.gatt.connect();
+    },
+    function success() {
+      log('> Bluetooth Device connected. Try disconnect it now.');
+    },
+    function fail() {
+      time('Failed to reconnect.');
+    });
+}
+
+function onDisconnected() {
+  log('> Bluetooth Device disconnected');
+  connect();
+}
+
+/* Utils */
+
+// This function keeps calling "toTry" until promise resolves or has
+// retried "max" number of times. First retry has a delay of "delay" seconds.
+// "success" is called upon success.
+function exponentialBackoff(max, delay, toTry, success, fail) {
+  toTry().then(result => success(result))
+  .catch(_ => {
+    if (max === 0) {
+      return fail();
+    }
+    time('Retrying in ' + delay + 's... (' + max + ' tries left)');
+    setTimeout(function() {
+      exponentialBackoff(--max, delay * 2, toTry, success, fail);
+    }, delay * 1000);
+  });
+}
+
+function anyDevice() {
+  // This is the closest we can get for now to get all devices.
+  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
+  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      .map(c => ({namePrefix: c}))
+      .concat({name: ''});
+}
+
+function time(text) {
+  log('[' + new Date().toJSON().substr(11, 8) + '] ' + text);
+}

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -23,3 +23,4 @@ icon_url: icon.png
 <p><a href="device-information-characteristics.html">Device Information Characteristics</a> - get all Device Information characteristics of a BLE Device.</p>
 <p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device (readValue & writeValue).</p>
 <p><a href="discover-services-and-characteristics.html">Discover Services & Characteristics</a> - discover all accessible primary services and their characteristics from a BLE Device.</p>
+<p><a href="automatic-reconnect.html">Automatic Reconnect</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>


### PR DESCRIPTION
This sample provides some guidance on how to automatically reconnect to a disconnected device using a simple exponential backoff algorithm. We can also use it as a way to calculate how much time scan will timeout. For instance, the reconnect algorithm is useless for now on macOS as `device.gatt.connect` never (ever) rejects.

You can try it live at https://beaufortfrancois.github.io/samples/web-bluetooth/automatic-reconnect.html

R=@g-ortuno @scheib @jyasskin

![screenshot 2016-06-16 at 3 14 06 pm](https://cloud.githubusercontent.com/assets/634478/16117949/0dbd448c-33d5-11e6-8b9b-2b526b338faf.png)
