### PR TITLE
Show error in console

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,7 @@ limitations under the License.
       // which don't support specific functionality still end up displaying a meaningful message.
       window.addEventListener('error', function(error) {
         if (ChromeSamples && ChromeSamples.setStatus) {
+          console.error(error);
           ChromeSamples.setStatus(error.message + ' (Your browser may not support this feature.)');
           error.preventDefault();
         }


### PR DESCRIPTION
When there's an error in our code, it is hard to know where it is exactly because of the global error handler. This patch simply shows it in JS Console.

R: @jeffposnick 
