### PR TITLE
Add basic Bluetooth GATT descriptors sample

### DIFF
--- a/web-bluetooth/get-descriptors-async-await.html
+++ b/web-bluetooth/get-descriptors-async-await.html
@@ -1,0 +1,46 @@
+---
+feature_name: Web Bluetooth / Get Descriptors (Async Await)
+chrome_version: 57
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+origin_trial: Am0/QOvI3DZpd6cZHdBdzx8sektPUUg8nUD5FCCrkZ8mDoiRUR+thZsZIuZYNKDJ26qZjTUHli7yvgOgug3XYg0AAABceyJvcmlnaW4iOiJodHRwczovL2dvb2dsZWNocm9tZS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkJsdWV0b290aCIsImV4cGlyeSI6MTQ4NTMyMDM5OX0=
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to get all
+characteristic's descriptors of an advertised service from a nearby Bluetooth
+Low Energy Device. You may want to try this demo with the BLE Peripheral
+Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a href="get-descriptors.html">Get
+Descriptors (Promises)</a> sample.</p>
+
+<form>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button>Get descriptors</button>
+</form>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='get-descriptors-async-await.js' %}
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/get-descriptors-async-await.js
+++ b/web-bluetooth/get-descriptors-async-await.js
@@ -20,16 +20,14 @@ async function onButtonClick() {
     log('Getting Service...');
     const service = await server.getPrimaryService(serviceUuid);
 
-    log('Getting Characteristics...');
-    let characteristics;
-    if (characteristicUuid) {
-      characteristics = await service.getCharacteristics(characteristicUuid);
-    } else {
-      characteristics = await service.getCharacteristics();
-    }
+    log('Getting Characteristic...');
+    const characteristic = await service.getCharacteristic(characteristicUuid);
 
-    log('> Characteristics: ' +
-      characteristics.map(c => c.uuid).join('\n' + ' '.repeat(19)));
+    log('Getting Descriptors...');
+    const descriptors = await characteristic.getDescriptors();
+
+    log('> Descriptors: ' +
+      descriptors.map(c => c.uuid).join('\n' + ' '.repeat(19)));
   } catch(error) {
     log('Argh! ' + error);
   }

--- a/web-bluetooth/get-descriptors.html
+++ b/web-bluetooth/get-descriptors.html
@@ -1,0 +1,46 @@
+---
+feature_name: Web Bluetooth / Get Descriptors
+chrome_version: 57
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+origin_trial: Am0/QOvI3DZpd6cZHdBdzx8sektPUUg8nUD5FCCrkZ8mDoiRUR+thZsZIuZYNKDJ26qZjTUHli7yvgOgug3XYg0AAABceyJvcmlnaW4iOiJodHRwczovL2dvb2dsZWNocm9tZS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkJsdWV0b290aCIsImV4cGlyeSI6MTQ4NTMyMDM5OX0=
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to get all
+characteristic's descriptors of an advertised service from a nearby Bluetooth
+Low Energy Device. You may want to try this demo with the BLE Peripheral
+Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a href="get-descriptors-async-await.html">Get Descriptors (Async
+Await)</a> sample.</p>
+
+<form>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button>Get descriptors</button>
+</form>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='get-descriptors.js' %}
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/get-descriptors.js
+++ b/web-bluetooth/get-descriptors.js
@@ -1,0 +1,37 @@
+function onButtonClick() {
+  let serviceUuid = document.querySelector('#service').value;
+  if (serviceUuid.startsWith('0x')) {
+    serviceUuid = parseInt(serviceUuid);
+  }
+
+  let characteristicUuid = document.querySelector('#characteristic').value;
+  if (characteristicUuid.startsWith('0x')) {
+    characteristicUuid = parseInt(characteristicUuid);
+  }
+
+  log('Requesting Bluetooth Device...');
+  navigator.bluetooth.requestDevice({filters: [{services: [serviceUuid]}]})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Service...');
+    return server.getPrimaryService(serviceUuid);
+  })
+  .then(service => {
+    log('Getting Characteristic...');
+    return service.getCharacteristic(characteristicUuid);
+  })
+  .then(characteristic => {
+    log('Getting Descriptors...');
+    return characteristic.getDescriptors();
+  })
+  .then(descriptors => {
+    log('> Descriptors: ' +
+      descriptors.map(c => c.uuid).join('\n' + ' '.repeat(19)));
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -20,6 +20,7 @@ for trials</a> so that websites can use it without any flag.</p>
 <p><a href="notifications.html">Notifications (Promises)</a> / <a href="notifications-async-await.html">Notifications (Async Await)</a> - start and stop characteristic notifications from a BLE Device.</p>
 <p><a href="device-disconnect.html">Device Disconnect (Promises)</a> / <a href="device-disconnect-async-await.html">Device Disconnect (Async Await)</a> - disconnect and get notified from a disconnection of a BLE Device after connecting to it.</p>
 <p><a href="get-characteristics.html">Get Characteristics (Promises)</a> - / <a href="get-characteristics-async-await.html">Get Characteristics (Async Await)</a> get all characteristics of an advertised service from a BLE Device.</p>
+<p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> get all characteristic's descriptors of an advertised service from a BLE Device.</p>
 
 <h3>Combining multiple operations</h3>
 


### PR DESCRIPTION
Due to popular demand, here's the first basic Bluetooth GATT Descriptors sample.

R: @scheib 

Try it live:
https://beaufortfrancois.github.io/samples/web-bluetooth/get-descriptors.html
https://beaufortfrancois.github.io/samples/web-bluetooth/get-descriptors-async-await.html
https://beaufortfrancois.github.io/samples/web-bluetooth/