### PR TITLE
Remove the 'View Source' link from the template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,6 @@ limitations under the License.
     <h1>{% if page.title %}{{ page.title }}{% else %}{{ page.feature_name }} Sample{% endif %}</h1>
     <p class="availability">
       Available in <a target="_blank" href="https://www.chromestatus.com/feature/{{ page.feature_id }}">Chrome {{ page.chrome_version }}+</a> |
-      <a target="_blank" href="view-source:{{ site.gh_pages_url_prefix }}{{ page.url }}">View Source</a> |
       <a target="_blank" href="{{ site.gh_url_prefix }}{{ page.url | remove_first: 'index.html' }}">View on GitHub</a> |
       <a target="_blank" href="https://www.chromestatus.com/samples">Browse Samples</a>
     </p>


### PR DESCRIPTION
R: @beaufortfrancois @addyosmani @ebidel etc.

Chrome 53 has followed the lead of other browsers, and no longer supports links with the `view-source:` scheme. There's no reason to keep it in the template.

The link to view the original source code on GitHub should suffice, and I'm assuming that most developers who are properly motivated will just right-click and choose "View Source"/use the DevTools.

Closes #294
