### PR TITLE
Fix payment-request demos w/ regards to new specs

### DIFF
--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -7,7 +7,7 @@
  */
 function initPaymentRequest() {
   let supportedInstruments = [{
-    supportedMethods: ['https://android.com/pay'],
+    supportedMethods: 'https://android.com/pay',
     data: {
       merchantName: 'Android Pay Demo',
       // Place your own Android Pay merchant ID here. The merchant ID is tied to
@@ -102,11 +102,9 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -7,7 +7,7 @@
  */
 function initPaymentRequest() {
   let supportedInstruments = [{
-    supportedMethods: 'https://android.com/pay',
+    supportedMethods: ['https://android.com/pay'],
     data: {
       merchantName: 'Android Pay Demo',
       // Place your own Android Pay merchant ID here. The merchant ID is tied to
@@ -102,9 +102,11 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/android-pay/demo.js
+++ b/paymentrequest/android-pay/demo.js
@@ -7,7 +7,7 @@
  */
 function initPaymentRequest() {
   let supportedInstruments = [{
-    supportedMethods: ['https://android.com/pay'],
+    supportedMethods: 'https://android.com/pay',
     data: {
       merchantName: 'Android Pay Demo',
       // Place your own Android Pay merchant ID here. The merchant ID is tied to

--- a/paymentrequest/can-make-payment/demo.js
+++ b/paymentrequest/can-make-payment/demo.js
@@ -1,4 +1,56 @@
 /**
+ * Builds PaymentRequest for credit cards & Android Pay, but does not show any UI yet.
+ *
+ * @return {PaymentRequest} The PaymentRequest oject.
+ */
+function initPaymentRequest() {
+  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
+      'visa', 'mir'];
+  let types = ['debit', 'credit', 'prepaid'];
+  let supportedInstruments = [{
+    supportedMethods: 'https://android.com/pay',
+    data: {
+      merchantName: 'Android Pay Demo',
+      // Place your own Android Pay merchant ID here. The merchant ID is tied to
+      // the origin of the website.
+      merchantId: '00184145120947117657',
+      // If you do not yet have a merchant ID, uncomment the following line.
+      // environment: 'TEST',
+      allowedCardNetworks: ['AMEX', 'DISCOVER', 'MASTERCARD', 'VISA'],
+      paymentMethodTokenizationParameters: {
+        tokenizationType: 'GATEWAY_TOKEN',
+        parameters: {
+          'gateway': 'stripe',
+          // Place your own Stripe publishable key here. Use a matching Stripe
+          // secret key on the server to initiate a transaction.
+          'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
+          'stripe:version': '2016-07-06',
+        },
+      },
+    },
+  }, {
+    supportedMethods: 'basic-card',
+    data: {supportedNetworks: networks, supportedTypes: types},
+  }];
+
+  let details = {
+    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
+    displayItems: [
+      {
+        label: 'Original donation amount',
+        amount: {currency: 'USD', value: '65.00'},
+      },
+      {
+        label: 'Friends and family discount',
+        amount: {currency: 'USD', value: '-10.00'},
+      },
+    ],
+  };
+
+  return new PaymentRequest(supportedInstruments, details);
+}
+
+/**
  * The callback for successful creation of PaymentRequest.
  *
  * @callback successCallback
@@ -27,72 +79,27 @@
  * @param {failureCallback} onFailure The callback to invoke when this function
  * is finished with failure.
  */
-function initPaymentRequest(onSuccess, onFailure) {
+function testCanPaymentRequest(onSuccess, onFailure) {
   if (!window.PaymentRequest) {
     onFailure('This browser does not support web payments.');
     return;
   }
 
-  let networks = ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay',
-      'visa', 'mir'];
-  let types = ['debit', 'credit', 'prepaid'];
-  let supportedInstruments = [{
-    supportedMethods: ['https://android.com/pay'],
-    data: {
-      merchantName: 'Android Pay Demo',
-      // Place your own Android Pay merchant ID here. The merchant ID is tied to
-      // the origin of the website.
-      merchantId: '00184145120947117657',
-      // If you do not yet have a merchant ID, uncomment the following line.
-      // environment: 'TEST',
-      allowedCardNetworks: ['AMEX', 'DISCOVER', 'MASTERCARD', 'VISA'],
-      paymentMethodTokenizationParameters: {
-        tokenizationType: 'GATEWAY_TOKEN',
-        parameters: {
-          'gateway': 'stripe',
-          // Place your own Stripe publishable key here. Use a matching Stripe
-          // secret key on the server to initiate a transaction.
-          'stripe:publishableKey': 'pk_live_lNk21zqKM2BENZENh3rzCUgo',
-          'stripe:version': '2016-07-06',
-        },
-      },
-    },
-  }, {
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
-    data: {supportedNetworks: networks, supportedTypes: types},
-  }];
-
-  let details = {
-    total: {label: 'Donation', amount: {currency: 'USD', value: '55.00'}},
-    displayItems: [
-      {
-        label: 'Original donation amount',
-        amount: {currency: 'USD', value: '65.00'},
-      },
-      {
-        label: 'Friends and family discount',
-        amount: {currency: 'USD', value: '-10.00'},
-      },
-    ],
-  };
-
-  let request = new PaymentRequest(supportedInstruments, details);
+  let request = initPaymentRequest();
 
   if (request.canMakePayment) {
     request.canMakePayment().then(function(result) {
       if (result) {
-        onSuccess(request);
+        onSuccess();
       } else {
         onFailure('Cannot make payment');
       }
     }).catch(function(err) {
-      onSuccess(request, err);
+      onSuccess(err);
     });
   } else {
     onSuccess(
-        request, 'This browser does not support "can make payment" query');
+        'This browser does not support "can make payment" query');
   }
 }
 
@@ -155,13 +162,11 @@ function instrumentToJsonString(instrument) {
  * @param {HTMLElement} payButton The "Buy" button to initialize.
  */
 function initBuyButton(payButton) {
-  initPaymentRequest(function(request, optionalWarning) {
+  testCanPaymentRequest(function(optionalWarning) {
     payButton.setAttribute('style', 'display: inline;');
     ChromeSamples.setStatus(optionalWarning ? optionalWarning : '');
     payButton.addEventListener('click', function handleClick() {
-      payButton.removeEventListener('click', handleClick);
-      onBuyClicked(request);
-      initBuyButton(payButton);
+      onBuyClicked(initPaymentRequest());
     });
   }, function(error) {
     payButton.setAttribute('style', 'display: none;');

--- a/paymentrequest/can-make-payment/demo.js
+++ b/paymentrequest/can-make-payment/demo.js
@@ -37,7 +37,7 @@ function initPaymentRequest(onSuccess, onFailure) {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: ['https://android.com/pay'],
+    supportedMethods: 'https://android.com/pay',
     data: {
       merchantName: 'Android Pay Demo',
       // Place your own Android Pay merchant ID here. The merchant ID is tied to
@@ -58,9 +58,7 @@ function initPaymentRequest(onSuccess, onFailure) {
       },
     },
   }, {
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -99,11 +97,9 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -9,7 +9,9 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: 'basic-card',
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -97,9 +99,11 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/contact-info/demo.js
+++ b/paymentrequest/contact-info/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -8,9 +8,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -8,9 +8,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -88,11 +86,9 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/credit-cards/demo.js
+++ b/paymentrequest/credit-cards/demo.js
@@ -8,7 +8,9 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: 'basic-card',
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -86,9 +88,11 @@ function instrumentToJsonString(instrument) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -177,11 +175,9 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -9,7 +9,9 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: 'basic-card',
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -175,9 +177,11 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/dynamic-shipping/demo.js
+++ b/paymentrequest/dynamic-shipping/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -9,7 +9,9 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: 'basic-card',
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -135,9 +137,11 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/free-shipping/demo.js
+++ b/paymentrequest/free-shipping/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -137,11 +135,9 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -9,7 +9,9 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: 'basic-card',
+    supportedMethods: networks,
+  }, {
+    supportedMethods: ['basic-card'],
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -178,9 +180,11 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
+  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(initPaymentRequest());
+    onBuyClicked(request);
+    request = initPaymentRequest();
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 

--- a/paymentrequest/shipping-options/demo.js
+++ b/paymentrequest/shipping-options/demo.js
@@ -9,9 +9,7 @@ function initPaymentRequest() {
       'visa', 'mir'];
   let types = ['debit', 'credit', 'prepaid'];
   let supportedInstruments = [{
-    supportedMethods: networks,
-  }, {
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {supportedNetworks: networks, supportedTypes: types},
   }];
 
@@ -180,11 +178,9 @@ function addressToDictionary(address) {
 const payButton = document.getElementById('buyButton');
 payButton.setAttribute('style', 'display: none;');
 if (window.PaymentRequest) {
-  let request = initPaymentRequest();
   payButton.setAttribute('style', 'display: inline;');
   payButton.addEventListener('click', function() {
-    onBuyClicked(request);
-    request = initPaymentRequest();
+    onBuyClicked(initPaymentRequest());
   });
 } else {
   ChromeSamples.setStatus('This browser does not support web payments');


### PR DESCRIPTION
Current state of **PaymentRequest** demos had two problems related to the ongoing specs:

1. Use of `supportedMethods` is now a *String* rather than an *Array*
2. Re-using the same **PaymentRequest** instance when clicking on "Buy" would lead to errors (at least on FF). I have not delved too much into the causes, but my intuitition is that showing a previous **PaymentRequest** causes an error (as it wasn't part of "user activation")
<img width="775" alt="image" src="https://user-images.githubusercontent.com/8869660/39898255-451849f0-54b6-11e8-928a-3a13670d442c.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/8869660/39898387-bcb9daaa-54b6-11e8-9567-dfb607b05739.png">


Fix to **1** was trivial. 
Fix to **2** required to create a new **PaymentRequest** instance every time we wanted to show the interface. 

With the current PR, the demos now work well with the new specs.

Note: this can replace PR #534.

CC: @rsolomakhin @mnoorenberghe 
