### PR TITLE
[Web Bluetooth] Add Read descriptors sample

### DIFF
--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -16,8 +16,8 @@ icon_url: icon.png
 <p><a href="characteristic-properties.html">Characteristic Properties (Promises)</a> / <a href="characteristic-properties-async-await.html">Characteristic Properties (Async Await)</a> - display all properties of a specific characteristic from a BLE Device.</p>
 <p><a href="notifications.html">Notifications (Promises)</a> / <a href="notifications-async-await.html">Notifications (Async Await)</a> - start and stop characteristic notifications from a BLE Device.</p>
 <p><a href="device-disconnect.html">Device Disconnect (Promises)</a> / <a href="device-disconnect-async-await.html">Device Disconnect (Async Await)</a> - disconnect and get notified from a disconnection of a BLE Device after connecting to it.</p>
-<p><a href="get-characteristics.html">Get Characteristics (Promises)</a> - / <a href="get-characteristics-async-await.html">Get Characteristics (Async Await)</a> get all characteristics of an advertised service from a BLE Device.</p>
-<p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> get all characteristic's descriptors of an advertised service from a BLE Device.</p>
+<p><a href="get-characteristics.html">Get Characteristics (Promises)</a> - / <a href="get-characteristics-async-await.html">Get Characteristics (Async Await)</a> - get all characteristics of an advertised service from a BLE Device.</p>
+<p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> - get all characteristic's descriptors of an advertised service from a BLE Device.</p>
 
 <h3>Combining multiple operations</h3>
 
@@ -26,7 +26,8 @@ icon_url: icon.png
 <p><a href="link-loss.html">Link Loss (Promises)</a> / <a href="link-loss-async-await.html">Link Loss (Async Await)</a> - set the Alert Level characteristic of a BLE Device (readValue & writeValue).</p>
 <p><a href="discover-services-and-characteristics.html">Discover Services & Characteristics (Promises)</a> / <a href="discover-services-and-characteristics-async-await.html">Discover Services & Characteristics (Async Await)</a> - discover all accessible primary services and their characteristics from a BLE Device.</p>
 <p><a href="automatic-reconnect.html">Automatic Reconnect (Promises)</a> / <a href="automatic-reconnect-async-await.html">Automatic Reconnect (Async Await)</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>
