### PR TITLE
Update Travis CI config to use Ruby 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.2
 script:
   - npm install
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.2
+- 2.2.2
 script:
   - npm install
   - npm run lint


### PR DESCRIPTION
R: @beaufortfrancois @addyosmani @PaulKinlan etc.

As per https://travis-ci.org/GoogleChrome/samples/builds/144504931#L193, our Travis CI builds are failing because one of the depedencies expects Ruby 2.2.2. I don't know of any reason not to upgrade, so this change does that.
