### PR TITLE
Changed presentationUrl to HTTPS

### DIFF
--- a/presentation-api/index.html
+++ b/presentation-api/index.html
@@ -39,7 +39,7 @@ feature_id: 6676265876586496
 // App ID EF1A139F is registered in the Google Cast SDK Developer
 // Console and points to the following custom receiver:
 // https://googlechrome.github.io/samples/presentation-api/receiver/index.html
-var presentationUrl = 'http://google.com/cast/#__castAppId__=EF1A139F';
+var presentationUrl = 'https://google.com/cast/#__castAppId__=EF1A139F';
 var presentationRequest;
 var presentationConnection;
 


### PR DESCRIPTION
When `presentationUrl` is not HTTPS, I get the error below:

> Uncaught SecurityError: Failed to construct 'PresentationRequest': Presentation of an insecure document [http://google.com/cast/#__castAppId__=EF1A139F] is prohibited from a secure context. (Your browser may not support this feature.)

TBR: @mounirlamouri 
