### PR TITLE
Add choose file button to error-message sample

### DIFF
--- a/media/error-message.html
+++ b/media/error-message.html
@@ -14,6 +14,8 @@ Set video with:
 <button id="emptySrcButton">Empty src</button>
 <button id="nonExistentFileButton">Non existent file</button>
 <button id="invalidFileButton">Invalid file</button>
+Or
+<input id="chooseFileButton" type="file"/>
 
 {% include output_helper.html initial_output_content=initial_output_content %}
 

--- a/media/error-message.js
+++ b/media/error-message.js
@@ -24,6 +24,6 @@ chooseFileButton.addEventListener('change', function() {
 });
 
 video.addEventListener('canplay', function() {
-  ChromeSamples.log('Video can play!');
+  ChromeSamples.log('"canplay" event received');
 });
 

--- a/media/error-message.js
+++ b/media/error-message.js
@@ -17,3 +17,13 @@ nonExistentFileButton.addEventListener('click', function() {
 invalidFileButton.addEventListener('click', function() {
   video.src = 'https://storage.googleapis.com/media-error/no_streams.webm';
 });
+
+chooseFileButton.addEventListener('change', function() {
+  const file = chooseFileButton.files[0];
+  video.src = URL.createObjectURL(file);
+});
+
+video.addEventListener('canplay', function() {
+  ChromeSamples.log('Video can play!');
+});
+


### PR DESCRIPTION
I found myself using that often these days and thought it would benefit more users. So let's add a "Choose File" button to the official MediaError.message Sample.

Try it live at https://beaufortfrancois.github.io/samples/media/error-message.html

What do you think @wolenetz?