### PR TITLE
Add indexed_db_observers sample

### DIFF
--- a/indexed_db_observers/README.md
+++ b/indexed_db_observers/README.md
@@ -1,0 +1,8 @@
+<!-- TODO: Replace PLACEHOLDER with feature name. -->
+PLACEHOLDER Sample
+===
+<!-- TODO: Replace PLACEHOLDER in the path to correspond to the real github.io URL. -->
+See https://googlechrome.github.io/samples/PLACEHOLDER/index.html for a live demo.
+
+<!-- TODO: Replace PLACEHOLDER with the id from the chromestatus.com URL. -->
+Learn more at https://www.chromestatus.com/feature/PLACEHOLDER

--- a/indexed_db_observers/README.md
+++ b/indexed_db_observers/README.md
@@ -1,8 +1,6 @@
-<!-- TODO: Replace PLACEHOLDER with feature name. -->
-PLACEHOLDER Sample
+indexed_db_observers Sample
 ===
-<!-- TODO: Replace PLACEHOLDER in the path to correspond to the real github.io URL. -->
-See https://googlechrome.github.io/samples/PLACEHOLDER/index.html for a live demo.
+See https://googlechrome.github.io/samples/indexed_db_observers/index.html for a live demo.
 
 <!-- TODO: Replace PLACEHOLDER with the id from the chromestatus.com URL. -->
-Learn more at https://www.chromestatus.com/feature/PLACEHOLDER
+Learn more at https://www.chromestatus.com/feature/5669292892749824

