### PR TITLE
Add Web Bluetooth service worker

### DIFF
--- a/web-bluetooth/_includes/intro.html
+++ b/web-bluetooth/_includes/intro.html
@@ -4,3 +4,9 @@ Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT). It is
 currently partially implemented in Chrome OS, Chrome for Android M and Linux
 behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.<br/>
 Check out <a href="index.html">all Web Bluetooth Samples</a>.</p>
+
+<script>
+  if('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+</script>

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -24,3 +24,9 @@ icon_url: icon.png
 <p><a href="link-loss.html">Link Loss</a> - set the Alert Level characteristic of a BLE Device (readValue & writeValue).</p>
 <p><a href="discover-services-and-characteristics.html">Discover Services & Characteristics</a> - discover all accessible primary services and their characteristics from a BLE Device.</p>
 <p><a href="automatic-reconnect.html">Automatic Reconnect</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>
+
+<script>
+  if('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+</script>

--- a/web-bluetooth/service-worker.js
+++ b/web-bluetooth/service-worker.js
@@ -1,0 +1,26 @@
+self.addEventListener('fetch', function(event) {
+  const request = event.request;
+  const url = new URL(event.request.url);
+
+  // Don't cache anything that is not on this origin.
+  if (url.origin !== location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.open('web-bluetooth').then(cache => {
+      return cache.match(request).then(response => {
+        var fetchPromise = fetch(request).then(networkResponse => {
+          cache.put(request, networkResponse.clone());
+          return networkResponse;
+        });
+        // We need to ensure that the event doesn't complete until we
+        // know we have fetched the data
+        event.waitUntil(fetchPromise);
+
+        // Return the response from cache or wait for network.
+        return response || fetchPromise;
+      });
+    })
+  );
+});

--- a/web-bluetooth/service-worker.js
+++ b/web-bluetooth/service-worker.js
@@ -7,20 +7,14 @@ self.addEventListener('fetch', function(event) {
     return;
   }
 
-  event.respondWith(
-    caches.open('web-bluetooth').then(cache => {
-      return cache.match(request).then(response => {
-        var fetchPromise = fetch(request).then(networkResponse => {
-          cache.put(request, networkResponse.clone());
-          return networkResponse;
-        });
-        // We need to ensure that the event doesn't complete until we
-        // know we have fetched the data
-        event.waitUntil(fetchPromise);
-
-        // Return the response from cache or wait for network.
-        return response || fetchPromise;
+  event.respondWith(caches.open('web-bluetooth').then(cache => {
+    return cache.match(request).then(response => {
+      var fetchPromise = fetch(request).then(networkResponse => {
+        cache.put(request, networkResponse.clone());
+        return networkResponse;
       });
-    })
-  );
+      // Return the response from cache or wait for network.
+      return response || fetchPromise;
+    });
+  }));
 });


### PR DESCRIPTION
@jeffposnick @addyosmani  In order to provide offline access to Web Bluetooth samples, I've added a simple service worker (stale while revalidate pattern). If that looks good to you, we could extend this solution to other samples. See https://github.com/GoogleChrome/samples/issues/376

Live preview at https://beaufortfrancois.github.io/samples/web-bluetooth/index.html
