### PR TITLE
Update to the window.caches sample

### DIFF
--- a/service-worker/window-caches/demo.js
+++ b/service-worker/window-caches/demo.js
@@ -1,0 +1,100 @@
+var CACHE_NAME = 'window-cache-v1';
+var cacheEntriesUl = document.querySelector('#cache-entries');
+
+function initializeUI() {
+  document.querySelector('#files').style.display = 'block';
+
+  document.querySelector('#add').addEventListener('click', function() {
+    var url = document.querySelector('#url').value;
+    if (url) {
+      addUrlToCache(url);
+    }
+  });
+
+  showList();
+}
+
+function showList() {
+  // Clear out any previous entries, in case this is being called after adding a
+  // new entry to the cache.
+  while (cacheEntriesUl.firstChild) {
+    cacheEntriesUl.removeChild(cacheEntriesUl.firstChild);
+  }
+
+  // All the Cache Storage API methods return Promises. If you're not familiar
+  // with them, see http://www.html5rocks.com/en/tutorials/es6/promises/
+  // Here, we're iterating over all the available caches, and for each cache,
+  // iterating over all the entries, adding each to the list.
+  window.caches.keys().then(function(cacheNames) {
+    cacheNames.forEach(function(cacheName) {
+      window.caches.open(cacheName).then(function(cache) {
+        return cache.keys();
+      }).then(function(requests) {
+        requests.forEach(function(request) {
+          addRequestToList(cacheName, request);
+        });
+      });
+    });
+  });
+}
+
+// This uses window.fetch() (https://developers.google.com/web/updates/2015/03/introduction-to-fetch)
+// to retrieve a Response from the network, and store it in the named cache.
+// In some cases, cache.add() can be used instead of the fetch()/cache.put(),
+// but only if we know that the resource we're fetching supports CORS.
+// cache.add() will fail when the response status isn't 200, and when CORS isn't
+// supported, the response status is always 0.
+// (See https://github.com/w3c/ServiceWorker/issues/823).
+function addUrlToCache(url) {
+  window.fetch(url, {mode: 'no-cors'}).then(function(response) {
+    caches.open(CACHE_NAME).then(function(cache) {
+      cache.put(url, response).then(showList);
+    });
+  }).catch(function(error) {
+    ChromeSamples.setStatus(error);
+  });
+}
+
+// Helper method to add a cached Request to the list of the cache contents.
+function addRequestToList(cacheName, request) {
+  var url = request.url;
+
+  var spanElement = document.createElement('span');
+  spanElement.textContent = url;
+
+  var buttonElement = document.createElement('button');
+  buttonElement.textContent = 'Remove';
+  buttonElement.dataset.url = url;
+  buttonElement.dataset.cacheName = cacheName;
+  buttonElement.addEventListener('click', function() {
+    remove(this.dataset.cacheName, this.dataset.url).then(function() {
+      var parent = this.parentNode;
+      var grandParent = parent.parentNode;
+      grandParent.removeChild(parent);
+    }.bind(this));
+  });
+
+  var liElement = document.createElement('li');
+  liElement.appendChild(spanElement);
+  liElement.appendChild(buttonElement);
+
+  cacheEntriesUl.appendChild(liElement);
+}
+
+// Given a cache name and URL, removes the cached entry.
+function remove(cacheName, url) {
+  return window.caches.open(cacheName).then(function(cache) {
+    return cache.delete(url);
+  });
+}
+
+if ('caches' in window) {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+    // As soon as the service worker has been installed, active the UI elements.
+    navigator.serviceWorker.ready.then(initializeUI);
+  }
+} else {
+  ChromeSamples.setStatus('window.caches is not supported in your browser.');
+}
+

--- a/service-worker/window-caches/index.html
+++ b/service-worker/window-caches/index.html
@@ -1,251 +1,46 @@
-<!doctype html>
-<!--
-Copyright 2015 Google Inc. All Rights Reserved.
+---
+feature_name: window.caches
+chrome_version: 43
+feature_id: 5072127703121920
+---
+<style>
+  #files {
+    display: none;
+  }
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  button {
+    margin-left: 1em;
+  }
+</style>
 
