### PR TITLE
[Web Payments] Rename buyButton because Safari doesn't like it

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -99,12 +99,12 @@ function instrumentToJsonString(instrument) {
   }
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });

--- a/paymentrequest/can-make-payment/demo.js
+++ b/paymentrequest/can-make-payment/demo.js
@@ -152,24 +152,24 @@ function instrumentToJsonString(instrument) {
 /**
  * Initializes the buy button.
  *
- * @param {HTMLElement} buyButton The "Buy" button to initialize.
+ * @param {HTMLElement} payButton The "Buy" button to initialize.
  */
-function initBuyButton(buyButton) {
+function initBuyButton(payButton) {
   initPaymentRequest(function(request, optionalWarning) {
-    buyButton.setAttribute('style', 'display: inline;');
+    payButton.setAttribute('style', 'display: inline;');
     ChromeSamples.setStatus(optionalWarning ? optionalWarning : '');
-    buyButton.addEventListener('click', function handleClick() {
-      buyButton.removeEventListener('click', handleClick);
+    payButton.addEventListener('click', function handleClick() {
+      payButton.removeEventListener('click', handleClick);
       onBuyClicked(request);
-      initBuyButton(buyButton);
+      initBuyButton(payButton);
     });
   }, function(error) {
-    buyButton.setAttribute('style', 'display: none;');
+    payButton.setAttribute('style', 'display: none;');
     ChromeSamples.setStatus(error);
   });
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 ChromeSamples.setStatus('Checking...');
-initBuyButton(buyButton);
+initBuyButton(payButton);

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -96,12 +96,12 @@ function instrumentToJsonString(instrument) {
   }, undefined, 2);
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -85,12 +85,12 @@ function instrumentToJsonString(instrument) {
   }, undefined, 2);
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -174,12 +174,12 @@ function addressToDictionary(address) {
   };
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -134,12 +134,12 @@ function addressToDictionary(address) {
   };
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -177,12 +177,12 @@ function addressToDictionary(address) {
   };
 }
 
-const buyButton = document.getElementById('buyButton');
-buyButton.setAttribute('style', 'display: none;');
+const payButton = document.getElementById('buyButton');
+payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
   let request = initPaymentRequest();
-  buyButton.setAttribute('style', 'display: inline;');
-  buyButton.addEventListener('click', function() {
+  payButton.setAttribute('style', 'display: inline;');
+  payButton.addEventListener('click', function() {
     onBuyClicked(request);
     request = initPaymentRequest();
   });


### PR DESCRIPTION
"can't create duplicate variable that shadows a global property"

const buyButton = document.getElementById('buyButton')

renaming the global to 'payButton' fixes that.