### PR TITLE
bluetooth: Add acceptAllDevices

### DIFF
--- a/web-bluetooth/_includes/intro.html
+++ b/web-bluetooth/_includes/intro.html
@@ -19,18 +19,35 @@ for trials</a> so that websites can use it without any experimental flag.</p>
 
     inputs.forEach(input => {
       if (searchParams.has(input.id)) {
-        input.value = searchParams.get(input.id);
-      }
-      input.addEventListener('input', function(event) {
-        const newSearchParams = new URL(location).searchParams;
-        if (event.target.value) {
-          newSearchParams.set(input.id, event.target.value);
+        if (input.type == 'checkbox') {
+          input.checked = searchParams.get(input.id);
         } else {
-          newSearchParams.delete(input.id);
+          input.value = searchParams.get(input.id);
         }
-        history.replaceState({}, '', Array.from(newSearchParams).length ?
-            location.pathname + '?' + newSearchParams : location.pathname);
-      });
+      }
+      if (input.type == 'checkbox') {
+        input.addEventListener('change', function(event) {
+          const newSearchParams = new URL(location).searchParams;
+          if (event.target.checked) {
+            newSearchParams.set(input.id, event.target.checked);
+          } else {
+            newSearchParams.delete(input.id);
+          }
+          history.replaceState({}, '', Array.from(newSearchParams).length ?
+              location.pathname + '?' + newSearchParams : location.pathname);
+        });
+      } else {
+        input.addEventListener('input', function(event) {
+          const newSearchParams = new URL(location).searchParams;
+          if (event.target.value) {
+            newSearchParams.set(input.id, event.target.value);
+          } else {
+            newSearchParams.delete(input.id);
+          }
+          history.replaceState({}, '', Array.from(newSearchParams).length ?
+              location.pathname + '?' + newSearchParams : location.pathname);
+        });
+      }
     });
   });
 </script>

