### PR TITLE
Reject if problem caching

### DIFF
--- a/service-worker/prefetch/service-worker.js
+++ b/service-worker/prefetch/service-worker.js
@@ -82,6 +82,7 @@ self.addEventListener('install', function(event) {
           return cache.put(urlToPrefetch, response);
         }).catch(function(error) {
           console.error('Not caching ' + urlToPrefetch + ' due to ' + error);
+          return Promise.reject(error);
         });
       });
 


### PR DESCRIPTION
Should presumably reject if the install fails to cache given that an offline app would normally be expected to work wholly offline.