### PR TITLE
Update PaymentRequest API for Chrome Dev 53.0.2774.4

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -3,10 +3,17 @@ function onBuyClicked() {
     {
       supportedMethods: ['https://android.com/pay'],
       data: {
-        'gateway': 'stripe',
-        // Place your own Stripe publishable key here.
-        'stripe:publishableKey': 'pk_test_VKUbaXb3LHE7GdxyOBMNwXqa',
-        'stripe:version': '2016-03-07'
+        merchantId: '123456',
+        allowedCardNetworks: ['AMEX', 'MASTERCARD', 'VISA'],
+        paymentMethodTokenizationParameters: {
+          tokenizationType: 'GATEWAY_TOKEN',
+          parameters: {
+            'gateway': 'stripe',
+            // Place your own Stripe publishable key here.
+            'stripe:publishableKey': 'pk_test_VKUbaXb3LHE7GdxyOBMNwXqa',
+            'stripe:version': '2016-03-07'
+          }
+        }
       }
     }
   ];
@@ -31,13 +38,10 @@ function onBuyClicked() {
         .then(function(instrumentResponse) {
           // Simulate server-side processing with a 2 second delay.
           window.setTimeout(function() {
-            instrumentResponse.complete(true)
+            instrumentResponse.complete('success')
                 .then(function() {
                   document.getElementById('result').innerHTML =
                       'methodName: ' + instrumentResponse.methodName +
-                      '<br>totalAmount: ' +
-                      JSON.stringify(
-                          instrumentResponse.totalAmount, undefined, 2) +
                       '<br>details: ' +
                       JSON.stringify(instrumentResponse.details, undefined, 2);
                 })

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -20,34 +20,36 @@ function onBuyClicked() {
     ]
   };
 
+  var options = {requestPayerPhone: true, requestPayerEmail: true};
+
   try {
-    new PaymentRequest(supportedInstruments, details) // eslint-disable-line no-undef
-        .show()
-        .then(function(instrumentResponse) {
-          // Simulate server-side processing with a 2 second delay.
-          window.setTimeout(function() {
-            instrumentResponse.complete('success')
-                .then(function() {
-                  document.getElementById('result').innerHTML =
-                      'methodName: ' + instrumentResponse.methodName +
-                      '<br>details: ' +
-                      JSON.stringify(instrumentResponse.details, undefined, 2);
-                })
-                .catch(function(err) {
-                  ChromeSamples.setStatus(err.message);
-                });
-          }, 2000);
-        })
-        .catch(function(err) {
-          ChromeSamples.setStatus(err.message);
-        });
+    var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
+    request.show().then(function(instrumentResponse) {
+      // Simulate server-side processing with a 2 second delay.
+      window.setTimeout(function() {
+        instrumentResponse.complete('success')
+            .then(function() {
+              document.getElementById('result').innerHTML =
+                  'payerPhone: ' + instrumentResponse.payerPhone +
+                  '<br>payerEmail: ' + instrumentResponse.payerEmail +
+                  '<br>methodName: ' + instrumentResponse.methodName +
+                  '<br>details: ' +
+                  JSON.stringify(instrumentResponse.details, undefined, 2);
+            })
+            .catch(function(err) {
+              ChromeSamples.setStatus(err.message);
+            });
+      }, 2000);
+    })
+    .catch(function(err) {
+      ChromeSamples.setStatus(err.message);
+    });
   } catch (e) {
     ChromeSamples.setStatus('Developer mistake: \'' + e.message + '\'');
   }
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
 if (!('PaymentRequest' in window)) {
   ChromeSamples.setStatus(
       'Enable chrome://flags/#enable-experimental-web-platform-features');

--- a/paymentrequest/contact-info/index.html
+++ b/paymentrequest/contact-info/index.html
@@ -1,0 +1,24 @@
+---
+feature_name: PaymentRequest Contact Info
+chrome_version: 52
+feature_id: 5639348045217792
+---
+
+<h3>Background</h3>
+<p>
+  <a href="https://github.com/w3c/browser-payment-api">PaymentRequest</a> lets
+  you accept payment from different payment methods.
+</p>
+
+<p>
+  This sample accepts credit card payments and requests user's contact
+  information: phone number and email address.
+</p>
+
+{% capture initial_output_content %}
+<div><button id="buyButton">Buy</button></div>
+<div><pre id="result"></pre></div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -34,7 +34,7 @@ function onBuyClicked() {
     request.show().then(function(instrumentResponse) {
       // Simulate server-side processing with a 2 second delay.
       window.setTimeout(function() {
-        instrumentResponse.complete(true)
+        instrumentResponse.complete('success')
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
@@ -43,8 +43,6 @@ function onBuyClicked() {
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>totalAmount: ' +
-                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
                   '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -37,7 +37,7 @@ function onBuyClicked() {
     request.show().then(function(instrumentResponse) {
       // Simulate server-side processing with a 2 second delay.
       window.setTimeout(function() {
-        instrumentResponse.complete(true)
+        instrumentResponse.complete('success')
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
@@ -46,8 +46,6 @@ function onBuyClicked() {
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>totalAmount: ' +
-                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
                   '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })

--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -27,4 +27,8 @@ feature_id: 5639348045217792
   <li><a href="dynamic-shipping/">Dynamic shipping</a> - a sample that accepts
     credit card payments and varies the availability and price of shipping
     options depending on the shipping address.</li>
+
+  <li><a href="contact-info/">Contact info</a> - a sample that accepts credit
+    card payments and requests user's contact information: phone number and
+    email address.</li>
 </ul>

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -51,7 +51,7 @@ function onBuyClicked() {
     request.show().then(function(instrumentResponse) {
       // Simulate server-side processing with a 2 second delay.
       window.setTimeout(function() {
-        instrumentResponse.complete(true)
+        instrumentResponse.complete('success')
             .then(function() {
               document.getElementById('result').innerHTML =
                   'shippingOption: ' + request.shippingOption +
@@ -60,8 +60,6 @@ function onBuyClicked() {
                       toDictionary(instrumentResponse.shippingAddress),
                       undefined, 2) +
                   '<br>methodName: ' + instrumentResponse.methodName +
-                  '<br>totalAmount: ' +
-                  JSON.stringify(instrumentResponse.totalAmount, undefined, 2) +
                   '<br>details: ' +
                   JSON.stringify(instrumentResponse.details, undefined, 2);
             })


### PR DESCRIPTION
The format of the Android Pay parameters has changed to pass in more
information or Android Pay. See the "Android Pay" sample for details.

PaymentRequest now allows merchants to collect user's contact
information: phone number and/or email address. The merchant can specify
this in options:

var options = {
  requestPayerPhone: true,
  requestPayerEmail: true
};

Chrome returns the contact information in the 'payerPhone' and
'payerEmail' fields in the instrument response.

The parameter type for the complete() method has changed from a boolean
to a string with two predefined values.

1) "success" - merchant successfully completed the transaction.
2) "fail" - merchant is not able to complete the transaction.

Any other string means the merchant cannot indicate either success or
failure to the user at the moment.

Chrome no longer returns the 'totalAmount' in the instrument response.
