### PR TITLE
Removed deprecated 'gcm_user_visible_only'

### DIFF
--- a/push-messaging-and-notifications/manifest.sample.json
+++ b/push-messaging-and-notifications/manifest.sample.json
@@ -7,8 +7,5 @@
       }],
   "start_url": "./index.html?homescreen=1",
   "display": "standalone",
-  "gcm_sender_id": "<Your Project Number from https://console.developers.google.com>",
-  
-  "//": "gcm_user_visible_only is only needed until Chrome 44 is in stable ",
-  "gcm_user_visible_only": true
+  "gcm_sender_id": "<Your Project Number from https://console.developers.google.com>"
 }


### PR DESCRIPTION
According to ChromeStatus this key is already deprecated (https://www.chromestatus.com/feature/5778950739460096). Proper code is already put in https://github.com/GoogleChrome/samples/blob/gh-pages/push-messaging-and-notifications/main.js : 119
