### PR TITLE
Override page index.html for web bluetooth samples

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@ limitations under the License.
     <p class="availability">
       Available in <a target="_blank" href="https://www.chromestatus.com/feature/{{ page.feature_id }}">Chrome {{ page.chrome_version }}+</a> |
       <a target="_blank" href="{{ site.gh_url_prefix }}{{ page.url | remove_first: 'index.html' }}">View on GitHub</a> |
-      <a target="_blank" href="https://www.chromestatus.com/samples">Browse Samples</a>
+      <a {% if page.index == null %}target="_blank"{% endif %} href="{% if page.index %}{{ page.index }}{% else %}https://www.chromestatus.com/samples{% endif %}">Browse Samples</a>
     </p>
     {{ content }}
     {% for local_js_file in page.local_js_files %}<script src="{{ local_js_file }}"></script>{% endfor %}

--- a/web-bluetooth/_includes/intro.html
+++ b/web-bluetooth/_includes/intro.html
@@ -1,10 +1,9 @@
 <p>The <a href="https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web">Web Bluetooth
   API</a> lets websites discover and communicate with devices over the
 Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT). It is
-currently partially implemented in Android M, Chrome OS, Linux, and Mac. Check
-out <a href="index.html">all Web Bluetooth Samples</a>.</p>
+currently partially implemented in Android M, Chrome OS, Linux, and Mac.</p>
 
-<p>Note: Starting in Chrome 53, it is also <a href="https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials">available
+<p>Note: In Chrome 53, it is also <a href="https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#available-for-origin-trials">available
 for trials</a> so that websites can use it without any experimental flag.</p>
 
 <script>

--- a/web-bluetooth/automatic-reconnect-async-await.html
+++ b/web-bluetooth/automatic-reconnect-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/automatic-reconnect.html
+++ b/web-bluetooth/automatic-reconnect.html
@@ -4,6 +4,7 @@ chrome_version: 52
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/battery-level-async-await.html
+++ b/web-bluetooth/battery-level-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/battery-level.html
+++ b/web-bluetooth/battery-level.html
@@ -4,6 +4,7 @@ chrome_version: 45
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/characteristic-properties-async-await.html
+++ b/web-bluetooth/characteristic-properties-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: AnLdgsfq0LCSh86RKcjZxXxRcP0rMTeMBwFNDF/6EIvxrjRARVPMbmJJ7MVIrqkWScDGT1rkdIR07hteek98SQkAAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDc2ODE1NjMwfQ==
 ---
 

--- a/web-bluetooth/characteristic-properties.html
+++ b/web-bluetooth/characteristic-properties.html
@@ -4,6 +4,7 @@ chrome_version: 48
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/device-disconnect-async-await.html
+++ b/web-bluetooth/device-disconnect-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/device-disconnect.html
+++ b/web-bluetooth/device-disconnect.html
@@ -4,6 +4,7 @@ chrome_version: 50
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/device-info-async-await.html
+++ b/web-bluetooth/device-info-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: AnLdgsfq0LCSh86RKcjZxXxRcP0rMTeMBwFNDF/6EIvxrjRARVPMbmJJ7MVIrqkWScDGT1rkdIR07hteek98SQkAAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDc2ODE1NjMwfQ==
 ---
 

--- a/web-bluetooth/device-info.html
+++ b/web-bluetooth/device-info.html
@@ -4,6 +4,7 @@ chrome_version: 45
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/device-information-characteristics-async-await.html
+++ b/web-bluetooth/device-information-characteristics-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/device-information-characteristics.html
+++ b/web-bluetooth/device-information-characteristics.html
@@ -4,6 +4,7 @@ chrome_version: 50
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/discover-services-and-characteristics-async-await.html
+++ b/web-bluetooth/discover-services-and-characteristics-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/discover-services-and-characteristics.html
+++ b/web-bluetooth/discover-services-and-characteristics.html
@@ -4,6 +4,7 @@ chrome_version: 53
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/gap-characteristics-async-await.html
+++ b/web-bluetooth/gap-characteristics-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/gap-characteristics.html
+++ b/web-bluetooth/gap-characteristics.html
@@ -4,6 +4,7 @@ chrome_version: 50
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/get-characteristics-async-await.html
+++ b/web-bluetooth/get-characteristics-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/get-characteristics.html
+++ b/web-bluetooth/get-characteristics.html
@@ -4,6 +4,7 @@ chrome_version: 50
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/link-loss-async-await.html
+++ b/web-bluetooth/link-loss-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/link-loss.html
+++ b/web-bluetooth/link-loss.html
@@ -4,6 +4,7 @@ chrome_version: 50
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/notifications-async-await.html
+++ b/web-bluetooth/notifications-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/notifications.html
+++ b/web-bluetooth/notifications.html
@@ -4,6 +4,7 @@ chrome_version: 48
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/read-characteristic-value-changed-async-await.html
+++ b/web-bluetooth/read-characteristic-value-changed-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 55
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/read-characteristic-value-changed.html
+++ b/web-bluetooth/read-characteristic-value-changed.html
@@ -4,6 +4,7 @@ chrome_version: 48
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 

--- a/web-bluetooth/reset-energy-async-await.html
+++ b/web-bluetooth/reset-energy-async-await.html
@@ -4,6 +4,7 @@ chrome_version: 45
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: AnLdgsfq0LCSh86RKcjZxXxRcP0rMTeMBwFNDF/6EIvxrjRARVPMbmJJ7MVIrqkWScDGT1rkdIR07hteek98SQkAAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDc2ODE1NjMwfQ==
 ---
 

--- a/web-bluetooth/reset-energy.html
+++ b/web-bluetooth/reset-energy.html
@@ -4,6 +4,7 @@ chrome_version: 45
 check_min_version: true
 feature_id: 5264933985976320
 icon_url: icon.png
+index: index.html
 origin_trial: ApmuBcRyiq3qe8VTsn2PzHQEgPZyZby+/54rVKFxsGMhaTw62E1pyMwknN+MFLmaAVMbuCQqelnYE5kzKjC6sQ0AAABheyJvcmlnaW4iOiAiaHR0cHM6Ly9nb29nbGVjaHJvbWUuZ2l0aHViLmlvOjQ0MyIsICJmZWF0dXJlIjogIldlYkJsdWV0b290aCIsICJleHBpcnkiOiAxNDgwMzQ1ODU2fQ==
 ---
 


### PR DESCRIPTION
Hello @jeffposnick, this patch gives the ability for individual samples to override their page index.html so that "Browse Samples" top link is unique.

For instance, all individual Web Bluetooth samples now use https://googlechrome.github.io/samples/web-bluetooth/index.html instead of https://www.chromestatus.com/samples. 
https://googlechrome.github.io/samples/web-bluetooth/index.html still use https://www.chromestatus.com/samples though.
