### PR TITLE
Custom offline page: avoid cache-busting "regular" requests

### DIFF
--- a/service-worker/custom-offline-page/service-worker.js
+++ b/service-worker/custom-offline-page/service-worker.js
@@ -83,7 +83,7 @@ self.addEventListener('fetch', event => {
        event.request.headers.get('accept').includes('text/html'))) {
     console.log('Handling fetch event for', event.request.url);
     event.respondWith(
-      fetch(createCacheBustedRequest(event.request.url)).catch(error => {
+      fetch(event.request).catch(error => {
         // The catch is only triggered if fetch() throws an exception, which will most likely
         // happen due to the server being unreachable.
         // If fetch() returns a valid HTTP response with an response code in the 4xx or 5xx


### PR DESCRIPTION
The request for `OFFLINE_URL` should be cache-busted to avoid surprises, but this isn't needed for regular requests.
