### PR TITLE
Foreign fetch sample

### DIFF
--- a/service-worker/README.md
+++ b/service-worker/README.md
@@ -52,6 +52,10 @@ a sample showing how `window.caches` provides access to the Cache Storage API.
 a sample showing how a service worker can cause web page clients it controls to
 navigate to a given URL.
 
+- [Foreign Fetch](https://googlechrome.github.io/samples/service-worker/foreign-fetch/index.html) -
+a sample showing a client making use of the foreign fetch service worker
+deployed by a third-party service.
+
 
 # Related samples
 

--- a/service-worker/foreign-fetch/README.md
+++ b/service-worker/foreign-fetch/README.md
@@ -1,0 +1,5 @@
+Foreign Fetch Service Worker Sample
+===========================
+See https://googlechrome.github.io/samples/service-worker/foreign-fetch/index.html for a live demo.
+
+Learn more at https://www.chromestatus.com/feature/5684130679357440

--- a/service-worker/foreign-fetch/foreign-fetch-sw.js
+++ b/service-worker/foreign-fetch/foreign-fetch-sw.js
@@ -1,0 +1,21 @@
+// This is deployed to https://foreign-fetch-demo.appspot.com/foreign-fetch-sw.js
+
+self.addEventListener('install', event => {
+  event.registerForeignFetch({
+    scopes: ['/random'], // or self.registration.scope to handle everything
+    origins: ['*'] // or ['https://client1.com'] to limit the remote origins
+  });
+});
+
+self.addEventListener('foreignfetch', event => {
+  event.respondWith(
+    fetch(event.request) // Try to make a network request
+      .catch(() => new Response('34')) // Offline? Your random number is 34!
+      .then(response => {
+        return {
+          response,
+          origin: event.origin // Make this a CORS response
+        };
+      })
+  );
+});

--- a/service-worker/foreign-fetch/foreign-fetch-sw.js
+++ b/service-worker/foreign-fetch/foreign-fetch-sw.js
@@ -3,7 +3,7 @@
 self.addEventListener('install', event => {
   event.registerForeignFetch({
     scopes: ['/random'], // or self.registration.scope to handle everything
-    origins: ['*'] // or ['https://client1.com'] to limit the remote origins
+    origins: ['*'] // or ['https://example.com'] to limit the remote origins
   });
 });
 

--- a/service-worker/foreign-fetch/index.html
+++ b/service-worker/foreign-fetch/index.html
@@ -1,0 +1,51 @@
+---
+feature_name: Foreign Fetch Service Worker
+chrome_version: 54
+feature_id: 5684130679357440
+---
+
+<h3>Background</h3>
+
+<p>
+  Third-party service providers can deploy
+  <a href="https://developers.google.com/web/updates/2016/09/foreign-fetch">foreign fetch service workers</a>
+  to intercept cross-origin requests from any client. For example, a web font
+  provider might want to register a foreign fetch service worker to implement an
+  advanced offline-first strategy for font requests, with a common cache shared
+  amongst all its clients.
+</p>
+
+<p>
+  A new <code>Link: rel="serviceworker"</code> response header facilitates
+  registering these third-party service workers.
+</p>
+
+<p>
+  Both foreign fetch itself and the <code>Link: rel="serviceworker"</code>
+  header are part of an
+  <a href="https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md">Origin Trial</a>
+  starting with Chrome 54, and running through March 2017. To test out a foreign
+  fetch service worker without requiring the third-party service to sign up for
+  an origin trial token, you can enable
+  <code>chrome://flags/#enable-experimental-web-platform-features</code>. (This
+  is not required to test the demo on this page, which makes a request against
+  a service that has a valid Origin Trial token.)
+</p>
+
+<p>
+  You can read about the new functionality in more detail in <a href="https://developers.google.com/web/updates/2016/09/foreign-fetch">this post</a>.
+</p>
+
+{% capture initial_output_content %}
+<div>
+  Try disabling your network connection and then requesting a new number. The
+  foreign fetch service worker should handle the network failure for you,
+  and return a hardcoded value of <code>34</code>.
+</div>
+<button id="random">New Number, Please</button>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='local-client.js' title="Client JavaScript" %}
+{% include js_snippet.html filename='remote-server.js' displayonly=true title="Server Implementation" %}
+{% include js_snippet.html filename='foreign-fetch-sw.js' displayonly=true title="Foreign Fetch Service Worker" %}

--- a/service-worker/foreign-fetch/local-client.js
+++ b/service-worker/foreign-fetch/local-client.js
@@ -1,0 +1,9 @@
+function updateRandom() {
+  fetch('https://foreign-fetch-demo.appspot.com/random')
+    .then(response => response.text())
+    .then(number => ChromeSamples.setStatus(`Your random number is ${number}`));
+}
+
+document.querySelector('#random').addEventListener('click', updateRandom);
+
+updateRandom();

--- a/service-worker/foreign-fetch/package.json
+++ b/service-worker/foreign-fetch/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "foreign-fetch-demo",
+  "version": "1.0.0",
+  "description": "Demo of a /random service that implements foreign fetch.",
+  "private": true,
+  "scripts": {
+    "start": "node app.js"
+  },
+  "author": "Jeff Posnick <jeffy@google.com>",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "express": "^4.14.0"
+  },
+  "engines": {
+    "node": ">=6.5.0"
+  }
+}

--- a/service-worker/foreign-fetch/remote-server.js
+++ b/service-worker/foreign-fetch/remote-server.js
@@ -1,0 +1,38 @@
+// This is the web server implementation for the "random number API".
+// It is currently deployed to https://foreign-fetch-demo.appspot.com
+
+const express = require('express');
+const app = express();
+
+const SW_JS_FILE = 'foreign-fetch-sw.js';
+const MAX_RANDOM_NUMBER = 100;
+
+app.use((req, res, next) => {
+  res.setHeader('Link', `</${SW_JS_FILE}>; rel="serviceworker"`);
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  // To test locally against a service without an Origin Trial token, enable
+  // chrome://flags/#enable-experimental-web-platform-features
+  // on all of the Chrome clients used for testing.
+  // The deployment at https://foreign-fetch-demo.appspot.com has a
+  // token, so it's foreign fetch service worker does not require the flag.
+  // res.setHeader('Origin-Trial', 'your-token-here');
+  return next();
+});
+
+app.get('/random', (req, res) => {
+  var randomNumber = Math.round(Math.random() * MAX_RANDOM_NUMBER);
+  res.send(String(randomNumber));
+});
+
+app.get(`/${SW_JS_FILE}`, (req, res) => {
+  res.sendFile(SW_JS_FILE, {root: '.'});
+});
+
+if (module === require.main) {
+  const server = app.listen(process.env.PORT || 8080, () => {
+    const port = server.address().port;
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
R: @addyosmani @jakearchibald @ebidel @PaulKinlan @beaufortfrancois etc.
CC: @mkruisselbrink

Here's a basic sample illustrating the use of foreign fetch to handle offline use cases for a trivial random-number API.

The code for the service that's checked in here is a copy of what's currently deployed at https://foreign-fetch-demo.appspot.com

Feel free to review at this time, but **DO NOT MERGE** yet, as there's a [serious bug](https://bugs.chromium.org/p/chromium/issues/detail?id=645281) in the current M54 implementation of foreign fetch that will cause the `fetch()` in the service worker to loop for ~10 seconds then fail.

The https://developers.google.com/web/updates/2016/09/foreign-fetch URL referenced in this post also is not live yet (waiting on the same bug to be resovled).
