### PR TITLE
bluetooth: Add Read Characteristic Value Changed Sample

### DIFF
--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -24,6 +24,7 @@ icon_url: icon.png
 <p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device (readValue & writeValue).</p>
 <p><a href="discover-services-and-characteristics.html">Discover Services & Characteristics</a> - discover all accessible primary services and their characteristics from a BLE Device.</p>
 <p><a href="automatic-reconnect.html">Automatic Reconnect</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>
+<p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed</a> - read battery level and be notified of changes from a BLE Device.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/read-characteristic-value-changed.html
+++ b/web-bluetooth/read-characteristic-value-changed.html
@@ -14,8 +14,11 @@ Battery information with Bluetooth Low Energy. You may want
 to try this demo with the BLE Peripheral
 Simulator App from the <a target="_blank"
 href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
-Play Store</a>. Note that a <a href="battery-level.html">simpler demo for retrieving battery level
-information</a> is also available.</p>
+Play Store</a>.</p>
+
+<p>Here, we use the <code>characteristicvaluechanged</code> event listener to
+handle reading battery level characteristic value. This event listener will
+optionally handle upcoming notifications as well.</p>
 
 <button id="readBatteryLevel">Read Bluetooth Device's Battery Level</button>
 <button id="startNotifications" disabled>Start Notifications</button>

--- a/web-bluetooth/read-characteristic-value-changed.html
+++ b/web-bluetooth/read-characteristic-value-changed.html
@@ -1,0 +1,55 @@
+---
+feature_name: Web Bluetooth / Read Characteristic Value Changed
+chrome_version: 48
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to read battery
+level and be notified of changes from a nearby Bluetooth Device advertising
+Battery information with Bluetooth Low Energy. You may want
+to try this demo with the BLE Peripheral
+Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a>. Note that a <a href="battery-level.html">simpler demo for retrieving battery level
+information</a> is also available.</p>
+
+<button id="readBatteryLevel">Read Bluetooth Device's Battery Level</button>
+<button id="startNotifications" disabled>Start Notifications</button>
+<button id="stopNotifications" disabled>Stop Notifications</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='read-characteristic-value-changed.js' %}
+
+<script>
+  document.querySelector('#readBatteryLevel').addEventListener('click', function() {
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onReadBatteryLevelButtonClick();
+    }
+  });
+
+  document.querySelector('#startNotifications').addEventListener('click', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      onStartNotificationsButtonClick();
+    }
+  });
+
+  document.querySelector('#stopNotifications').addEventListener('click', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      onStopNotificationsButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/read-characteristic-value-changed.js
+++ b/web-bluetooth/read-characteristic-value-changed.js
@@ -25,7 +25,7 @@ function onReadBatteryLevelButtonClick() {
   })
   .then(_ => {
     document.querySelector('#startNotifications').disabled = false;
-    document.querySelector('#stopNotifications').disabled = false;
+    document.querySelector('#stopNotifications').disabled = true;
   })
   .catch(error => {
     log('Argh! ' + error);
@@ -45,6 +45,8 @@ function onStartNotificationsButtonClick() {
   batteryLevelCharacteristic.startNotifications()
   .then(_ => {
     log('> Notifications started');
+    document.querySelector('#startNotifications').disabled = true;
+    document.querySelector('#stopNotifications').disabled = false;
   })
   .catch(error => {
     log('Argh! ' + error);
@@ -56,6 +58,8 @@ function onStopNotificationsButtonClick() {
   batteryLevelCharacteristic.stopNotifications()
   .then(_ => {
     log('> Notifications stopped');
+    document.querySelector('#startNotifications').disabled = false;
+    document.querySelector('#stopNotifications').disabled = true;
   })
   .catch(error => {
     log('Argh! ' + error);

--- a/web-bluetooth/read-characteristic-value-changed.js
+++ b/web-bluetooth/read-characteristic-value-changed.js
@@ -34,7 +34,7 @@ function onReadBatteryLevelButtonClick() {
 
 /* This function will be called when `readValue` resolves and
  * characteristic value changes since `characteristicvaluechanged` event
- * listener has been added. Note that it would also work with `writeValue`. */
+ * listener has been added. */
 function handleBatteryLevelChanged(event) {
   let batteryLevel = event.target.value.getUint8(0);
   log('> Battery Level is ' + batteryLevel + '%');

--- a/web-bluetooth/read-characteristic-value-changed.js
+++ b/web-bluetooth/read-characteristic-value-changed.js
@@ -1,0 +1,73 @@
+var batteryLevelCharacteristic;
+
+function onReadBatteryLevelButtonClick() {
+  log('Requesting Bluetooth Device...');
+  navigator.bluetooth.requestDevice(
+    {filters: anyDevice(), optionalServices: ['battery_service']})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Battery Service...');
+    return server.getPrimaryService('battery_service');
+  })
+  .then(service => {
+    log('Getting Battery Level Characteristic...');
+    return service.getCharacteristic('battery_level');
+  })
+  .then(characteristic => {
+    log('Reading Battery Level...');
+    batteryLevelCharacteristic = characteristic;
+    batteryLevelCharacteristic.addEventListener('characteristicvaluechanged',
+        handleBatteryLevelChanged);
+    return batteryLevelCharacteristic.readValue();
+  })
+  .then(_ => {
+    document.querySelector('#startNotifications').disabled = false;
+    document.querySelector('#stopNotifications').disabled = false;
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+/* This function will be called when `readValue` resolves and
+ * characteristic value changes since `characteristicvaluechanged` event
+ * listener has been added. Note that it would also work with `writeValue`. */
+function handleBatteryLevelChanged(event) {
+  let batteryLevel = event.target.value.getUint8(0);
+  log('> Battery Level is ' + batteryLevel + '%');
+}
+
+function onStartNotificationsButtonClick() {
+  log('Starting Battery Level Notifications...');
+  batteryLevelCharacteristic.startNotifications()
+  .then(_ => {
+    log('> Notifications started');
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function onStopNotificationsButtonClick() {
+  log('Stopping Battery Level Notifications...');
+  batteryLevelCharacteristic.stopNotifications()
+  .then(_ => {
+    log('> Notifications stopped');
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+/* Utils */
+
+function anyDevice() {
+  // This is the closest we can get for now to get all devices.
+  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
+  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      .map(c => ({namePrefix: c}))
+      .concat({name: ''});
+}


### PR DESCRIPTION
This sample combines `readValue`, `characteristicvaluechanged` and `{start,stop}Notifications` to read battery level and be notified of changes from a nearby BLE device.

Featured: 
- `characteristicvaluechanged` event listener added to read characteristic value ✨ 
- read & notifications on the same `characteristic`
- trick to get all devices

R=@scheib @jyasskin @g-ortuno @jeffposnick 

Try it live at https://beaufortfrancois.github.io/samples/web-bluetooth/read-characteristic-value-changed.html

PS: There's a bug on Android I've filed at http://crbug.com/622217

![screenshot 2016-06-22 at 10 52 57 am](https://cloud.githubusercontent.com/assets/634478/16260383/8150df94-3867-11e6-9a03-c9acd39f05b1.png)