--- a/web-bluetooth/_includes/intro.html
+++ b/web-bluetooth/_includes/intro.html
@@ -23,6 +23,7 @@ for trials</a> so that websites can use it without any experimental flag.</p>
           input.checked = searchParams.get(input.id);
         } else {
           input.value = searchParams.get(input.id);
+          input.blur();
         }
       }
       if (input.type == 'checkbox') {

--- a/web-bluetooth/automatic-reconnect-async-await.js
+++ b/web-bluetooth/automatic-reconnect-async-await.js
@@ -5,7 +5,7 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     bluetoothDevice = await navigator.bluetooth.requestDevice({
-        filters: anyNamedDevice()});
+        acceptAllDevices: true});
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
     connect();
   } catch(error) {
@@ -50,14 +50,6 @@ async function exponentialBackoff(max, delay, toTry, success, fail) {
       exponentialBackoff(--max, delay * 2, toTry, success, fail);
     }, delay * 1000);
   }
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }
 
 function time(text) {

--- a/web-bluetooth/automatic-reconnect-async-await.js
+++ b/web-bluetooth/automatic-reconnect-async-await.js
@@ -5,6 +5,7 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     bluetoothDevice = await navigator.bluetooth.requestDevice({
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
         acceptAllDevices: true});
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
     connect();

--- a/web-bluetooth/automatic-reconnect.js
+++ b/web-bluetooth/automatic-reconnect.js
@@ -3,7 +3,7 @@ var bluetoothDevice;
 function onButtonClick() {
   bluetoothDevice = null;
   log('Requesting any Bluetooth Device...');
-  navigator.bluetooth.requestDevice({filters: anyNamedDevice()})
+  navigator.bluetooth.requestDevice({acceptAllDevices: true})
   .then(device => {
     bluetoothDevice = device;
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
@@ -49,14 +49,6 @@ function exponentialBackoff(max, delay, toTry, success, fail) {
       exponentialBackoff(--max, delay * 2, toTry, success, fail);
     }, delay * 1000);
   });
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }
 
 function time(text) {

--- a/web-bluetooth/automatic-reconnect.js
+++ b/web-bluetooth/automatic-reconnect.js
@@ -3,7 +3,9 @@ var bluetoothDevice;
 function onButtonClick() {
   bluetoothDevice = null;
   log('Requesting any Bluetooth Device...');
-  navigator.bluetooth.requestDevice({acceptAllDevices: true})
+  navigator.bluetooth.requestDevice({
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+     acceptAllDevices: true})
   .then(device => {
     bluetoothDevice = device;
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);

--- a/web-bluetooth/device-info-async-await.html
+++ b/web-bluetooth/device-info-async-await.html
@@ -15,9 +15,11 @@ device information from a nearby Bluetooth Low Energy Device. You may want to
 check out the <a href="device-info.html">Device Info (Promises)</a> sample.</p>
 
 <form>
-  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
-  <input id="name" type="text" placeholder="Device Name">
-  <input id="namePrefix" type="text" placeholder="Device Name Prefix">
+  <label for="allDevices">All Devices</label>
+  <input id="allDevices" type="checkbox">
+  <input id="service" type="text" size=17 list="services" placeholder="Bluetooth Service">
+  <input id="name" type="text" size=17 placeholder="Device Name">
+  <input id="namePrefix" type="text" size=17 placeholder="Device Name Prefix">
   <button>Get Bluetooth Device Info</button>
 </form>
 

--- a/web-bluetooth/device-info-async-await.js
+++ b/web-bluetooth/device-info-async-await.js
@@ -19,10 +19,10 @@ async function onButtonClick() {
     filters.push({namePrefix: filterNamePrefix});
   }
 
-  let options = {
-    acceptAllDevices: document.querySelector('#allDevices').checked
-  };
-  if (filters.length) {
+  let options = {};
+  if (document.querySelector('#allDevices').checked) {
+    options.acceptAllDevices = true;
+  } else {
     options.filters = filters;
   }
 

--- a/web-bluetooth/device-info-async-await.js
+++ b/web-bluetooth/device-info-async-await.js
@@ -19,9 +19,17 @@ async function onButtonClick() {
     filters.push({namePrefix: filterNamePrefix});
   }
 
+  let options = {
+    acceptAllDevices: document.querySelector('#allDevices').checked
+  };
+  if (filters.length) {
+    options.filters = filters;
+  }
+
   try {
     log('Requesting Bluetooth Device...');
-    const device = await navigator.bluetooth.requestDevice({filters: filters});
+    log('with ' + JSON.stringify(options));
+    const device = await navigator.bluetooth.requestDevice(options);
 
     log('> Name:             ' + device.name);
     log('> Id:               ' + device.id);

--- a/web-bluetooth/device-info.html
+++ b/web-bluetooth/device-info.html
@@ -16,9 +16,11 @@ check out the <a href="device-info-async-await.html">Device Info (Async
 Await)</a> sample.</p>
 
 <form>
-  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
-  <input id="name" type="text" placeholder="Device Name">
-  <input id="namePrefix" type="text" placeholder="Device Name Prefix">
+  <label for="allDevices">All Devices</label>
+  <input id="allDevices" type="checkbox">
+  <input id="service" type="text" size=17 list="services" placeholder="Bluetooth Service">
+  <input id="name" type="text" size=17 placeholder="Device Name">
+  <input id="namePrefix" type="text" size=17 placeholder="Device Name Prefix">
   <button>Get Bluetooth Device Info</button>
 </form>
 

--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -19,10 +19,10 @@ function onButtonClick() {
     filters.push({namePrefix: filterNamePrefix});
   }
 
-  let options = {
-    acceptAllDevices: document.querySelector('#allDevices').checked
-  };
-  if (filters.length) {
+  let options = {};
+  if (document.querySelector('#allDevices').checked) {
+    options.acceptAllDevices = true;
+  } else {
     options.filters = filters;
   }
 

--- a/web-bluetooth/device-info.js
+++ b/web-bluetooth/device-info.js
@@ -19,8 +19,16 @@ function onButtonClick() {
     filters.push({namePrefix: filterNamePrefix});
   }
 
+  let options = {
+    acceptAllDevices: document.querySelector('#allDevices').checked
+  };
+  if (filters.length) {
+    options.filters = filters;
+  }
+
   log('Requesting Bluetooth Device...');
-  navigator.bluetooth.requestDevice({filters: filters})
+  log('with ' + JSON.stringify(options));
+  navigator.bluetooth.requestDevice(options)
   .then(device => {
     log('> Name:             ' + device.name);
     log('> Id:               ' + device.id);

--- a/web-bluetooth/device-information-characteristics-async-await.js
+++ b/web-bluetooth/device-information-characteristics-async-await.js
@@ -2,7 +2,7 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        filters: anyNamedDevice(), optionalServices: ['device_information']});
+        acceptAllDevices: true, optionalServices: ['device_information']});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();
@@ -104,12 +104,4 @@ function getUsbVendorName(value) {
   // Check out page source to see what valueToUsbVendorName object is.
   return value +
       (value in valueToUsbVendorName ? ' (' + valueToUsbVendorName[value] + ')' : '');
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/device-information-characteristics-async-await.js
+++ b/web-bluetooth/device-information-characteristics-async-await.js
@@ -2,7 +2,9 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        acceptAllDevices: true, optionalServices: ['device_information']});
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true,
+        optionalServices: ['device_information']});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();

--- a/web-bluetooth/device-information-characteristics.js
+++ b/web-bluetooth/device-information-characteristics.js
@@ -1,7 +1,7 @@
 function onButtonClick() {
   log('Requesting any Bluetooth Device...');
-  navigator.bluetooth.requestDevice(
-    {filters: anyNamedDevice(), optionalServices: ['device_information']})
+  navigator.bluetooth.requestDevice({
+      acceptAllDevices: true, optionalServices: ['device_information']})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();
@@ -109,12 +109,4 @@ function getUsbVendorName(value) {
   // Check out page source to see what valueToUsbVendorName object is.
   return value +
       (value in valueToUsbVendorName ? ' (' + valueToUsbVendorName[value] + ')' : '');
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/device-information-characteristics.js
+++ b/web-bluetooth/device-information-characteristics.js
@@ -1,7 +1,9 @@
 function onButtonClick() {
   log('Requesting any Bluetooth Device...');
   navigator.bluetooth.requestDevice({
-      acceptAllDevices: true, optionalServices: ['device_information']})
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: ['device_information']})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();

--- a/web-bluetooth/discover-services-and-characteristics-async-await.js
+++ b/web-bluetooth/discover-services-and-characteristics-async-await.js
@@ -7,7 +7,9 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        acceptAllDevices: true, optionalServices: optionalServices});
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true,
+        optionalServices: optionalServices});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();