--- a/indexed_db_observers/demo.js
+++ b/indexed_db_observers/demo.js
@@ -38,7 +38,7 @@ incrementButton.addEventListener('click', function(event) {
   var request = nameStore.put(nameField.innerHTML, nameField.innerHTML);
   request.onsuccess = function() {
     var newDataNumber = dataNumber + 1;
-    dataStore.put(dataKey, newDataNumber);
+    dataStore.put(newDataNumber, dataKey);
     transaction.oncomplete = function() {
       setDataNumber(newDataNumber);
     }

--- a/indexed_db_observers/demo.js
+++ b/indexed_db_observers/demo.js
@@ -1,16 +1,27 @@
 var dataField = document.querySelector('#data');
 var nameField = document.querySelector('#name');
 var incrementButton = document.querySelector('#incrementButton');
+var resetButton = document.querySelector('#resetButton');
 
 var dataNumber = 0;
 var db = null;
 
+var setDataNumber = function(number) {
+  dataNumber = number;
+  dataField.innerHTML = dataNumber;
+}
+
 var observer = new IDBObserver(function(changes) {
   var originTab = changes.records.get('name')[0].key.lower;
+  var dataChange = changes.records.get('data')[0];
+  if (dataChange.type == 'clear') {
+    ChromeSamples.log('Tab "' + originTab + '" reset the data to 0.');
+    setDataNumber(0);
+    return;
+  }
   var newDataValue = changes.records.get('data')[0].key.lower;
-  ChromeSamples.log('Tab "' + originTab + '" set the data value to ' + newDataValue);
-  dataNumber = newDataValue;
-  dataField.innerHTML = dataNumber;
+  ChromeSamples.log('Tab "' + originTab + '" set the data value to ' + newDataValue + '.');
+  setDataNumber(newDataValue);
 });
 
 incrementButton.addEventListener('click', function(event) {
@@ -21,12 +32,31 @@ incrementButton.addEventListener('click', function(event) {
   var transaction = db.transaction(['data', 'name'], 'readwrite');
   var dataStore = transaction.objectStore('data');
   var nameStore = transaction.objectStore('name');
-  
-  dataNumber++;
-  dataStore.put(dataNumber, dataNumber);
+
+  // We wait for the first success to signify we've been scheduled.
+  var request = nameStore.put(nameField.innerHTML, nameField.innerHTML);
+  request.onsuccess = function() {
+    var newDataNumber = dataNumber + 1;
+    dataStore.put(newDataNumber, newDataNumber);
+    transaction.oncomplete = function() {
+      setDataNumber(newDataNumber);
+    }
+  }
+});
+
+resetButton.addEventListener('click', function(event) {
+  if (db == null) {
+    ChromeSamples.log('Database connection still openning.');
+    return;
+  }
+  var transaction = db.transaction(['data', 'name'], 'readwrite');
+  var dataStore = transaction.objectStore('data');
+  var nameStore = transaction.objectStore('name');
+
   nameStore.put(nameField.innerHTML, nameField.innerHTML);
+  dataStore.clear();
   transaction.oncomplete = function() {
-    dataField.innerHTML = dataNumber;
+    setDataNumber(0);
   }
 });
 
@@ -36,27 +66,28 @@ openRequest.onupgradeneeded = function() {
   openRequest.result.createObjectStore('data');
 }
 openRequest.onerror = function() {
-    ChromeSamples.log('Error openning database: ', openRequest.error);
+  ChromeSamples.log('Error opening database: ', openRequest.error);
 }
 openRequest.onsuccess = function(event) {
   db = event.target.result;
   var transaction = db.transaction(['data', 'name'], 'readonly');
   // Observe starting after this transaction!
-  observer.observe(db, transaction, {operationTypes: ['put']});
+  observer.observe(db, transaction, { operationTypes: ['put', 'clear'] });
+
   // This is ugly because we have to use the keys. When value or
   // transaction support is available we will use that.
   var dataStore = transaction.objectStore('data');
   dataStore.getAllKeys().onsuccess = function(event) {
     var maxNumber = 0;
     if (event.target.result.length == 0) {
-      dataNumber = maxNumber;
-      dataField.innerHTML = dataNumber;
+      setDataNumber(0);
+      ChromeSamples.log('Database is empty, starting at 0.');
       return;
     }
     event.target.result.forEach(function(number) {
       maxNumber = maxNumber > number ? maxNumber : number;
-    })
-    dataNumber = maxNumber;
-   dataField.innerHTML = dataNumber;
+    });
+    setDataNumber(maxNumber);
+    ChromeSamples.log('Database has starting value of ' + maxNumber + '.');
   }
 }

--- a/indexed_db_observers/demo.js
+++ b/indexed_db_observers/demo.js
@@ -1,0 +1,62 @@
+var dataField = document.querySelector('#data');
+var nameField = document.querySelector('#name');
+var incrementButton = document.querySelector('#incrementButton');
+
+var dataNumber = 0;
+var db = null;
+
+var observer = new IDBObserver(function(changes) {
+  var originTab = changes.records.get('name')[0].key.lower;
+  var newDataValue = changes.records.get('data')[0].key.lower;
+  ChromeSamples.log('Tab "' + originTab + '" set the data value to ' + newDataValue);
+  dataNumber = newDataValue;
+  dataField.innerHTML = dataNumber;
+});
+
+incrementButton.addEventListener('click', function(event) {
+  if (db == null) {
+    ChromeSamples.log('Database connection still openning.');
+    return;
+  }
+  var transaction = db.transaction(['data', 'name'], 'readwrite');
+  var dataStore = transaction.objectStore('data');
+  var nameStore = transaction.objectStore('name');
+  
+  dataNumber++;
+  dataStore.put(dataNumber, dataNumber);
+  nameStore.put(nameField.innerHTML, nameField.innerHTML);
+  transaction.oncomplete = function() {
+    dataField.innerHTML = dataNumber;
+  }
+});
+
+var openRequest = indexedDB.open('demoDB');
+openRequest.onupgradeneeded = function() {
+  openRequest.result.createObjectStore('name');
+  openRequest.result.createObjectStore('data');
+}
+openRequest.onerror = function() {
+    ChromeSamples.log('Error openning database: ', openRequest.error);
+}
+openRequest.onsuccess = function(event) {
+  db = event.target.result;
+  var transaction = db.transaction(['data', 'name'], 'readonly');
+  // Observe starting after this transaction!
+  observer.observe(db, transaction, {operationTypes: ['put']});
+  // This is ugly because we have to use the keys. When value or
+  // transaction support is available we will use that.
+  var dataStore = transaction.objectStore('data');
+  dataStore.getAllKeys().onsuccess = function(event) {
+    var maxNumber = 0;
+    if (event.target.result.length == 0) {
+      dataNumber = maxNumber;
+      dataField.innerHTML = dataNumber;
+      return;
+    }
+    event.target.result.forEach(function(number) {
+      maxNumber = maxNumber > number ? maxNumber : number;
+    })
+    dataNumber = maxNumber;
+   dataField.innerHTML = dataNumber;
+  }
+}

--- a/indexed_db_observers/index.html
+++ b/indexed_db_observers/index.html
@@ -19,7 +19,7 @@ feature_id: 5669292892749824
 <p>IndexedDB Observers allow one to observe changes to indexeddb in an efficient and data-consistant way.
   Open this page in multiple tabs or windows, and observer how the data consistantly updates.</p>
 <p>See <a href="https://github.com/WICG/indexed-db-observers/blob/gh-pages/EXPLAINER.md">this explainer</a> for more info and the proposed specification changes.</a>
-<p><b>Note:</b> You must be using Chrome 57.0.2986.0 or higher, with the #experimental-web-platform-features flag enabled.</p>
+<p><b>Note:</b> You must be using Chrome 57.0.2986.0 or higher, with the #enable-experimental-web-platform-features flag enabled.</p>
 
 <h4>Tab Name: <span id='name'></span></h4>
 <h4>Data number: <span id='data'></span></h4>

--- a/indexed_db_observers/index.html
+++ b/indexed_db_observers/index.html
@@ -1,0 +1,38 @@
+---
+feature_name: IndexedDB Observers
+chrome_version: 57
+feature_id: 5669292892749824
+---
+
+<style>
+  #data {
+    background-color: #C8E6C9;
+    font-size: 2em;
+  }
+  #name {
+    background-color: #C8E6C9;
+    font-size: 2em;
+  }
+</style>
+
+<h3>Background</h3>
+<p>Background info goes here.</p>
+<p>Any content here, outside of a capture block, is included verbatim on the resulting page.</p>
+
+
+<h4>Tab Name: <span id='name'></span></h4>
+<h4>Data number: <span id='data'></span></h4>
+<button id="incrementButton">Increment data number</button>
+
+<script>
+var names = ['Toby', 'Fred', 'George', 'Bob', 'Bill', 'Buster', 'Jenn', 'Zoe', 'Carla', 'Stacy', 'Alyssa', 'Catherine', 'Sally', 'Austin', 'Jackson', 'Grace'];
+var nameField = document.querySelector('#name');
+nameField.innerHTML = names[Math.floor(Math.random()*names.length)];
+</script>
+
+{% capture initial_output_content %}
+<p>Database changes appear here.</p>
+{% endcapture %}
+{% include output_helper.html initial_output_content=initial_output_content%}
+
+{% include js_snippet.html filename='demo.js' %}

--- a/indexed_db_observers/index.html
+++ b/indexed_db_observers/index.html
@@ -16,22 +16,26 @@ feature_id: 5669292892749824
 </style>
 
 <h3>Background</h3>
-<p>Background info goes here.</p>
-<p>Any content here, outside of a capture block, is included verbatim on the resulting page.</p>
-
+<p>IndexedDB Observers allow one to observe changes to indexeddb in an efficient and data-consistant way.</p>
+<p>See <a href="https://github.com/WICG/indexed-db-observers/blob/gh-pages/EXPLAINER.md">this explainer</a> for the proposed specification</a>
 
 <h4>Tab Name: <span id='name'></span></h4>
 <h4>Data number: <span id='data'></span></h4>
-<button id="incrementButton">Increment data number</button>
+<button id="incrementButton">Increment Data Number</button>
+<button id="resetButton">Reset Data Number</button>
 
 <script>
-var names = ['Toby', 'Fred', 'George', 'Bob', 'Bill', 'Buster', 'Jenn', 'Zoe', 'Carla', 'Stacy', 'Alyssa', 'Catherine', 'Sally', 'Austin', 'Jackson', 'Grace'];
+var names = ['Toby', 'Fred', 'George', 'Bob', 'Bill', 'Buster',
+             'Jenn', 'Zoe', 'Carla', 'Stacy', 'Alyssa', 'Catherine',
+             'Sally', 'Austin', 'Jackson', 'Grace',
+             'Tasha', 'Arthur', 'Michael', 'Echo', 'Topher', 'Sierra',
+             'Whisky', 'DeWitt'];
 var nameField = document.querySelector('#name');
 nameField.innerHTML = names[Math.floor(Math.random()*names.length)];
 </script>
 
 {% capture initial_output_content %}
-<p>Database changes appear here.</p>
+<pre>Database changes appear here:</pre>
 {% endcapture %}
 {% include output_helper.html initial_output_content=initial_output_content%}
 

--- a/indexed_db_observers/index.html
+++ b/indexed_db_observers/index.html
@@ -19,6 +19,7 @@ feature_id: 5669292892749824
 <p>IndexedDB Observers allow one to observe changes to indexeddb in an efficient and data-consistant way.
   Open this page in multiple tabs or windows, and observer how the data consistantly updates.</p>
 <p>See <a href="https://github.com/WICG/indexed-db-observers/blob/gh-pages/EXPLAINER.md">this explainer</a> for more info and the proposed specification changes.</a>
+<p><b>Note:</b> You must be using Chrome 57.0.2986.0 or higher, with the #experimental-web-platform-features flag enabled.</p>
 
 <h4>Tab Name: <span id='name'></span></h4>
 <h4>Data number: <span id='data'></span></h4>

--- a/indexed_db_observers/index.html
+++ b/indexed_db_observers/index.html
@@ -16,8 +16,9 @@ feature_id: 5669292892749824
 </style>
 
 <h3>Background</h3>
-<p>IndexedDB Observers allow one to observe changes to indexeddb in an efficient and data-consistant way.</p>
-<p>See <a href="https://github.com/WICG/indexed-db-observers/blob/gh-pages/EXPLAINER.md">this explainer</a> for the proposed specification</a>
+<p>IndexedDB Observers allow one to observe changes to indexeddb in an efficient and data-consistant way.
+  Open this page in multiple tabs or windows, and observer how the data consistantly updates.</p>
+<p>See <a href="https://github.com/WICG/indexed-db-observers/blob/gh-pages/EXPLAINER.md">this explainer</a> for more info and the proposed specification changes.</a>
 
 <h4>Tab Name: <span id='name'></span></h4>
 <h4>Data number: <span id='data'></span></h4>


### PR DESCRIPTION
Now that values and transactions are supported in IDB Observers, I'm comfortable releasing this sample. I may iterate a bit later to show off transaction support.

@jeffposnick for this update.