### PR TITLE
Add Origin Trial note to Web Bluetooth samples

### DIFF
--- a/web-bluetooth/_includes/intro.html
+++ b/web-bluetooth/_includes/intro.html
@@ -1,9 +1,12 @@
 <p>The <a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth
   API</a> lets websites discover and communicate with devices over the
 Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT). It is
-currently partially implemented in Chrome OS, Chrome for Android M and Linux
+currently partially implemented in Chrome OS, Android M, Linux and Mac
 behind the experimental flag <code>chrome://flags/#enable-web-bluetooth</code>.<br/>
 Check out <a href="index.html">all Web Bluetooth Samples</a>.</p>
+
+<p>Note: Starting in Chrome 53, it is also <a href="https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials">available
+for trials</a> so that websites can use it without any flag.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -7,6 +7,9 @@ icon_url: icon.png
 
 <p>The following samples show you some of the ways that you can use the <a href="https://github.com/WebBluetoothCG/web-bluetooth">Web Bluetooth API</a>.</p>
 
+<p>Note: Starting in Chrome 53, it is also <a href="https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials">available
+for trials</a> so that websites can use it without any flag.</p>
+
 <h3>Beginner</h3>
 
 <p><a href="device-info.html">Device Info</a> - retrieve basic device information from a BLE Device.</p>


### PR DESCRIPTION
R:@jeffposnick @jyasskin

If that looks good to you, I'll merge this one when ["Interact with Bluetooth devices on the Web"](https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web) article gets updated/pushed at https://github.com/google/WebFundamentals/pull/3147.
