### PR TITLE
Rasterization & will-change: transform sample

### DIFF
--- a/css-will-change-transform-rasterization/README.md
+++ b/css-will-change-transform-rasterization/README.md
@@ -1,0 +1,5 @@
+Rasterization & will-change: transform Sample
+=============================================
+See https://googlechrome.github.io/samples/css-will-change-transform-rasterization/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/5637351992721408

--- a/css-will-change-transform-rasterization/demo.js
+++ b/css-will-change-transform-rasterization/demo.js
@@ -1,0 +1,9 @@
+window.addEventListener('load', function() {
+  requestAnimationFrame(function() {
+    var remainsBlurry = document.querySelector('#remainsBlurry');
+    remainsBlurry.style.transform = 'scale(2, 2) translate3d(50px, 0, 0)';
+
+    var noLongerBlurry = document.querySelector('#noLongerBlurry');
+    noLongerBlurry.style.transform = 'scale(2, 2) translate3d(50px, 0, 0)';
+  });
+});

--- a/css-will-change-transform-rasterization/index.html
+++ b/css-will-change-transform-rasterization/index.html
@@ -1,0 +1,58 @@
+---
+feature_name: "Rasterization &amp; will-change: transform"
+chrome_version: 53
+feature_id: 5637351992721408
+---
+
+<h3>Background</h3>
+<p>
+  All content that does not have the <code>will-change: transform</code> CSS
+  property will be re-rastered when its transform scale changes. In other words,
+  <code>will-change: transform</code> effectively means "please animate it fast"
+  without taking the additional time for rasterization. This only applies to
+  scaling that happen via JavaScript manipulation, and does not apply to CSS
+  animations.
+</p>
+
+<h3>Live Output</h3>
+<p>
+  You can see the impact in the sample text below:
+</p>
+
+{% capture html %}
+<div id="container">
+  <div id="remainsBlurry">always blurry</div>
+  <div id="noLongerBlurry">blurry before Chrome 53</div>
+  <div id="alwaysCrisp">always crisp</div>
+</div>
+{% endcapture %}
+{% include html_snippet.html html=html %}
+
+{% capture css %}
+#container {
+  margin-left: 50px;
+  margin-top: 100px;
+}
+
+#remainsBlurry {
+  height: 50px;
+  transform: translate3d(0, 0, 0);
+  width: 300px;
+  will-change: transform;
+}
+
+#noLongerBlurry {
+  height: 50px;
+  transform: translate3d(0, 0, 0);
+  width: 300px;
+}
+
+#alwaysCrisp {
+  height: 50px;
+  transform: scale(2, 2) translate3d(25px, 0, 0);
+  width: 200px;
+}
+{% endcapture %}
+{% include css_snippet.html css=css %}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/css-will-change-transform-rasterization/index.html
+++ b/css-will-change-transform-rasterization/index.html
@@ -4,14 +4,31 @@ chrome_version: 53
 feature_id: 5637351992721408
 ---
 
+<style>
+  #container {
+    margin-left: 50px;
+    margin-top: 100px;
+  }
+
+  #container > div {
+    height: 50px;
+    width: 300px;
+  }
+</style>
+
 <h3>Background</h3>
 <p>
   All content that does not have the <code>will-change: transform</code> CSS
   property will be re-rastered when its transform scale changes. In other words,
-  <code>will-change: transform</code> effectively means "please animate it fast"
+  <code>will-change: transform</code> effectively means "please apply the transformation quickly"
   without taking the additional time for rasterization. This only applies to
   scaling that happen via JavaScript manipulation, and does not apply to CSS
   animations.
+</p>
+
+<p>
+  More detailed background information is available in the
+  <a href="https://docs.google.com/document/d/1f8WS99F9GORWP_m74l_JfsTHgCrHkbEorHYu72D4Xag/edit">Intent to Ship</a> document.
 </p>
 
 <h3>Live Output</h3>
@@ -29,28 +46,17 @@ feature_id: 5637351992721408
 {% include html_snippet.html html=html %}
 
 {% capture css %}
-#container {
-  margin-left: 50px;
-  margin-top: 100px;
-}
-
 #remainsBlurry {
-  height: 50px;
   transform: translate3d(0, 0, 0);
-  width: 300px;
   will-change: transform;
 }
 
 #noLongerBlurry {
-  height: 50px;
   transform: translate3d(0, 0, 0);
-  width: 300px;
 }
 
 #alwaysCrisp {
-  height: 50px;
-  transform: scale(2, 2) translate3d(25px, 0, 0);
-  width: 200px;
+  transform: scale(2, 2) translate3d(50px, 0, 0);
 }
 {% endcapture %}
 {% include css_snippet.html css=css %}


### PR DESCRIPTION
R: @surma @PaulKinlan @beaufortfrancois @ebidel etc.

This is a sample to accompany the "[Raster on composited layer scale change, except if will-change: transform or an accelerated animation is present](https://www.chromestatus.com/feature/5637351992721408)" feature launching in Chrome 53.

Much of the background and the sample is transferred from the [Intent to Ship](https://docs.google.com/document/d/1f8WS99F9GORWP_m74l_JfsTHgCrHkbEorHYu72D4Xag/edit) announcement. I can't find the relevant engineers on GitHub to CC: them, so I'll email them a link to this PR as a heads-up.

There's a lot of extra background information that could probably be included, but I think that will be best covered in the article that @surma will eventually write.

Live staged version at https://jeffy.info/samples/css-will-change-transform-rasterization/
