### PR TITLE
Add write descriptor sample

### DIFF
--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -28,7 +28,7 @@ icon_url: icon.png
 <p><a href="automatic-reconnect.html">Automatic Reconnect (Promises)</a> / <a href="automatic-reconnect-async-await.html">Automatic Reconnect (Async Await)</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>
 <p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed (Promises)</a> / <a href="read-characteristic-value-changed-async-await.html">Read Characteristic Value Changed (Async Await)</a> - read battery level and be notified of changes from a BLE Device.</p>
 <p><a href="read-descriptors.html">Read Descriptors (Promises)</a> / <a href="read-descriptors-async-await.html">Read Descriptors (Async Await)</a> - read all characteristic's descriptors of a service from a BLE Device.</p>
-<p><a href="write-descriptor.html">Characteristic User Description (Promises)</a> / <a href="write-descriptor-async-await.html">Characteristic User Description (Async Await)</a> - change Characteristic User Description characteristic's descriptor of a service from a BLE Device.</p>
+<p><a href="write-descriptor.html">Write Descriptor (Promises)</a> / <a href="write-descriptor-async-await.html">Write Descriptor (Async Await)</a> - write to the descriptor "Characteristic User Description" on a BLE Device.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -28,6 +28,7 @@ icon_url: icon.png
 <p><a href="automatic-reconnect.html">Automatic Reconnect (Promises)</a> / <a href="automatic-reconnect-async-await.html">Automatic Reconnect (Async Await)</a> - Reconnect to a disconnected BLE device using an exponential backoff algorithm.</p>
 <p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed (Promises)</a> / <a href="read-characteristic-value-changed-async-await.html">Read Characteristic Value Changed (Async Await)</a> - read battery level and be notified of changes from a BLE Device.</p>
 <p><a href="read-descriptors.html">Read Descriptors (Promises)</a> / <a href="read-descriptors-async-await.html">Read Descriptors (Async Await)</a> - read all characteristic's descriptors of a service from a BLE Device.</p>