--- a/web-bluetooth/discover-services-and-characteristics-async-await.js
+++ b/web-bluetooth/discover-services-and-characteristics-async-await.js
@@ -7,7 +7,7 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        filters: anyNamedDevice(), optionalServices: optionalServices});
+        acceptAllDevices: true, optionalServices: optionalServices});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();
@@ -42,12 +42,4 @@ function getSupportedProperties(characteristic) {
     }
   }
   return '[' + supportedProperties.join(', ') + ']';
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/discover-services-and-characteristics.js
+++ b/web-bluetooth/discover-services-and-characteristics.js
@@ -5,8 +5,8 @@ function onButtonClick() {
     .filter(s => s && BluetoothUUID.getService);
 
   log('Requesting any Bluetooth Device...');
-  navigator.bluetooth.requestDevice(
-    {filters: anyNamedDevice(), optionalServices: optionalServices})
+  navigator.bluetooth.requestDevice({
+      acceptAllDevices: true, optionalServices: optionalServices})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();
@@ -46,12 +46,4 @@ function getSupportedProperties(characteristic) {
     }
   }
   return '[' + supportedProperties.join(', ') + ']';
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/discover-services-and-characteristics.js
+++ b/web-bluetooth/discover-services-and-characteristics.js
@@ -6,7 +6,9 @@ function onButtonClick() {
 
   log('Requesting any Bluetooth Device...');
   navigator.bluetooth.requestDevice({
-      acceptAllDevices: true, optionalServices: optionalServices})
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: optionalServices})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();