-  http://www.apache.org/licenses/LICENSE-2.0
+<h3>Background</h3>
+<p>
+  This sample demonstrates basic service worker registration, in conjunction with pre-fetching
+  of specific resource URLs during the installation phase. Additionally, it illustrates how
+  <code>window.caches</code> can be used to make calls against the
+  <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">Cache Storage API</a>
+  from the context of a normal document. (This was previously only exposed to service workers.)
+</p>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+{% capture initial_output_content %}
+<div id="files">
+  <p>
+    The resources currently in the cache are listed below. Some initial files have been added
+    via the service worker's install handler. You can add additional files to the cache or
+    remove files from the context of the current page, without having to pass messages back
+    and forth to the service worker.
+  </p>
 
-    <meta name="description" content="Sample showing how window.caches provides access to the Cache Storage API.">
+  <ul id="cache-entries"></ul>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <div>
+    <label for="url">URL to Cache:</label>
+    <input type="text" id="url" size="60" value="https://www.google.com">
+    <button id="add">Add</button>
+  </div>
+</div>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
 
-    <title>Service Worker Sample: Using window.caches</title>
-
-    <!-- Add to homescreen for Chrome on Android -->
-    <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" sizes="192x192" href="../../images/touch/chrome-touch-icon-192x192.png">
-
-    <!-- Add to homescreen for Safari on iOS -->
-    <meta name="apple-mobile-web-app-title" content="Service Worker Sample: Pre-fetching Resources During Registration">
-
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <link rel="apple-touch-icon-precomposed" href="../../images/apple-touch-icon-precomposed.png">
-
-    <!-- Tile icon for Win8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
-    <meta name="msapplication-TileColor" content="#3372DF">
-
-    <link rel="icon" href="../../images/favicon.ico">
-
-    <script>
-      // Service workers require HTTPS (http://goo.gl/lq4gCo). If we're running on a real web server
-      // (as opposed to localhost on a custom port, which is whitelisted), then change the protocol to HTTPS.
-      if ((!location.port || location.port == "80") && location.protocol != 'https:') {
-        location.protocol = 'https:';
-      }
-    </script>
-
-    <link rel="stylesheet" href="../../styles/main.css">
-
-    <style>
-      #files {
-        display: none;
-      }
-
-      button {
-        margin-left: 1em;
-      }
-    </style>
-  </head>
-
-  <body>
-    <h1>Service Worker Sample: Using window.caches</h1>
-
-    <p>Available in <a href="https://www.chromestatus.com/features/5072127703121920">Chrome 43+</a></p>
-
-    <p>
-      This sample demonstrates basic service worker registration, in conjunction with pre-fetching
-      of specific resource URLs during the installation phase. Additionally, it illustrates how
-      <code>window.caches</code> can be used to make calls against the
-      <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">Cache Storage API</a>
-      from the context of a normal document. (This was previously only exposed to service workers.)
-    </p>
-
-    <p>
-      Visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below
-      the registered service worker to view logging statements for the various actions the
-      <code><a href="service-worker.js">service-worker.js</a></code> script is performing.
-    </p>
-
-    <div class="output">
-      <div id="status"></div>
-
-      <div id="files">
-        <p>
-          The resources currently in the cache are listed below. Some initial files have been added
-          via the service worker's install handler. You can add additional files to the cache or
-          remove files from the context of the current page, without having to pass messages back
-          and forth to the service worker.
-        </p>
-
-        <ul id="cache-entries">
-        </ul>
-
-        <div>
-          <label for="url">URL to Cache:</label>
-          <input type="text" id="url" size="60" value="https://www.google.com">
-          <button id="add">Add</button>
-        </div>
-      </div>
-    </div>
-
-    <script>
-      var CACHE_NAME = 'window-cache-v1';
-      var cacheEntriesUl = document.querySelector('#cache-entries');
-
-      function initializeUI() {
-        document.querySelector('#files').style.display = 'block';
-
-        document.querySelector('#add').addEventListener('click', function() {
-          var url = document.querySelector('#url').value;
-          if (url) {
-            addUrlToCache(url);
-          }
-        });
-
-        showList();
-      }
-
-      function showList() {
-        // Clear out any previous entries, in case this is being called after adding a new entry
-        // to the cache.
-        while (cacheEntriesUl.firstChild) {
-          cacheEntriesUl.removeChild(cacheEntriesUl.firstChild);
-        }
-
-        // All the Cache Storage API methods return Promises. If you're not familiar with them, see
-        // http://www.html5rocks.com/en/tutorials/es6/promises/
-        // Here, we're iterating over all the available caches, and for each cache, iterating
-        // over all the entries, adding each to the list.
-        window.caches.keys().then(function(cacheNames) {
-          cacheNames.forEach(function(cacheName) {
-            window.caches.open(cacheName).then(function(cache) {
-              cache.keys().then(function(requests) {
-                requests.forEach(function(request) {
-                  addRequestToList(cacheName, request);
-                });
-              });
-            });
-          });
-        });
-      }
-
-      // This uses window.fetch() (https://developers.google.com/web/updates/2015/03/introduction-to-fetch)
-      // to retrieve a Response from the network, and store it in the named cache.
-      // Note that the service worker controlling this page has no fetch event handler, so this
-      // request is made without service worker involvement.
-      function addUrlToCache(url) {
-        window.fetch(url, {mode: 'no-cors'}).then(function(response) {
-          if (response.status < 400) {
-            caches.open(CACHE_NAME).then(function(cache) {
-              cache.put(url, response).then(showList);
-            });
-          }
-        }).catch(function(error) {
-          document.querySelector('#status').textContent = error;
-        });
-      }
-
-      // Helper method to add a cached Request to the list of the cache contents.
-      function addRequestToList(cacheName, request) {
-        var url = request.url;
-
-        var spanElement = document.createElement('span');
-        spanElement.textContent = url;
-
-        var buttonElement = document.createElement('button');
-        buttonElement.textContent = 'Remove';
-        buttonElement.dataset.url = url;
-        buttonElement.dataset.cacheName = cacheName;
-        buttonElement.addEventListener('click', function() {
-          removeCachedResponse(this.dataset.cacheName, this.dataset.url).then(function() {
-            var parent = this.parentNode;
-            var grandParent = parent.parentNode;
-            grandParent.removeChild(parent);
-          }.bind(this));
-        });
-
-        var liElement = document.createElement('li');
-        liElement.appendChild(spanElement);
-        liElement.appendChild(buttonElement);
-
-        cacheEntriesUl.appendChild(liElement);
-      }
-
-      // Given a cache name and URL, removes the cached entry.
-      function removeCachedResponse(cacheName, url) {
-        return window.caches.open(cacheName).then(function(cache) {
-          return cache.delete(url);
-        });
-      }
-
-      // Helper function which returns a promise which resolves once the service worker registration
-      // is past the "installing" state.
-      function waitUntilInstalled(registration) {
-        return new Promise(function(resolve, reject) {
-          if (registration.installing) {
-            // If the current registration represents the "installing" service worker, then wait
-            // until the installation step (during which the resources are pre-fetched) completes
-            // to display the file list.
-            registration.installing.addEventListener('statechange', function(e) {
-              if (e.target.state == 'installed') {
-                resolve();
-              } else if(e.target.state == 'redundant') {
-                reject();
-              }
-            });
-          } else {
-            // Otherwise, if this isn't the "installing" service worker, then installation must have been
-            // completed during a previous visit to this page, and the resources are already pre-fetched.
-            // So we can show the list of files right away.
-            resolve();
-          }
-        });
-      }
-
-      if ('serviceWorker' in navigator && 'caches' in window) {
-        navigator.serviceWorker.register('./service-worker.js', {scope: './'})
-          .then(waitUntilInstalled)
-          .then(initializeUI)
-          .catch(function(error) {
-            // Something went wrong during registration. The service-worker.js file
-            // might be unavailable or contain a syntax error.
-            document.querySelector('#status').textContent = error;
-          });
-      } else {
-        // The current browser doesn't support service workers.
-        var aElement = document.createElement('a');
-        aElement.href = 'http://www.chromium.org/blink/serviceworker/service-worker-faq';
-        aElement.textContent = 'Your browser does not support service workers and window.caches';
-        document.querySelector('#status').appendChild(aElement);
-      }
-    </script>
-
-    <script>
-      /* jshint ignore:start */
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-53563471-1', 'auto');
-      ga('send', 'pageview');
-      /* jshint ignore:end */
-    </script>
-    <!-- Built with love using Web Starter Kit -->
-  </body>
-</html>
+{% include js_snippet.html filename='demo.js' %}
+{% include js_snippet.html filename='service-worker.js' displayonly=true title="Service Worker's JavaScript" %}

