### PR TITLE
Update web payments samples.

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -1,19 +1,27 @@
 /**
- * Invokes PaymentRequest for Android Pay.
+ * Invokes PaymentRequest for Android Pay. If you encounter issues when running
+ * your own copy of this sample, run 'adb logcat | grep Wallet' to see detailed
+ * error messages.
  */
 function onBuyClicked() {
   var supportedInstruments = [{
     supportedMethods: ['https://android.com/pay'],
     data: {
-      environment: 'TEST',
-      merchantId: '123456',
+      merchantName: 'Android Pay Demo',
+      // Place your own Android Pay merchant ID here. The merchant ID is tied to
+      // the origin of the website.
+      merchantId: '00184145120947117657',
+      // If you do not yet have a merchant ID, uncomment the following line.
+      // environment: 'TEST',
       allowedCardNetworks: ['AMEX', 'DISCOVER', 'MASTERCARD', 'VISA'],
       paymentMethodTokenizationParameters: {
         tokenizationType: 'GATEWAY_TOKEN',
         parameters: {
           'gateway': 'stripe',
-          'stripe:publishableKey': '<PLACE_YOUR_STRIPE_PUBLISHABLE_KEY_HERE>',
-          'stripe:version': '2016-03-07'
+          // Place your own Stripe publishable key here. Use a matching Stripe
+          // secret key on the server to initiate a transaction.
+          'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
+          'stripe:version': '2016-07-06'
         }
       }
     }
@@ -82,16 +90,10 @@ function instrumentToJsonString(instrument) {
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -79,16 +79,10 @@ function instrumentToJsonString(instrument) {
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -74,16 +74,10 @@ function instrumentToJsonString(instrument) {
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -140,21 +140,16 @@ function addressToDictionary(address) {
     postalCode: address.postalCode,
     sortingCode: address.sortingCode,
     country: address.country,
+    languageCode: address.languageCode,
     phone: address.phone
   };
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -33,8 +33,13 @@ function onBuyClicked() {
 
   var options = {requestShipping: true};
 
-  new PaymentRequest(supportedInstruments, details, options) // eslint-disable-line no-undef
-      .show()
+  var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
+
+  request.addEventListener('shippingaddresschange', function(evt) {
+    evt.updateWith(Promise.resolve(details));
+  });
+
+  request.show()
       .then(function(instrumentResponse) {
         sendPaymentToServer(instrumentResponse);
       })
@@ -107,21 +112,16 @@ function addressToDictionary(address) {
     postalCode: address.postalCode,
     sortingCode: address.sortingCode,
     country: address.country,
+    languageCode: address.languageCode,
     phone: address.phone
   };
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -42,6 +42,10 @@ function onBuyClicked() {
 
   var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
 
+  request.addEventListener('shippingaddresschange', function(evt) {
+    evt.updateWith(Promise.resolve(details));
+  });
+
   request.addEventListener('shippingoptionchange', function(evt) {
     evt.updateWith(new Promise(function(resolve, reject) {
       updateDetails(details, request.shippingOption, resolve, reject);
@@ -152,21 +156,16 @@ function addressToDictionary(address) {
     postalCode: address.postalCode,
     sortingCode: address.sortingCode,
     country: address.country,
+    languageCode: address.languageCode,
     phone: address.phone
   };
 }
 
 var buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
-if (!('PaymentRequest' in window)) {
-  ChromeSamples.setStatus(
-      'Enable chrome://flags/#enable-experimental-web-platform-features');
-} else if (!navigator.userAgent.match(/Android/i)) {
-  ChromeSamples.setStatus(
-      'PaymentRequest is supported only on Android for now.');
-} else if (!navigator.userAgent.match(/Chrome\/5[3-4]/i)) { // eslint-disable-line no-negated-condition
-  ChromeSamples.setStatus('These tests are for Chrome 53 and 54.');
-} else {
+if ('PaymentRequest' in window) {
   buyButton.setAttribute('style', 'display: inline;');
   buyButton.addEventListener('click', onBuyClicked);
+} else {
+  buyButton.setAttribute('style', 'display: none;');
+  ChromeSamples.setStatus('This browser does not support web payments');
 }


### PR DESCRIPTION
- Use a merchant ID and Stripe publishable key in Android Pay demo.
- Simplify feature detection.
- Listen to 'shippingaddresschange' events when requesting shipping
  information.
- Print 'languageCode' of the shipping address.
