### PR TITLE
Add VP9 codec string sample

### DIFF
--- a/media/vp9-codec-string.html
+++ b/media/vp9-codec-string.html
@@ -1,0 +1,33 @@
+---
+feature_name: New VP9 codec string and Profile 2 support
+chrome_version: 60
+feature_id: 6230726177456128
+check_min_version: true
+---
+
+<h3>Background</h3>
+<p>
+VP9 is an open and royalty-free video codec that has been supported in Chromium
+since 2013. An update adds <a href="https://www.webmproject.org/vp9/mp4/">a new
+string format</a> for describing the encoding properties, such as the profile,
+level, etc. Such properties are common in video codecs but are not exposed in
+the current VP9 string format.
+<p>
+</p>
+In addition, this update includes a new format to advertise support for VP9
+Profile 2. This profile is needed to enable higher bit-depth video and the new
+binding allows higher granularity in the query for specific features of the VP9
+bitstream. The string format is accepted by media-related APIs such as
+<code>MediaSource.isTypeSupported()</code>, <code>HTMLMediaElement.canPlayType()</code>, and 
+<code>navigator.requestMediaKeySystemAccess()</code>.
+</p>
+
+{% include output_helper.html %}
+
+<script>
+  log = ChromeSamples.log;
+  log('Your browser supports:');
+</script>
+
+{% include js_snippet.html filename='vp9-codec-string.js' %}
+

--- a/media/vp9-codec-string.js
+++ b/media/vp9-codec-string.js
@@ -1,0 +1,25 @@
+if (MediaSource.isTypeSupported('video/webm; codecs="vp9"')) {
+  log('> VP9, Profile 0, level 1 (later fields defaulted)');
+}
+
+if (MediaSource.isTypeSupported('video/webm; codecs="vp09.00.10.08"')) {
+  log('> VP9, Profile 0, level 1, bit depth 8 (later fields defaulted)');
+}
+
+if (MediaSource.isTypeSupported('video/webm; codecs="vp09.01.20.08.01"')) {
+  log('> VP9, Profile 0, level 1, bit depth 8, 4:2:0 chroma subsampling ' +
+      '(later fields defaulted)');
+}
+
+if (MediaSource.isTypeSupported('video/webm; codecs="vp09.01.20.08.01.01.01.01.00"')) {
+  log('> VP9, Profile 1, level 2, bit depth 8, ' +
+      '4:2:0 chroma subsampling, REC709 color/transfer/matrix, ' +
+      'luma/chroma encoded in the "legal" range.');
+}
+
+if (MediaSource.isTypeSupported('video/webm; codecs="vp09.02.10.10.01.09.16.09.01"')) {
+  log('> VP9, Profile 2, level 1, 10-bit YUV content, ' +
+      '4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ' + 
+      'ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, ' +
+      'full-range chroma/luma encoding.');
+}

--- a/media/vp9-codec-string.js
+++ b/media/vp9-codec-string.js
@@ -1,5 +1,5 @@
 if (MediaSource.isTypeSupported('video/webm; codecs="vp9"')) {
-  log('> VP9, Profile 0, level 1 (later fields defaulted)');
+  log('> Some VP9 profile');
 }
 
 if (MediaSource.isTypeSupported('video/webm; codecs="vp09.00.10.08"')) {
@@ -7,19 +7,22 @@ if (MediaSource.isTypeSupported('video/webm; codecs="vp09.00.10.08"')) {
 }
 
 if (MediaSource.isTypeSupported('video/webm; codecs="vp09.01.20.08.01"')) {
-  log('> VP9, Profile 0, level 1, bit depth 8, 4:2:0 chroma subsampling ' +
+  log('> VP9, Profile 1, level 2, bit depth 8, ' +
+      '4:2:0 chroma subsampling colocated with (0,0) luma, ' +
       '(later fields defaulted)');
 }
 
 if (MediaSource.isTypeSupported('video/webm; codecs="vp09.01.20.08.01.01.01.01.00"')) {
   log('> VP9, Profile 1, level 2, bit depth 8, ' +
-      '4:2:0 chroma subsampling, REC709 color/transfer/matrix, ' +
+      '4:2:0 chroma subsampling colocated with (0,0) luma, ' +
+      'REC709 color/transfer/matrix, ' +
       'luma/chroma encoded in the "legal" range.');
 }
 
 if (MediaSource.isTypeSupported('video/webm; codecs="vp09.02.10.10.01.09.16.09.01"')) {
   log('> VP9, Profile 2, level 1, 10-bit YUV content, ' +
-      '4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ' + 
+      '4:2:0 colocated with luma (0,0) chroma subsampling, ' +
+      'ITU-R BT.2020 primaries, ' +
       'ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, ' +
       'full-range chroma/luma encoding.');
 }


### PR DESCRIPTION
Hello @wolenetz,
This sample describes the upcoming new VP9 codec string and Profile 2 support in Chrome 60.

What do you think?

![screenshot 2017-05-29 at 1 04 20 pm - display 1](https://cloud.githubusercontent.com/assets/634478/26547452/765ce942-446f-11e7-9d1d-3fe678371957.png)