-<p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed (Promises)</a> / <a href="read-characteristic-value-changed-async-await.html">Read Characteristic Value Changed (Async Await)</a>- read battery level and be notified of changes from a BLE Device.</p>
+<p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed (Promises)</a> / <a href="read-characteristic-value-changed-async-await.html">Read Characteristic Value Changed (Async Await)</a> - read battery level and be notified of changes from a BLE Device.</p>
+<p><a href="read-descriptors.html">Read Descriptors (Promises)</a> - / <a href="read-descriptors-async-await.html">Read Descriptors (Async Await)</a> - read all characteristic's descriptors of a service from a BLE Device.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/read-descriptors-async-await.html
+++ b/web-bluetooth/read-descriptors-async-await.html
@@ -1,0 +1,45 @@
+---
+feature_name: Web Bluetooth / Read Descriptors (Async Await)
+chrome_version: 58
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to read all
+characteristic's descriptors of a service from a nearby Bluetooth Low Energy
+Device. You may want to try this demo with the BLE Peripheral Simulator App
+from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a href="read-descriptors.html">Read
+Descriptors (Promises)</a> sample.</p>
+
+<form>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button>Read descriptors</button>
+</form>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='read-descriptors-async-await.js' %}
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/read-descriptors-async-await.js
+++ b/web-bluetooth/read-descriptors-async-await.js
@@ -1,0 +1,76 @@
+async function onButtonClick() {
+  let serviceUuid = document.querySelector('#service').value;
+  if (serviceUuid.startsWith('0x')) {
+    serviceUuid = parseInt(serviceUuid);
+  }
+
+  let characteristicUuid = document.querySelector('#characteristic').value;
+  if (characteristicUuid.startsWith('0x')) {
+    characteristicUuid = parseInt(characteristicUuid);
+  }
+
+  try {
+    log('Requesting any Bluetooth Device...');
+    const device = await navigator.bluetooth.requestDevice({
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true, optionalServices: [serviceUuid]});
+
+    log('Connecting to GATT Server...');
+    const server = await device.gatt.connect();
+
+    log('Getting Service...');
+    const service = await server.getPrimaryService(serviceUuid);
+
+    log('Getting Characteristic...');
+    const characteristic = await service.getCharacteristic(characteristicUuid);
+
+    log('Getting Descriptors...');
+    const descriptors = await characteristic.getDescriptors();
+
+    for (const descriptor of descriptors) {
+      switch (descriptor.uuid) {
+
+        case BluetoothUUID.getDescriptor('gatt.client_characteristic_configuration'):
+          await descriptor.readValue().then(value => {
+            log('> Client Characteristic Configuration:');
+            log('  > Notifications: ' + (value.getUint8(0) ? 'ON' : 'OFF'));
+            log('  > Indications: ' + (value.getUint8(1) ? 'ON' : 'OFF'));
+          });
+          break;
+
+        case BluetoothUUID.getDescriptor('gatt.characteristic_user_description'):
+          await descriptor.readValue().then(value => {
+            let decoder = new TextDecoder('utf-8');
+            log('> Characteristic User Description: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getDescriptor('report_reference'):
+          await descriptor.readValue().then(value => {
+            log('> Report Reference:');
+            log('  > Report ID: ' + value.getUint8(0));
+            log('  > Report Type: ' + getReportType(value));
+          });
+          break;
+
+        default: log('> Unknown Descriptor: ' + descriptor.uuid);
+      }
+    }
+  } catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+/* Utils */
+
+const valueToReportType = {
+  1: 'Input Report',
+  2: 'Output Report',
+  3: 'Feature Report'
+};
+
+function getReportType(value) {
+  let v = value.getUint8(1);
+  return v + (v in valueToReportType ?
+      ' (' + valueToReportType[v] + ')' : 'Unknown');
+}

--- a/web-bluetooth/read-descriptors-async-await.js
+++ b/web-bluetooth/read-descriptors-async-await.js
@@ -33,8 +33,10 @@ async function onButtonClick() {
         case BluetoothUUID.getDescriptor('gatt.client_characteristic_configuration'):
           await descriptor.readValue().then(value => {
             log('> Client Characteristic Configuration:');
-            log('  > Notifications: ' + (value.getUint8(0) ? 'ON' : 'OFF'));
-            log('  > Indications: ' + (value.getUint8(1) ? 'ON' : 'OFF'));
+            let notificationsBit = value.getUint8(0) & 0b01;
+            log('  > Notifications: ' + (notificationsBit ? 'ON' : 'OFF'));
+            let indicationsBit = value.getUint8(0) & 0b10;
+            log('  > Indications: ' + (indicationsBit ? 'ON' : 'OFF'));
           });
           break;
 

--- a/web-bluetooth/read-descriptors.html
+++ b/web-bluetooth/read-descriptors.html
@@ -1,0 +1,45 @@
+---
+feature_name: Web Bluetooth / Read Descriptors
+chrome_version: 58
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to read all
+characteristic's descriptors of a service from a nearby Bluetooth Low Energy
+Device. You may want to try this demo with the BLE Peripheral Simulator App
+from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a href="read-descriptors-async-await.html">Read Descriptors (Async
+Await)</a> sample.</p>
+
+<form>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button>Read descriptors</button>
+</form>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='read-descriptors.js' %}
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onButtonClick();
+    }
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/read-descriptors.js
+++ b/web-bluetooth/read-descriptors.js
@@ -38,8 +38,10 @@ function onButtonClick() {
         case BluetoothUUID.getDescriptor('gatt.client_characteristic_configuration'):
           queue = queue.then(_ => descriptor.readValue()).then(value => {
             log('> Client Characteristic Configuration:');
-            log('  > Notifications: ' + (value.getUint8(0) ? 'ON' : 'OFF'));
-            log('  > Indications: ' + (value.getUint8(1) ? 'ON' : 'OFF'));
+            let notificationsBit = value.getUint8(0) & 0b01;
+            log('  > Notifications: ' + (notificationsBit ? 'ON' : 'OFF'));
+            let indicationsBit = value.getUint8(0) & 0b10;
+            log('  > Indications: ' + (indicationsBit ? 'ON' : 'OFF'));
           });
           break;
 

--- a/web-bluetooth/read-descriptors.js
+++ b/web-bluetooth/read-descriptors.js
@@ -1,0 +1,83 @@
+function onButtonClick() {
+  let serviceUuid = document.querySelector('#service').value;
+  if (serviceUuid.startsWith('0x')) {
+    serviceUuid = parseInt(serviceUuid);
+  }
+
+  let characteristicUuid = document.querySelector('#characteristic').value;
+  if (characteristicUuid.startsWith('0x')) {
+    characteristicUuid = parseInt(characteristicUuid);
+  }
+
+  log('Requesting any Bluetooth Device...');
+  navigator.bluetooth.requestDevice({
+    // filters: [...] <- Prefer filters to save energy & show relevant devices.
+    acceptAllDevices: true,
+    optionalServices: [serviceUuid]})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Service...');
+    return server.getPrimaryService(serviceUuid);
+  })
+  .then(service => {
+    log('Getting Characteristic...');
+    return service.getCharacteristic(characteristicUuid);
+  })
+  .then(characteristic => {
+    log('Getting Descriptors...');
+    return characteristic.getDescriptors();
+  })
+  .then(descriptors => {
+    let queue = Promise.resolve();
+    descriptors.forEach(descriptor => {
+      switch (descriptor.uuid) {
+
+        case BluetoothUUID.getDescriptor('gatt.client_characteristic_configuration'):
+          queue = queue.then(_ => descriptor.readValue()).then(value => {
+            log('> Client Characteristic Configuration:');
+            log('  > Notifications: ' + (value.getUint8(0) ? 'ON' : 'OFF'));
+            log('  > Indications: ' + (value.getUint8(1) ? 'ON' : 'OFF'));
+          });
+          break;
+
+        case BluetoothUUID.getDescriptor('gatt.characteristic_user_description'):
+          queue = queue.then(_ => descriptor.readValue()).then(value => {
+            let decoder = new TextDecoder('utf-8');
+            log('> Characteristic User Description: ' + decoder.decode(value));
+          });
+          break;
+
+        case BluetoothUUID.getDescriptor('report_reference'):
+          queue = queue.then(_ => descriptor.readValue()).then(value => {
+            log('> Report Reference:');
+            log('  > Report ID: ' + value.getUint8(0));
+            log('  > Report Type: ' + getReportType(value));
+          });
+          break;
+
+        default: log('> Unknown Descriptor: ' + descriptor.uuid);
+      }
+    });
+    return queue;
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+/* Utils */
+
+const valueToReportType = {
+  1: 'Input Report',
+  2: 'Output Report',
+  3: 'Feature Report'
+};
+
+function getReportType(value) {
+  let v = value.getUint8(1);
+  return v + (v in valueToReportType ?
+      ' (' + valueToReportType[v] + ')' : 'Unknown');
+}


### PR DESCRIPTION
Here's a more advanced sample for reading Bluetooth GATT descriptors.

R: @scheib 

You can try it live at:
https://beaufortfrancois.github.io/samples/web-bluetooth/read-descriptors.html
https://beaufortfrancois.github.io/samples/web-bluetooth/read-descriptors-async-await.html
https://beaufortfrancois.github.io/samples/web-bluetooth/index.html