### PR TITLE
2017 links update

### DIFF
--- a/app-install-banner/deferred-banner/index.html
+++ b/app-install-banner/deferred-banner/index.html
@@ -27,12 +27,12 @@ limitations under the License.
     
     <p>Available in <a href="https://www.chromestatus.com/features/4540065577435136">Chrome 45+ (for Android)</a></p>
 
-    <p>The <a href="https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android">web app install banner</a> will prompt the user to add your web app to the users home screen.
+    <p>The <a href="https://developers.google.com/web/fundamentals/engage-and-retain/app-install-banners/">web app install banner</a> will prompt the user to add your web app to the users home screen.
     It will only prompt when a number of criteria have been met:
     </p>
 
     <ul>
-      <li>The app uses a <a href="http://www.html5rocks.com/en/tutorials/service-worker/introduction/">service worker</a></li>
+      <li>The app uses a <a href="https://developers.google.com/web/fundamentals/getting-started/primers/service-workers">service worker</a></li>
       <li>The site is using HTTPS</li>
       <li>The app has a manifest declared</li>
       <li>The manifest has a <code>short_name</code>, 144 pixel icon and a type of 'image/png'</li>


### PR DESCRIPTION
Also, https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android should be marked as deprecated and point to https://developers.google.com/web/fundamentals/engage-and-retain/app-install-banners/