### PR TITLE
Web Payments API update.

### DIFF
--- a/paymentrequest/README.md
+++ b/paymentrequest/README.md
@@ -1,24 +1,28 @@
 # PaymentRequest Recipes
 
-- [Credit cards](https://googlechrome.github.io/samples/paymentrequest/credit-cards/index.html) -
+- [Credit cards](https://googlechrome.github.io/samples/paymentrequest/credit-cards/) -
 a sample that accepts credit card payments and does not request shipping
 information.
 
-- [Android Pay](https://googlechrome.github.io/samples/paymentrequest/android-pay/index.html) -
+- [Android Pay](https://googlechrome.github.io/samples/paymentrequest/android-pay/) -
 a sample that accepts Android Pay payments and does not request shipping
 information.
 
-- [Free shipping](https://googlechrome.github.io/samples/paymentrequest/free-shipping/index.html) -
+- [Free shipping](https://googlechrome.github.io/samples/paymentrequest/free-shipping/) -
 a sample that accepts credit card payments and provides free shipping worldwide.
 
-- [Shipping options](https://googlechrome.github.io/samples/paymentrequest/shipping-options/index.html) -
+- [Shipping options](https://googlechrome.github.io/samples/paymentrequest/shipping-options/) -
 a sample that accepts credit card payments and provides a couple of shipping
 options regardless of shipping address.
 
-- [Dynamic shipping options](https://googlechrome.github.io/samples/paymentrequest/dynamic-shipping/index.html) -
+- [Dynamic shipping options](https://googlechrome.github.io/samples/paymentrequest/dynamic-shipping/) -
 a sample that accepts credit card payments and varies the availability and price
 of shipping options depending on the shipping address.
 
-- [Contact info](https://googlechrome.github.io/samples/paymentrequest/contact-info/index.html) -
+- [Contact info](https://googlechrome.github.io/samples/paymentrequest/contact-info/) -
 a sample that accepts credit card payments and requests user's contact
-information: phone number and email address.
+information: name, phone number, and email address.
+
+- [Can make payment](https://googlechrome.github.io/samples/paymentrequest/can-make-payment/) -
+a sample that accepts both Android Pay and credit card payments and checks
+whether the browser can make payment.

--- a/paymentrequest/can-make-payment/demo.js
+++ b/paymentrequest/can-make-payment/demo.js
@@ -1,0 +1,180 @@
+/**
+ * The callback for successful creation of PaymentRequest.
+ *
+ * @callback successCallback
+ * @param {PaymentRequest} request The newly created instance of PaymentRequest
+ * object.
+ * @param {string} optionalWarning The optional warning message to be used, for
+ * example, when unable to determine whether the browser can make payments.
+ */
+
+/**
+ * The callback for failed creation of PaymentRequest.
+ *
+ * @callback failureCallback
+ * @param {string} error The message indicating the reason why an instance of
+ * PaymentRequest was not created.
+ */
+
+/**
+ * Asynchronously builds PaymentRequest for both Android Pay and credit card
+ * payments, but does not show any UI yet. Succeeds only if can make payments.
+ * If you encounter issues when running your own copy of this sample, run 'adb
+ * logcat | grep Wallet' to see detailed error messages.
+ *
+ * @param {successCallback} onSuccess The callback to invoke when this function
+ * is finished successfully.
+ * @param {failureCallback} onFailure The callback to invoke when this function
+ * is finished with failure.
+ */
+function initPaymentRequest(onSuccess, onFailure) {
+  if (!navigator.userAgent.match(/Android/i)) {
+    onFailure('Supported only on Android for now.');
+    return;
+  }
+
+  if (!('PaymentRequest' in window)) {
+    onFailure('This browser does not support web payments.');
+    return;
+  }
+
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: ['https://android.com/pay'],
+    data: {
+      merchantName: 'Android Pay Demo',
+      // Place your own Android Pay merchant ID here. The merchant ID is tied to
+      // the origin of the website.
+      merchantId: '00184145120947117657',
+      // If you do not yet have a merchant ID, uncomment the following line.
+      // environment: 'TEST',
+      allowedCardNetworks: ['AMEX', 'DISCOVER', 'MASTERCARD', 'VISA'],
+      paymentMethodTokenizationParameters: {
+        tokenizationType: 'GATEWAY_TOKEN',
+        parameters: {
+          'gateway': 'stripe',
+          // Place your own Stripe publishable key here. Use a matching Stripe
+          // secret key on the server to initiate a transaction.
+          'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
+          'stripe:version': '2016-07-06',
+        },
+      },
+    },
+  }, {
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
+    data: {supportedNetworks: networks, supportedTypes: types},
+  }];
+
+  let details = {
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
+      {
+        label: 'Original donation amount',
+        amount: {currency: 'USD', value: '65.00'},
+      },
+      {
+        label: 'Friends and family discount',
+        amount: {currency: 'USD', value: '-10.00'},
+      },
+    ],
+  };
+
+  let request = new PaymentRequest(supportedInstruments, details);
+
+  if (request.canMakePayment) {
+    request.canMakePayment().then(function(result) {
+      if (result) {
+        onSuccess(request);
+      } else {
+        onFailure('Cannot make payment');
+      }
+    }).catch(function(err) {
+      onSuccess(request, err);
+    });
+  } else {
+    onSuccess(
+        request, 'This browser does not support "can make payment" query');
+  }
+}
+
+/**
+ * Invokes PaymentRequest for Android Pay.
+ *
+ * @param {PaymentRequest} request The PaymentRequest object.
+ */
+function onBuyClicked(request) {
+  request.show().then(function(instrumentResponse) {
+    sendPaymentToServer(instrumentResponse);
+  })
+  .catch(function(err) {
+    ChromeSamples.setStatus(err);
+  });
+}
+
+/**
+ * Simulates processing the payment data on the server.
+ *
+ * @param {PaymentResponse} instrumentResponse The payment information to
+ * process.
+ */
+function sendPaymentToServer(instrumentResponse) {
+  // There's no server-side component of these samples. No transactions are
+  // processed and no money exchanged hands. Instantaneous transactions are not
+  // realistic. Add a 2 second delay to make it seem more real.
+  window.setTimeout(function() {
+    instrumentResponse.complete('success')
+        .then(function() {
+          document.getElementById('result').innerHTML =
+              instrumentToJsonString(instrumentResponse);
+        })
+        .catch(function(err) {
+          ChromeSamples.setStatus(err);
+        });
+  }, 2000);
+}
+
+/**
+ * Converts the payment instrument into a JSON string.
+ *
+ * @param {PaymentResponse} instrument The instrument to convert.
+ * @return {string} The JSON string representation of the instrument.
+ */
+function instrumentToJsonString(instrument) {
+  if (instrument.toJSON) {
+    return JSON.stringify(instrument, undefined, 2);
+  } else {
+    return JSON.stringify({
+      methodName: instrument.methodName,
+      details: instrument.details,
+    }, undefined, 2);
+  }
+}
+
+/**
+ * Initializes the buy button.
+ *
+ * @param {HTMLElement} buyButton The "Buy" button to initialize.
+ */
+function initBuyButton(buyButton) {
+  initPaymentRequest(function(request, optionalWarning) {
+    buyButton.setAttribute('style', 'display: inline;');
+    ChromeSamples.setStatus(optionalWarning ? optionalWarning : '');
+    buyButton.addEventListener('click', function handleClick() {
+      buyButton.removeEventListener('click', handleClick);
+      onBuyClicked(request);
+      initBuyButton(buyButton);
+    });
+  }, function(error) {
+    buyButton.setAttribute('style', 'display: none;');
+    ChromeSamples.setStatus(error);
+  });
+}
+
+const buyButton = document.getElementById('buyButton');
+buyButton.setAttribute('style', 'display: none;');
+ChromeSamples.setStatus('Checking...');
+initBuyButton(buyButton);

--- a/paymentrequest/can-make-payment/index.html
+++ b/paymentrequest/can-make-payment/index.html
@@ -1,6 +1,6 @@
 ---
-feature_name: PaymentRequest Contact Info
-chrome_version: 53
+feature_name: PaymentRequest Can Make Payment
+chrome_version: 56
 feature_id: 5639348045217792
 ---
 
@@ -11,8 +11,8 @@ feature_id: 5639348045217792
 </p>
 
 <p>
-  This sample accepts credit card payments and requests payer's contact
-  information: name, phone number, and email address.
+  This sample accepts both Android Pay and credit card payments and checks
+  whether the browser can make payment.
 </p>
 
 {% capture initial_output_content %}

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -1,36 +1,55 @@
 /**
- * Invokes PaymentRequest that also gathers user's contact information.
+ * Builds PaymentRequest that also gathers user's contact information, but does
+ * not show any UI yet.
+ *
+ * @return {PaymentRequest} The PaymentRequest object.
  */
-function onBuyClicked() {
-  var supportedInstruments = [{
-    supportedMethods: ['amex', 'diners', 'discover', 'jcb', 'mastercard',
-        'unionpay', 'visa']
+function initPaymentRequest() {
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
+    data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
-  var details = {
+  let details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
     displayItems: [
       {
         label: 'Original donation amount',
-        amount: {currency: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'},
       },
       {
         label: 'Friends and family discount',
-        amount: {currency: 'USD', value: '-10.00'}
-      }
-    ]
+        amount: {currency: 'USD', value: '-10.00'},
+      },
+    ],
   };
 
-  var options = {requestPayerPhone: true, requestPayerEmail: true};
+  let options = {
+    requestPayerName: true,
+    requestPayerPhone: true,
+    requestPayerEmail: true,
+  };
 
-  new PaymentRequest(supportedInstruments, details, options) // eslint-disable-line no-undef
-      .show()
-      .then(function(instrumentResponse) {
-        sendPaymentToServer(instrumentResponse);
-      })
-      .catch(function(err) {
-        ChromeSamples.setStatus(err);
-      });
+  return new PaymentRequest(supportedInstruments, details, options);
+}
+
+/**
+ * Invokes PaymentRequest that also gathers user's contact information.
+ *
+ * @param {PaymentRequest} request The PaymentRequest object.
+ */
+function onBuyClicked(request) {
+  request.show().then(function(instrumentResponse) {
+    sendPaymentToServer(instrumentResponse);
+  })
+  .catch(function(err) {
+    ChromeSamples.setStatus(err);
+  });
 }
 
 /**
@@ -41,7 +60,7 @@ function onBuyClicked() {
  * process.
  */
 function sendPaymentToServer(instrumentResponse) {
-  // There's no server-side component of these samples. Not transactions are
+  // There's no server-side component of these samples. No transactions are
   // processed and no money exchanged hands. Instantaneous transactions are not
   // realistic. Add a 2 second delay to make it seem more real.
   window.setTimeout(function() {
@@ -64,25 +83,30 @@ function sendPaymentToServer(instrumentResponse) {
  * @return {string} The JSON string representation of the instrument.
  */
 function instrumentToJsonString(instrument) {
-  var details = instrument.details;
+  let details = instrument.details;
   details.cardNumber = 'XXXX-XXXX-XXXX-' + details.cardNumber.substr(12);
   details.cardSecurityCode = '***';
 
-  // PaymentInsrument is an interface, but JSON.stringify works only on
-  // dictionaries.
   return JSON.stringify({
     methodName: instrument.methodName,
     details: details,
+    payerName: instrument.payerName,
     payerPhone: instrument.payerPhone,
-    payerEmail: instrument.payerEmail
+    payerEmail: instrument.payerEmail,
   }, undefined, 2);
 }
 
-var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+const buyButton = document.getElementById('buyButton');
+buyButton.setAttribute('style', 'display: none;');
+if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus('Supported only on Android for now.');
+} else if ('PaymentRequest' in window) {
+  let request = initPaymentRequest();
   buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', onBuyClicked);
+  buyButton.addEventListener('click', function() {
+    onBuyClicked(request);
+    request = initPaymentRequest();
+  });
 } else {
-  buyButton.setAttribute('style', 'display: none;');
   ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -1,34 +1,48 @@
 /**
- * Invokes PaymentRequest for credit cards.
+ * Builds PaymentRequest for credit cards, but does not show any UI yet.
+ *
+ * @return {PaymentRequest} The PaymentRequest oject.
  */
-function onBuyClicked() {
-  var supportedInstruments = [{
-    supportedMethods: ['amex', 'diners', 'discover', 'jcb', 'mastercard',
-        'unionpay', 'visa']
+function initPaymentRequest() {
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
+    data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
-  var details = {
+  let details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
     displayItems: [
       {
         label: 'Original donation amount',
-        amount: {currency: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'},
       },
       {
         label: 'Friends and family discount',
-        amount: {currency: 'USD', value: '-10.00'}
-      }
-    ]
+        amount: {currency: 'USD', value: '-10.00'},
+      },
+    ],
   };
 
-  new PaymentRequest(supportedInstruments, details) // eslint-disable-line no-undef
-      .show()
-      .then(function(instrumentResponse) {
-        sendPaymentToServer(instrumentResponse);
-      })
-      .catch(function(err) {
-        ChromeSamples.setStatus(err);
-      });
+  return new PaymentRequest(supportedInstruments, details);
+}
+
+/**
+ * Invokes PaymentRequest for credit cards.
+ *
+ * @param {PaymentRequest} request The PaymentRequest object.
+ */
+function onBuyClicked(request) {
+  request.show().then(function(instrumentResponse) {
+    sendPaymentToServer(instrumentResponse);
+  })
+  .catch(function(err) {
+    ChromeSamples.setStatus(err);
+  });
 }
 
 /**
@@ -38,7 +52,7 @@ function onBuyClicked() {
  * process.
  */
 function sendPaymentToServer(instrumentResponse) {
-  // There's no server-side component of these samples. Not transactions are
+  // There's no server-side component of these samples. No transactions are
   // processed and no money exchanged hands. Instantaneous transactions are not
   // realistic. Add a 2 second delay to make it seem more real.
   window.setTimeout(function() {
@@ -61,23 +75,27 @@ function sendPaymentToServer(instrumentResponse) {
  * @return {string} The JSON string representation of the instrument.
  */
 function instrumentToJsonString(instrument) {
-  var details = instrument.details;
+  let details = instrument.details;
   details.cardNumber = 'XXXX-XXXX-XXXX-' + details.cardNumber.substr(12);
   details.cardSecurityCode = '***';
 
-  // PaymentInsrument is an interface, but JSON.stringify works only on
-  // dictionaries.
   return JSON.stringify({
     methodName: instrument.methodName,
-    details: details
+    details: details,
   }, undefined, 2);
 }
 
-var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+const buyButton = document.getElementById('buyButton');
+buyButton.setAttribute('style', 'display: none;');
+if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus('Supported only on Android for now.');
+} else if ('PaymentRequest' in window) {
+  let request = initPaymentRequest();
   buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', onBuyClicked);
+  buyButton.addEventListener('click', function() {
+    onBuyClicked(request);
+    request = initPaymentRequest();
+  });
 } else {
-  buyButton.setAttribute('style', 'display: none;');
   ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -1,29 +1,42 @@
 /**
- * Invokes PaymentRequest with dynamic shipping price calculation.
+ * Builds PaymentRequest with dynamic shipping price calculation, but does not
+ * show any UI yet.
+ *
+ * @return {PaymentRequest} The PaymentRequest object.
  */
-function onBuyClicked() {
-  var supportedInstruments = [{
-    supportedMethods: ['amex', 'diners', 'discover', 'jcb', 'mastercard',
-        'unionpay', 'visa']
+function initPaymentRequest() {
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
+    data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
-  var details = {
+  let details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
     displayItems: [
       {
         label: 'Original donation amount',
-        amount: {currency: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'},
+      },
+      {
+        label: 'Shipping',
+        amount: {currency: 'USD', value: '0.00'},
+        pending: true,
       },
       {
         label: 'Friends and family discount',
-        amount: {currency: 'USD', value: '-10.00'}
-      }
-    ]
+        amount: {currency: 'USD', value: '-10.00'},
+      },
+    ],
   };
 
-  var options = {requestShipping: true};
+  let options = {requestShipping: true};
 
-  var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
+  let request = new PaymentRequest(supportedInstruments, details, options);
 
   request.addEventListener('shippingaddresschange', function(evt) {
     evt.updateWith(new Promise(function(resolve) {
@@ -31,6 +44,15 @@ function onBuyClicked() {
     }));
   });
 
+  return request;
+}
+
+/**
+ * Invokes PaymentRequest with dynamic shipping price calculation.
+ *
+ * @param {PaymentRequest} request The PaymentRequest object.
+ */
+function onBuyClicked(request) {
   request.show().then(function(instrumentResponse) {
     sendPaymentToServer(instrumentResponse);
   })
@@ -50,13 +72,14 @@ function onBuyClicked() {
  * shipping options.
  */
 function updateDetails(details, shippingAddress, callback) {
+  let shippingOption = {
+    id: '',
+    label: '',
+    amount: {currency: 'USD', value: '0.00'},
+    selected: true,
+    pending: false,
+  };
   if (shippingAddress.country === 'US') {
-    var shippingOption = {
-      id: '',
-      label: '',
-      amount: {currency: 'USD', value: '0.00'},
-      selected: true
-    };
     if (shippingAddress.region === 'CA') {
       shippingOption.id = 'californiaFreeShipping';
       shippingOption.label = 'Free shipping in California';
@@ -67,12 +90,17 @@ function updateDetails(details, shippingAddress, callback) {
       shippingOption.amount.value = '5.00';
       details.total.amount.value = '60.00';
     }
-    details.displayItems.splice(2, 1, shippingOption);
     details.shippingOptions = [shippingOption];
+    delete details.error;
   } else {
     // Don't ship outside of US for the purposes of this example.
+    shippingOption.label = 'Shipping';
+    shippingOption.pending = true;
+    details.total.amount.value = '55.00';
+    details.error = 'Cannot ship outside of US.';
     delete details.shippingOptions;
   }
+  details.displayItems.splice(1, 1, shippingOption);
   callback(details);
 }
 
@@ -84,7 +112,7 @@ function updateDetails(details, shippingAddress, callback) {
  * process.
  */
 function sendPaymentToServer(instrumentResponse) {
-  // There's no server-side component of these samples. Not transactions are
+  // There's no server-side component of these samples. No transactions are
   // processed and no money exchanged hands. Instantaneous transactions are not
   // realistic. Add a 2 second delay to make it seem more real.
   window.setTimeout(function() {
@@ -107,17 +135,15 @@ function sendPaymentToServer(instrumentResponse) {
  * @return {string} The JSON string representation of the instrument.
  */
 function instrumentToJsonString(instrument) {
-  var details = instrument.details;
+  let details = instrument.details;
   details.cardNumber = 'XXXX-XXXX-XXXX-' + details.cardNumber.substr(12);
   details.cardSecurityCode = '***';
 
-  // PaymentInsrument is an interface, but JSON.stringify works only on
-  // dictionaries.
   return JSON.stringify({
     methodName: instrument.methodName,
     details: details,
     shippingAddress: addressToDictionary(instrument.shippingAddress),
-    shippingOption: instrument.shippingOption
+    shippingOption: instrument.shippingOption,
   }, undefined, 2);
 }
 
@@ -129,6 +155,10 @@ function instrumentToJsonString(instrument) {
  * @return {object} The dictionary representation of the shipping address.
  */
 function addressToDictionary(address) {
+  if (address.toJSON) {
+    return address.toJSON();
+  }
+
   return {
     recipient: address.recipient,
     organization: address.organization,
@@ -140,15 +170,21 @@ function addressToDictionary(address) {
     sortingCode: address.sortingCode,
     country: address.country,
     languageCode: address.languageCode,
-    phone: address.phone
+    phone: address.phone,
   };
 }
 
-var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+const buyButton = document.getElementById('buyButton');
+buyButton.setAttribute('style', 'display: none;');
+if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus('Supported only on Android for now.');
+} else if ('PaymentRequest' in window) {
+  let request = initPaymentRequest();
   buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', onBuyClicked);
+  buyButton.addEventListener('click', function() {
+    onBuyClicked(request);
+    request = initPaymentRequest();
+  });
 } else {
-  buyButton.setAttribute('style', 'display: none;');
   ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -1,51 +1,67 @@
 /**
- * Invokes PaymentRequest that also gathers user's shipping address.
+ * Builds PaymentRequest that also gathers user's shipping address, but does not
+ * show any UI yet.
+ *
+ * @return {PaymentRequest} The PaymentRequest object.
  */
-function onBuyClicked() {
-  var supportedInstruments = [{
-    supportedMethods: ['amex', 'diners', 'discover', 'jcb', 'mastercard',
-        'unionpay', 'visa']
+function initPaymentRequest() {
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
+    data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
-  var details = {
+  let details = {
     total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
     displayItems: [
       {
         label: 'Original donation amount',
-        amount: {currency: 'USD', value: '65.00'}
+        amount: {currency: 'USD', value: '65.00'},
       },
       {
         label: 'Friends and family discount',
-        amount: {currency: 'USD', value: '-10.00'}
+        amount: {currency: 'USD', value: '-10.00'},
       },
       {
         label: 'Free shipping worldwide',
-        amount: {currency: 'USD', value: '0.00'}
-      }
+        amount: {currency: 'USD', value: '0.00'},
+      },
     ],
     shippingOptions: [{
       id: 'freeWorldwideShipping',
       label: 'Free shipping worldwide',
       amount: {currency: 'USD', value: '0.00'},
-      selected: true
-    }]
+      selected: true,
+    }],
   };
 
-  var options = {requestShipping: true};
+  let options = {requestShipping: true};
 
-  var request = new PaymentRequest(supportedInstruments, details, options); // eslint-disable-line no-undef
+  let request = new PaymentRequest(supportedInstruments, details, options);
 
   request.addEventListener('shippingaddresschange', function(evt) {
     evt.updateWith(Promise.resolve(details));
   });
 
-  request.show()
-      .then(function(instrumentResponse) {
-        sendPaymentToServer(instrumentResponse);
-      })
-      .catch(function(err) {
-        ChromeSamples.setStatus(err);
-      });
+  return request;
+}
+
+/**
+ * Invokes PaymentRequest that also gathers user's shipping address.
+ *
+ * @param {PaymentRequest} request The PaymentRequest object.
+ */
+function onBuyClicked(request) {
+  request.show().then(function(instrumentResponse) {
+    sendPaymentToServer(instrumentResponse);
+  })
+  .catch(function(err) {
+    ChromeSamples.setStatus(err);
+  });
 }
 
 /**
@@ -56,7 +72,7 @@ function onBuyClicked() {
  * process.
  */
 function sendPaymentToServer(instrumentResponse) {
-  // There's no server-side component of these samples. Not transactions are
+  // There's no server-side component of these samples. No transactions are
   // processed and no money exchanged hands. Instantaneous transactions are not
   // realistic. Add a 2 second delay to make it seem more real.
   window.setTimeout(function() {
@@ -79,17 +95,15 @@ function sendPaymentToServer(instrumentResponse) {
  * @return {string} The JSON string representation of the instrument.
  */
 function instrumentToJsonString(instrument) {
-  var details = instrument.details;
+  let details = instrument.details;
   details.cardNumber = 'XXXX-XXXX-XXXX-' + details.cardNumber.substr(12);
   details.cardSecurityCode = '***';
 
-  // PaymentInsrument is an interface, but JSON.stringify works only on
-  // dictionaries.
   return JSON.stringify({
     methodName: instrument.methodName,
     details: details,
     shippingAddress: addressToDictionary(instrument.shippingAddress),
-    shippingOption: instrument.shippingOption
+    shippingOption: instrument.shippingOption,
   }, undefined, 2);
 }
 
@@ -101,6 +115,10 @@ function instrumentToJsonString(instrument) {
  * @return {object} The dictionary representation of the shipping address.
  */
 function addressToDictionary(address) {
+  if (address.toJSON) {
+    return address.toJSON();
+  }
+
   return {
     recipient: address.recipient,
     organization: address.organization,
@@ -112,15 +130,21 @@ function addressToDictionary(address) {
     sortingCode: address.sortingCode,
     country: address.country,
     languageCode: address.languageCode,
-    phone: address.phone
+    phone: address.phone,
   };
 }
 
-var buyButton = document.getElementById('buyButton');
-if ('PaymentRequest' in window) {
+const buyButton = document.getElementById('buyButton');
+buyButton.setAttribute('style', 'display: none;');
+if (!navigator.userAgent.match(/Android/i)) {
+  ChromeSamples.setStatus('Supported only on Android for now.');
+} else if ('PaymentRequest' in window) {
+  let request = initPaymentRequest();
   buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', onBuyClicked);
+  buyButton.addEventListener('click', function() {
+    onBuyClicked(request);
+    request = initPaymentRequest();
+  });
 } else {
-  buyButton.setAttribute('style', 'display: none;');
   ChromeSamples.setStatus('This browser does not support web payments');
 }

--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -29,8 +29,12 @@ feature_id: 5639348045217792
     options depending on the shipping address.</li>
 
   <li><a href="contact-info/">Contact info</a> - a sample that accepts credit
-    card payments and requests user's contact information: phone number and
-    email address.</li>
+    card payments and requests user's contact information: name, phone number,
+    and email address.</li>
+
+  <li><a href="can-make-payment/">Can make payment</a> - a sample that accepts
+    both Android Pay and credit card payments and checks whether the browser can
+    make payment.</li>
 
   <li><a href="https://emerald-eon.appspot.com">Server side</a> - sample that
     demonstrates server-side calculation of shipping price and processing


### PR DESCRIPTION
Web Payments API update.

1) Build `PaymentRequest` object on page load, so that querying of slower payment apps does not result in showing a spinner when `.show()` is called.

2) Check if user has a payment instrument by calling `.canMakePayment()` in the new sample at `paymentrequest/can-make-payment/`.

3) Use the built-in serializer for `PaymentResponse` and `PaymentAddress`.

4) Add support for Basic Card payment method.

5) Add support for MIR credit card type.

6) Show 'Cannot ship outside of US' in the dynamic shipping example.

7) Make the shipping price "pending" until user selects a valid shipping address.

8) Warn that these tests work only on Android for now.