### PR TITLE
Changed Presentation Receiver API sample to Chrome 59+

### DIFF
--- a/presentation-api/index.html
+++ b/presentation-api/index.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Presentation Receiver API
-chrome_version: 58
+chrome_version: 59
 feature_id: 5414209298890752
 ---
 


### PR DESCRIPTION
@mfoltzgoogle Can you confirm the Presentation Receiver API was added in Chrome 59 not Chrome 58?