### PR TITLE
Update PaymentRequest Chrome version.

### DIFF
--- a/paymentrequest/android-pay/index.html
+++ b/paymentrequest/android-pay/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Android Pay
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/contact-info/index.html
+++ b/paymentrequest/contact-info/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Contact Info
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/credit-cards/index.html
+++ b/paymentrequest/credit-cards/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Credit Cards
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/dynamic-shipping/index.html
+++ b/paymentrequest/dynamic-shipping/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Dynamic Shipping
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/free-shipping/index.html
+++ b/paymentrequest/free-shipping/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Free Shipping
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 

--- a/paymentrequest/shipping-options/index.html
+++ b/paymentrequest/shipping-options/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: PaymentRequest Shipping Options
-chrome_version: 52
+chrome_version: 53
 feature_id: 5639348045217792
 ---
 


### PR DESCRIPTION
Chrome 53 is the first version where PaymentRequest is enabled by
default.
