### PR TITLE
Remove hover on-demand in media-hover-pointer demo.

### DIFF
--- a/media-hover-pointer/index.html
+++ b/media-hover-pointer/index.html
@@ -140,12 +140,6 @@ limitations under the License.
         text-decoration: none;
       }
     }
-    @media (any-hover: on-demand) {
-      .demo.any-hover--on-demand {
-        opacity: 1.0;
-        text-decoration: none;
-      }
-    }
     @media (any-hover: hover) {
       .demo.any-hover--hover {
         opacity: 1.0;
@@ -177,9 +171,6 @@ limitations under the License.
         </div>
         <div class="demo any-hover--none">
           any-hover: none
-        </div>
-        <div class="demo any-hover--on-demand">
-          any-hover: on-demand
         </div>
         <div class="demo any-hover--hover">
           any-hover: hover


### PR DESCRIPTION
The value was removed from the spec (see https://drafts.csswg.org/mediaqueries-4/#descdef-media-hover).

The support was also removed from Chrome https://bugs.chromium.org/p/chromium/issues/detail?id=654861.

Ecosystem is aligning see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9308676/

Firefox and Safari never shipped this property.