### PR TITLE
Add eslint rule about single-parameter arrow functions.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "ChromeSamples": true
   },
   "rules": {
+    "arrow-parens": [2, "as-needed"],
     "require-jsdoc": 0,
     "no-inline-comments": 0
   }


### PR DESCRIPTION
As mentioned in https://github.com/GoogleChrome/samples/pull/407#discussion_r75683772 by @jeffposnick , here's a eslint rule about single-parameter arrow functions.