--- a/web-bluetooth/gap-characteristics-async-await.js
+++ b/web-bluetooth/gap-characteristics-async-await.js
@@ -2,7 +2,7 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        filters: anyNamedDevice(), optionalServices: ['generic_access']});
+        acceptAllDevices: true, optionalServices: ['generic_access']});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();
@@ -96,12 +96,4 @@ function getDeviceType(value) {
   // Check out page source to see what valueToDeviceType object is.
   return value +
       (value in valueToDeviceType ? ' (' + valueToDeviceType[value] + ')' : '');
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/gap-characteristics-async-await.js
+++ b/web-bluetooth/gap-characteristics-async-await.js
@@ -2,7 +2,9 @@ async function onButtonClick() {
   try {
     log('Requesting any Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        acceptAllDevices: true, optionalServices: ['generic_access']});
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true,
+        optionalServices: ['generic_access']});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();

--- a/web-bluetooth/gap-characteristics.js
+++ b/web-bluetooth/gap-characteristics.js
@@ -1,7 +1,9 @@
 function onButtonClick() {
   log('Requesting any Bluetooth Device...');
   navigator.bluetooth.requestDevice({
-      acceptAllDevices: true, optionalServices: ['generic_access']})
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: ['generic_access']})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();

--- a/web-bluetooth/gap-characteristics.js
+++ b/web-bluetooth/gap-characteristics.js
@@ -1,7 +1,7 @@
 function onButtonClick() {
   log('Requesting any Bluetooth Device...');
-  navigator.bluetooth.requestDevice(
-    {filters: anyNamedDevice(), optionalServices: ['generic_access']})
+  navigator.bluetooth.requestDevice({
+      acceptAllDevices: true, optionalServices: ['generic_access']})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();
@@ -106,12 +106,4 @@ function getDeviceType(value) {
   // Check out page source to see what valueToDeviceType object is.
   return value +
       (value in valueToDeviceType ? ' (' + valueToDeviceType[value] + ')' : '');
-}
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/link-loss-async-await.js
+++ b/web-bluetooth/link-loss-async-await.js
@@ -4,7 +4,9 @@ async function onReadButtonClick() {
   try {
     log('Requesting Bluetooth Device...');
     const device = await navigator.bluetooth.requestDevice({
-        filters: [{services: ['link_loss']}]});
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true,
+        optionalServices: ['link_loss']});
 
     log('Connecting to GATT Server...');
     const server = await device.gatt.connect();

--- a/web-bluetooth/link-loss.js
+++ b/web-bluetooth/link-loss.js
@@ -2,7 +2,10 @@ var alertLevelCharacteristic;
 
 function onReadButtonClick() {
   log('Requesting Bluetooth Device...');
-  navigator.bluetooth.requestDevice({filters: [{services: ['link_loss']}]})
+  navigator.bluetooth.requestDevice({
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: ['link_loss']})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();

--- a/web-bluetooth/read-characteristic-value-changed-async-await.js
+++ b/web-bluetooth/read-characteristic-value-changed-async-await.js
@@ -16,9 +16,11 @@ async function onReadBatteryLevelButtonClick() {
 }
 
 async function requestDevice() {
-  log('Requesting Bluetooth Device...');
+  log('Requesting any Bluetooth Device...');
   bluetoothDevice = await navigator.bluetooth.requestDevice({
-      acceptAllDevices: true, optionalServices: ['battery_service']});
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: ['battery_service']});
   bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
 }
 

--- a/web-bluetooth/read-characteristic-value-changed-async-await.js
+++ b/web-bluetooth/read-characteristic-value-changed-async-await.js
@@ -18,7 +18,7 @@ async function onReadBatteryLevelButtonClick() {
 async function requestDevice() {
   log('Requesting Bluetooth Device...');
   bluetoothDevice = await navigator.bluetooth.requestDevice({
-      filters: anyNamedDevice(), optionalServices: ['battery_service']});
+      acceptAllDevices: true, optionalServices: ['battery_service']});
   bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
 }
 
@@ -94,15 +94,4 @@ async function onDisconnected() {
   } catch(error) {
     log('Argh! ' + error);
   }
-}
-
-
-/* Utils */
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/read-characteristic-value-changed.js
+++ b/web-bluetooth/read-characteristic-value-changed.js
@@ -15,8 +15,8 @@ function onReadBatteryLevelButtonClick() {
 
 function requestDevice() {
   log('Requesting Bluetooth Device...');
-  return navigator.bluetooth.requestDevice(
-    {filters: anyNamedDevice(), optionalServices: ['battery_service']})
+  return navigator.bluetooth.requestDevice({
+      acceptAllDevices: true, optionalServices: ['battery_service']})
   .then(device => {
     bluetoothDevice = device;
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);
@@ -98,14 +98,4 @@ function onDisconnected() {
   .catch(error => {
     log('Argh! ' + error);
   });
-}
-
-/* Utils */
-
-function anyNamedDevice() {
-  // This is the closest we can get for now to get all devices.
-  // https://github.com/WebBluetoothCG/web-bluetooth/issues/234
-  return Array.from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-      .map(c => ({namePrefix: c}))
-      .concat({name: ''});
 }

--- a/web-bluetooth/read-characteristic-value-changed.js
+++ b/web-bluetooth/read-characteristic-value-changed.js
@@ -14,9 +14,11 @@ function onReadBatteryLevelButtonClick() {
 }
 
 function requestDevice() {
-  log('Requesting Bluetooth Device...');
+  log('Requesting any Bluetooth Device...');
   return navigator.bluetooth.requestDevice({
-      acceptAllDevices: true, optionalServices: ['battery_service']})
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: ['battery_service']})
   .then(device => {
     bluetoothDevice = device;
     bluetoothDevice.addEventListener('gattserverdisconnected', onDisconnected);


### PR DESCRIPTION
You can give a try to this updated samples at https://beaufortfrancois.github.io/samples/web-bluetooth.

https://beaufortfrancois.github.io/samples/web-bluetooth/device-info.html and any sample previously using `anyNamedDevice` have been updated to use `acceptAllDevices`.

R: @g-ortuno @jeffposnick 