### PR TITLE
Fix app basic install banner output element

### DIFF
--- a/app-install-banner/basic-banner/index.html
+++ b/app-install-banner/basic-banner/index.html
@@ -57,7 +57,11 @@ limitations under the License.
       <li>The manifest has a <code>short_name</code>, 144 pixel icon and a type of 'image/png'</li>
     </ul>
 
+    <p>In this example you will see below a message indicating that the beforeinstallprompt was fired.</p>
+
+    <pre id=output></pre>
+
     <p>To see if this example works, come back in another day and you will see the banner.</p>
     <p>For testing we encourage you to force the banner to appear by setting the chrome://flags/#bypass-app-banner-engagement-checks flag.</p>
   </body>
-</head>
+</html>

--- a/app-install-banner/basic-banner/index.html
+++ b/app-install-banner/basic-banner/index.html
@@ -57,9 +57,9 @@ limitations under the License.
       <li>The manifest has a <code>short_name</code>, 144 pixel icon and a type of 'image/png'</li>
     </ul>
 
-    <p>In this example you will see below a message indicating that the beforeinstallprompt was fired.</p>
+    <p>In this example you will see below a message indicating that the <code>beforeinstallprompt</code> event was fired.</p>
 
-    <pre id=output></pre>
+    <pre id="output"></pre>
 
     <p>To see if this example works, come back in another day and you will see the banner.</p>
     <p>For testing we encourage you to force the banner to appear by setting the chrome://flags/#bypass-app-banner-engagement-checks flag.</p>


### PR DESCRIPTION
This PR adds the missing `#output` element used in the script (`var outputElement = document.getElementById('output');`).