+<p><a href="write-descriptor.html">Characteristic User Description (Promises)</a> / <a href="write-descriptor-async-await.html">Characteristic User Description (Async Await)</a> - change Characteristic User Description characteristic's descriptor of a service from a BLE Device.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/read-descriptors.js
+++ b/web-bluetooth/read-descriptors.js
@@ -11,9 +11,9 @@ function onButtonClick() {
 
   log('Requesting any Bluetooth Device...');
   navigator.bluetooth.requestDevice({
-    // filters: [...] <- Prefer filters to save energy & show relevant devices.
-    acceptAllDevices: true,
-    optionalServices: [serviceUuid]})
+  // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: [serviceUuid]})
   .then(device => {
     log('Connecting to GATT Server...');
     return device.gatt.connect();

--- a/web-bluetooth/write-descriptor-async-await.html
+++ b/web-bluetooth/write-descriptor-async-await.html
@@ -1,0 +1,50 @@
+---
+feature_name: Web Bluetooth / Characteristic User Description (Async Await)
+chrome_version: 58
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to change
+Characteristic User Description characteristic's descriptor of a service from a
+nearby Bluetooth Low Energy Device. You may want to try this demo with the BLE
+Peripheral Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a
+href="write-descriptor.html">Characteristic User Description (Promises)</a> sample.</p>
+
+<p>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button id="readButton">Get Characteristic User Description</button>
+</p>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+<p>
+  <input id="description" type="text" placeholder="Characteristic User Description">
+  <button id="writeButton" disabled>Set Characteristic User Description</button>
+</p>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='write-descriptor-async-await.js' %}
+
+<script>
+  document.querySelector('#readButton').addEventListener('click', function() {
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onReadButtonClick();
+    }
+  });
+  document.querySelector('#writeButton').addEventListener('click', function() {
+    onWriteButtonClick();
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/write-descriptor-async-await.html
+++ b/web-bluetooth/write-descriptor-async-await.html
@@ -1,5 +1,5 @@
 ---
-feature_name: Web Bluetooth / Characteristic User Description (Async Await)
+feature_name: Web Bluetooth / Write Descriptor (Async Await)
 chrome_version: 58
 check_min_version: true
 feature_id: 5264933985976320
@@ -9,13 +9,13 @@ index: index.html
 
 {% include_relative _includes/intro.html %}
 
-<p>This sample illustrates the use of the Web Bluetooth API to change
-Characteristic User Description characteristic's descriptor of a service from a
-nearby Bluetooth Low Energy Device. You may want to try this demo with the BLE
-Peripheral Simulator App from the <a target="_blank"
+<p>This sample illustrates the use of the Web Bluetooth API to write to the
+descriptor "Characteristic User Description" on a nearby Bluetooth Low Energy
+Device. You may want to try this demo with the BLE Peripheral Simulator App
+from the <a target="_blank"
 href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
 Play Store</a> and check out the <a
-href="write-descriptor.html">Characteristic User Description (Promises)</a> sample.</p>
+href="write-descriptor.html">Write Descriptor (Promises)</a> sample.</p>
 
 <p>
   <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">

--- a/web-bluetooth/write-descriptor-async-await.js
+++ b/web-bluetooth/write-descriptor-async-await.js
@@ -1,0 +1,61 @@
+var myDescriptor;
+
+async function onReadButtonClick() {
+  let serviceUuid = document.querySelector('#service').value;
+  if (serviceUuid.startsWith('0x')) {
+    serviceUuid = parseInt(serviceUuid);
+  }
+
+  let characteristicUuid = document.querySelector('#characteristic').value;
+  if (characteristicUuid.startsWith('0x')) {
+    characteristicUuid = parseInt(characteristicUuid);
+  }
+
+  try {
+    log('Requesting any Bluetooth Device...');
+    const device = await navigator.bluetooth.requestDevice({
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true, optionalServices: [serviceUuid]});
+
+    log('Connecting to GATT Server...');
+    const server = await device.gatt.connect();
+
+    log('Getting Service...');
+    const service = await server.getPrimaryService(serviceUuid);
+
+    log('Getting Characteristic...');
+    const characteristic = await service.getCharacteristic(characteristicUuid);
+
+    log('Getting Descriptor...');
+    myDescriptor = await characteristic.getDescriptor('gatt.characteristic_user_description');
+
+    document.querySelector('#writeButton').disabled =
+        !characteristic.properties.write;
+
+    log('Reading Descriptor...');
+    const value = await myDescriptor.readValue();
+
+    let decoder = new TextDecoder('utf-8');
+    log('> Characteristic User Description: ' + decoder.decode(value));
+  } catch(error) {
+    document.querySelector('#writeButton').disabled = true;
+    log('Argh! ' + error);
+  }
+}
+
+async function onWriteButtonClick() {
+  if (!myDescriptor) {
+    return;
+  }
+  let encoder = new TextEncoder('utf-8');
+  let value = document.querySelector('#description').value;
+  try {
+    log('Setting Characteristic User Description...');
+    await myDescriptor.writeValue(encoder.encode(value));
+
+    log('> Characteristic User Description changed to: ' + value);
+  } catch(error) {
+    log('Argh! ' + error);
+  }
+}
+

--- a/web-bluetooth/write-descriptor.html
+++ b/web-bluetooth/write-descriptor.html
@@ -1,0 +1,50 @@
+---
+feature_name: Web Bluetooth / Characteristic User Description
+chrome_version: 58
+check_min_version: true
+feature_id: 5264933985976320
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to change
+Characteristic User Description characteristic's descriptor of a service from a
+nearby Bluetooth Low Energy Device. You may want to try this demo with the BLE
+Peripheral Simulator App from the <a target="_blank"
+href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
+Play Store</a> and check out the <a
+href="write-descriptor-async-await.html">Characteristic User Description (Async Await)</a> sample.</p>
+
+<p>
+  <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">
+  <input id="characteristic" type="text" list="characteristics" placeholder="Bluetooth Characteristic">
+  <button id="readButton">Get Characteristic User Description</button>
+</p>
+
+{% include_relative _includes/datalist-services.html %}
+{% include_relative _includes/datalist-characteristics.html %}
+
+<p>
+  <input id="description" type="text" placeholder="Characteristic User Description">
+  <button id="writeButton" disabled>Set Characteristic User Description</button>
+</p>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='write-descriptor.js' %}
+
+<script>
+  document.querySelector('#readButton').addEventListener('click', function() {
+    if (isWebBluetoothEnabled()) {
+      ChromeSamples.clearLog();
+      onReadButtonClick();
+    }
+  });
+  document.querySelector('#writeButton').addEventListener('click', function() {
+    onWriteButtonClick();
+  });
+</script>
+
+{% include_relative _includes/utils.html %}

--- a/web-bluetooth/write-descriptor.html
+++ b/web-bluetooth/write-descriptor.html
@@ -1,5 +1,5 @@
 ---
-feature_name: Web Bluetooth / Characteristic User Description
+feature_name: Web Bluetooth / Write Descriptor
 chrome_version: 58
 check_min_version: true
 feature_id: 5264933985976320
@@ -9,13 +9,13 @@ index: index.html
 
 {% include_relative _includes/intro.html %}
 
-<p>This sample illustrates the use of the Web Bluetooth API to change
-Characteristic User Description characteristic's descriptor of a service from a
-nearby Bluetooth Low Energy Device. You may want to try this demo with the BLE
-Peripheral Simulator App from the <a target="_blank"
+<p>This sample illustrates the use of the Web Bluetooth API to write to the
+descriptor "Characteristic User Description" on a nearby Bluetooth Low Energy
+Device. You may want to try this demo with the BLE Peripheral Simulator App
+from the <a target="_blank"
 href="https://play.google.com/store/apps/details?id=io.github.webbluetoothcg.bletestperipheral">Google
 Play Store</a> and check out the <a
-href="write-descriptor-async-await.html">Characteristic User Description (Async Await)</a> sample.</p>
+href="write-descriptor-async-await.html">Write Descriptor (Async Await)</a> sample.</p>
 
 <p>
   <input id="service" type="text" list="services" autofocus placeholder="Bluetooth Service">

--- a/web-bluetooth/write-descriptor.js
+++ b/web-bluetooth/write-descriptor.js
@@ -1,0 +1,66 @@
+var myDescriptor;
+
+function onReadButtonClick() {
+  let serviceUuid = document.querySelector('#service').value;
+  if (serviceUuid.startsWith('0x')) {
+    serviceUuid = parseInt(serviceUuid);
+  }
+
+  let characteristicUuid = document.querySelector('#characteristic').value;
+  if (characteristicUuid.startsWith('0x')) {
+    characteristicUuid = parseInt(characteristicUuid);
+  }
+
+  log('Requesting any Bluetooth Device...');
+  navigator.bluetooth.requestDevice({
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true,
+      optionalServices: [serviceUuid]})
+  .then(device => {
+    log('Connecting to GATT Server...');
+    return device.gatt.connect();
+  })
+  .then(server => {
+    log('Getting Service...');
+    return server.getPrimaryService(serviceUuid);
+  })
+  .then(service => {
+    log('Getting Characteristic...');
+    return service.getCharacteristic(characteristicUuid);
+  })
+  .then(characteristic => {
+    log('Getting Descriptor...');
+    return characteristic.getDescriptor('gatt.characteristic_user_description');
+  })
+  .then(descriptor => {
+    document.querySelector('#writeButton').disabled =
+        !descriptor.characteristic.properties.write;
+    myDescriptor = descriptor;
+    log('Reading Descriptor...');
+    return descriptor.readValue();
+  })
+  .then(value => {
+    let decoder = new TextDecoder('utf-8');
+    log('> Characteristic User Description: ' + decoder.decode(value));
+  })
+  .catch(error => {
+    document.querySelector('#writeButton').disabled = true;
+    log('Argh! ' + error);
+  });
+}
+
+function onWriteButtonClick() {
+  if (!myDescriptor) {
+    return;
+  }
+  let encoder = new TextEncoder('utf-8');
+  let value = document.querySelector('#description').value;
+  log('Setting Characteristic User Description...');
+  myDescriptor.writeValue(encoder.encode(value))
+  .then(_ => {
+    log('> Characteristic User Description changed to: ' + value);
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}


### PR DESCRIPTION
This sample is the one featuring how to write a value to a Bluetooth GATT descriptor.

Try them live at:
https://beaufortfrancois.github.io/samples/web-bluetooth/
https://beaufortfrancois.github.io/samples/web-bluetooth/write-descriptor.html
https://beaufortfrancois.github.io/samples/web-bluetooth/write-descriptor-async-await.html

R: @scheib 