### PR TITLE
bluetooth: Add Battery Level ES7 Async sample

### DIFF
--- a/web-bluetooth/battery-level-async-await.html
+++ b/web-bluetooth/battery-level-async-await.html
@@ -1,6 +1,6 @@
 ---
-feature_name: Web Bluetooth / Battery Level
-chrome_version: 45
+feature_name: Web Bluetooth / Battery Level (ES7 Async)
+chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
@@ -14,13 +14,13 @@ information from a nearby Bluetooth Device advertising Battery information with
 Bluetooth Low Energy. You may want to try this demo with the BLE Peripheral
 Simulator App from the <a target="_blank"
 href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
-Play Store</a> and check out the <a href="battery-level-async-await.html">Battery Level (ES7 Async)</a> sample.</p>
+Play Store</a> and check out the <a href="battery-level.html">Battery Level (Promises)</a> sample.</p>
 
 <button>Get Bluetooth Device's Battery Level</button>
 
 {% include output_helper.html %}
 
-{% include js_snippet.html filename='battery-level.js' %}
+{% include js_snippet.html filename='battery-level-async-await.js' %}
 
 <script>
   document.querySelector('button').addEventListener('click', function() {

--- a/web-bluetooth/battery-level-async-await.html
+++ b/web-bluetooth/battery-level-async-await.html
@@ -1,5 +1,5 @@
 ---
-feature_name: Web Bluetooth / Battery Level (ES7 Async)
+feature_name: Web Bluetooth / Battery Level (Async Await)
 chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320

--- a/web-bluetooth/battery-level-async-await.js
+++ b/web-bluetooth/battery-level-async-await.js
@@ -17,7 +17,7 @@ async function onButtonClick() {
     const value = await characteristic.readValue();
 
     log('> Battery Level is ' + value.getUint8(0) + '%');
-  } catch(e) {
+  } catch(error) {
     log('Argh! ' + error);
   }
 }

--- a/web-bluetooth/battery-level-async-await.js
+++ b/web-bluetooth/battery-level-async-await.js
@@ -1,0 +1,23 @@
+async function onButtonClick() {
+  try {
+    log('Requesting Bluetooth Device...');
+    const device = await navigator.bluetooth.requestDevice({
+        filters: [{services: ['battery_service']}]});
+
+    log('Connecting to GATT Server...');
+    const server = await device.gatt.connect();
+
+    log('Getting Battery Service...');
+    const service = await server.getPrimaryService('battery_service');
+
+    log('Getting Battery Level Characteristic...');
+    const characteristic = await service.getCharacteristic('battery_level');
+
+    log('Reading Battery Level...');
+    const value = await characteristic.readValue();
+
+    log('> Battery Level is ' + value.getUint8(0) + '%');
+  } catch(e) {
+    log('Argh! ' + error);
+  }
+}

--- a/web-bluetooth/battery-level.html
+++ b/web-bluetooth/battery-level.html
@@ -14,7 +14,7 @@ information from a nearby Bluetooth Device advertising Battery information with
 Bluetooth Low Energy. You may want to try this demo with the BLE Peripheral
 Simulator App from the <a target="_blank"
 href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
-Play Store</a> and check out the <a href="battery-level-async-await.html">Battery Level (ES7 Async)</a> sample.</p>
+Play Store</a> and check out the <a href="battery-level-async-await.html">Battery Level (Async Await)</a> sample.</p>
 
 <button>Get Bluetooth Device's Battery Level</button>
 

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -14,7 +14,7 @@ for trials</a> so that websites can use it without any flag.</p>
 <h3>Beginner</h3>
 
 <p><a href="device-info.html">Device Info</a> - retrieve basic device information from a BLE Device.</p>
-<p><a href="battery-level.html">Battery Level</a> - retrieve battery information from a BLE Device advertising Battery information (readValue).</p>
+<p><a href="battery-level.html">Battery Level (Promises)</a> / <a href="battery-level-async-await.html">Battery Level (ES7 Async)</a> - retrieve battery information from a BLE Device advertising Battery information (readValue).</p>
 <p><a href="reset-energy.html">Reset Energy</a> - reset energy expended from a BLE Device advertising Heart Rate (writeValue).</p>
 <p><a href="characteristic-properties.html">Characteristic Properties</a> - display all properties of a specific characteristic from a BLE Device.</p>
 <p><a href="notifications.html">Notifications</a> - start and stop characteristic notifications from a BLE Device.</p>

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -14,7 +14,7 @@ for trials</a> so that websites can use it without any flag.</p>
 <h3>Beginner</h3>
 
 <p><a href="device-info.html">Device Info</a> - retrieve basic device information from a BLE Device.</p>
-<p><a href="battery-level.html">Battery Level (Promises)</a> / <a href="battery-level-async-await.html">Battery Level (ES7 Async)</a> - retrieve battery information from a BLE Device advertising Battery information (readValue).</p>
+<p><a href="battery-level.html">Battery Level (Promises)</a> / <a href="battery-level-async-await.html">Battery Level (Async Await)</a> - retrieve battery information from a BLE Device advertising Battery information (readValue).</p>
 <p><a href="reset-energy.html">Reset Energy</a> - reset energy expended from a BLE Device advertising Heart Rate (writeValue).</p>
 <p><a href="characteristic-properties.html">Characteristic Properties</a> - display all properties of a specific characteristic from a BLE Device.</p>
 <p><a href="notifications.html">Notifications</a> - start and stop characteristic notifications from a BLE Device.</p>


### PR DESCRIPTION
With ES7 Async functions (async await) in M55 now, I thought we may want to add a sample on how to use them with the Web Bluetooth API.

@jeffposnick @scheib @jyasskin @g-ortuno

See https://beaufortfrancois.github.io/samples/web-bluetooth/battery-level-async-await.html and https://beaufortfrancois.github.io/samples/web-bluetooth/index.html

![screenshot 2016-10-10 at 2 52 10 pm](https://cloud.githubusercontent.com/assets/634478/19236757/5d440d22-8ef9-11e6-9996-0126d25748bd.png)