--- a/service-worker/window-caches/service-worker.js
+++ b/service-worker/window-caches/service-worker.js
@@ -11,9 +11,6 @@
  limitations under the License.
 */
 
-// This polyfill provides Cache.add(), Cache.addAll(), and CacheStorage.match()
-importScripts('../serviceworker-cache-polyfill.js');
-
 // While overkill for this specific sample in which there is only one cache,
 // this is one best practice that can be followed in general to keep track of
 // multiple caches used by a given service worker, and keep them all versioned.
@@ -35,32 +32,17 @@ var CURRENT_CACHES = {
 self.addEventListener('install', function(event) {
   var urlsToPrefetch = [
     './static/pre_fetched.txt',
-    './static/pre_fetched.html',
-    // This is an image that will be used in pre_fetched.html
-    'https://www.chromium.org/_/rsrc/1302286216006/config/customLogo.gif'
+    './static/pre_fetched.html'
   ];
-
-  // All of these logging statements should be visible via the "Inspect" interface
-  // for the relevant SW accessed via chrome://serviceworker-internals
-  console.log('Handling install event. Resources to pre-fetch:',
-    urlsToPrefetch);
 
   event.waitUntil(
     caches.open(CURRENT_CACHES.prefetch).then(function(cache) {
-      return cache.addAll(urlsToPrefetch.map(function(urlToPrefetch) {
-        // It's very important to use {mode: 'no-cors'} if there is any chance that
-        // the resources being fetched are served off of a server that doesn't support
-        // CORS (http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
-        // In this example, www.chromium.org doesn't support CORS, and the fetch()
-        // would fail if the default mode of 'cors' was used for the fetch() request.
-        // The drawback of hardcoding {mode: 'no-cors'} is that the response from all
-        // cross-origin hosts will always be opaque
-        // (https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cross-origin-resources)
-        // and it is not possible to determine whether an opaque response represents a success or failure
-        // (https://github.com/whatwg/fetch/issues/14).
-        return new Request(urlToPrefetch, {mode: 'no-cors'});
-      })).then(function() {
+      return cache.addAll(urlsToPrefetch).then(function() {
         console.log('All resources have been fetched and cached.');
+        // skipWaiting() allows this service worker to become active
+        // immediately, bypassing the waiting state, even if there's a previous
+        // version of the service worker already installed.
+        self.skipWaiting();
       });
     }).catch(function(error) {
       // This catch() will handle any exceptions from the caches.open()/cache.addAll() steps.
@@ -70,6 +52,10 @@ self.addEventListener('install', function(event) {
 });
 
 self.addEventListener('activate', function(event) {
+  // clients.claim() tells the active service worker to take immediate
+  // control of all of the clients under its scope.
+  self.clients.claim();
+
   // Delete all caches that aren't named in CURRENT_CACHES.
   // While there is only one cache in this example, the same logic will handle the case where
   // there are multiple versioned caches.
@@ -82,7 +68,8 @@ self.addEventListener('activate', function(event) {
       return Promise.all(
         cacheNames.map(function(cacheName) {
           if (expectedCacheNames.indexOf(cacheName) === -1) {
-            // If this cache name isn't present in the array of "expected" cache names, then delete it.
+            // If this cache name isn't present in the array of "expected" cache names,
+            // then delete it.
             console.log('Deleting out of date cache:', cacheName);
             return caches.delete(cacheName);
           }


### PR DESCRIPTION
R: @jmadler 

Modernizes the sample to reflect some changes to the cache.add() behavior, as well as moving to the new templating system. It also explicitly checks for `window.caches` and displays an error status when it's not available.

Fixes #413 
