### PR TITLE
Update presentation-api sample

### DIFF
--- a/presentation-api/index.html
+++ b/presentation-api/index.html
@@ -1,7 +1,7 @@
 ---
-feature_name: Presentation API
-chrome_version: 51
-feature_id: 6676265876586496
+feature_name: Presentation API: Receiver API
+chrome_version: 58
+feature_id: 5414209298890752
 ---
 
 <h3>Background</h3>
@@ -10,7 +10,7 @@ feature_id: 6676265876586496
   This sample illustrates the use of
   <a href="https://w3c.github.io/presentation-api/">Presentation API</a>,
   which gives the ability to access external presentation-type displays and use
-  them for presenting web content. The <code>PresentationRequest</code> object
+  them for presenting Web content. The <code>PresentationRequest</code> object
   is associated with a request to initiate or reconnect to a presentation made
   by a controlling browsing context and it takes in a presentation request URL
   when constructed. A presentation can be started by calling the
@@ -36,28 +36,30 @@ feature_id: 6676265876586496
 {% include output_helper.html initial_output_content=initial_output_content %}
 
 {% capture js %}
-// App ID EF1A139F is registered in the Google Cast SDK Developer
-// Console and points to the following custom receiver:
-// https://googlechrome.github.io/samples/presentation-api/receiver/index.html
-var presentationUrl = 'https://google.com/cast/#__castAppId__=EF1A139F';
-var presentationRequest;
-var presentationConnection;
+const presentationUrls =
+  ['https://googlechrome.github.io/samples/presentation-api/receiver/index.html']
+let presentationRequest;
+let presentationConnection;
 
 function updatePresentationAvailability(displaysAvailable) {
   ChromeSamples.log('Presentation displays are ' +
       (displaysAvailable ? 'available' : 'unavailable') + '.');
 }
 
-document.querySelector('#createRequest').addEventListener('click', function() {
-  presentationRequest = new PresentationRequest(presentationUrl);
+document.querySelector('#createRequest').addEventListener('click', () => {
+  presentationRequest = new PresentationRequest(presentationUrls);
   document.querySelector('#createRequest').disabled = true;
   document.querySelector('#start').disabled = false;
   document.querySelector('#reconnect').disabled = false;
-  presentationRequest.getAvailability().then(function(availability) {
+  presentationRequest.getAvailability().then(availability => {
     updatePresentationAvailability(availability.value);
-    availability.onchange = function() {
+    availability.onchange = () => {
       updatePresentationAvailability(availability.value);
     };
+  }).catch(error => {
+    ChromeSamples.log('Presentation availability not supported, ' +
+                      error.name + ': ' + error.message);
+    updatePresentationAvailability(false);
   });
 });
 
@@ -65,36 +67,37 @@ function setConnection(connection) {
   presentationConnection = connection;
   document.querySelector('#close').disabled = false;
   document.querySelector('#terminate').disabled = false;
-  presentationConnection.onclose = function() {
+  presentationConnection.onclose = () => {
     ChromeSamples.log('Connection closed.');
   };
-  presentationConnection.onterminate = function() {
+  presentationConnection.onterminate = () => {
     ChromeSamples.log('Connection terminated.');
   };
 }
 
-document.querySelector('#start').addEventListener('click', function() {
-  presentationRequest.start().then(function(connection) {
+document.querySelector('#start').addEventListener('click', () => {
+  presentationRequest.start().then(connection => {
     ChromeSamples.log('Connected to presentation: ' + connection.id);
     setConnection(connection);
-  }).catch(function(error) {
+  }).catch(error => {
     ChromeSamples.log(error.name + ': ' + error.message);
   });
 });
 
-document.querySelector('#reconnect').addEventListener('click', function() {
-  var presentationId = document.querySelector('#presentationId').value.trim();
+document.querySelector('#reconnect').addEventListener('click', () => {
+  const presentationId = document.querySelector('#presentationId').value.trim();
   if (presentationId.length) {
-    presentationRequest.reconnect(presentationId).then(function(connection) {
+    presentationRequest.reconnect(presentationId).then(connection => {
       ChromeSamples.log('Reconnected to presentation: ' + connection.id);
       setConnection(connection);
-    }).catch(function(error) {
-      ChromeSamples.log(error.name + ': ' + error.message);
+    }).catch(error => {
+      ChromeSamples.log('Presentation.reconnect() error, ' + error.name + ': ' +
+                        error.message);
     });
   }
 });
 
-document.querySelector('#close').addEventListener('click', function() {
+document.querySelector('#close').addEventListener('click', () => {
   if (presentationConnection) {
     presentationConnection.close();
     document.querySelector('#close').disabled = true;
@@ -102,7 +105,7 @@ document.querySelector('#close').addEventListener('click', function() {
   }
 });
 
-document.querySelector('#terminate').addEventListener('click', function() {
+document.querySelector('#terminate').addEventListener('click', () => {
   if (presentationConnection) {
     presentationConnection.terminate();
     document.querySelector('#close').disabled = true;

--- a/presentation-api/index.html
+++ b/presentation-api/index.html
@@ -1,5 +1,5 @@
 ---
-feature_name: Presentation API: Receiver API
+feature_name: Presentation API Receiver API
 chrome_version: 58
 feature_id: 5414209298890752
 ---

--- a/presentation-api/index.html
+++ b/presentation-api/index.html
@@ -37,7 +37,7 @@ feature_id: 5414209298890752
 
 {% capture js %}
 const presentationUrls =
-  ['https://googlechrome.github.io/samples/presentation-api/receiver/index.html']
+  ['https://googlechrome.github.io/samples/presentation-api/receiver/index.html'];
 let presentationRequest;
 let presentationConnection;
 


### PR DESCRIPTION
@beaufortfrancois @zhaobin2016

Updates Presentation API sample (Issue https://github.com/GoogleChrome/samples/issues/498).

* Update referenced Chrome feature to use the Receiver API which supports normal URLs.
* Convert sample to use 1-UA/2-UA mode instead of the Cast protocol.
  * 1-UA requires a Cast device.
  * 2-UA requres the Google Cast for EDU Chrome app.
* Update to use ES6 style.

TODO:
- Investigate why `.close()` and `.terminate()` are not firing events on 1-UA.
- Investigate why `.close()` is not firing an event on 2-UA.
