### PR TITLE
Move Android Pay sample to Google Pay

### DIFF
--- a/paymentrequest/google-pay/demo.js
+++ b/paymentrequest/google-pay/demo.js
@@ -1,16 +1,16 @@
 /**
- * Builds PaymentRequest for Android Pay, but does not show any UI yet. If you
+ * Builds PaymentRequest for Google Pay, but does not show any UI yet. If you
  * encounter issues when running your own copy of this sample, run 'adb logcat |
- * grep Wallet' to see detailed error messages.
+ * grep Wallet' to see detailed error messages or watch Chrome DevTools console.
  *
  * @return {PaymentRequest} The PaymentRequest object.
  */
 function initPaymentRequest() {
   let supportedInstruments = [{
-    supportedMethods: 'https://android.com/pay',
+    supportedMethods: 'https://google.com/pay',
     data: {
-      merchantName: 'Android Pay Demo',
-      // Place your own Android Pay merchant ID here. The merchant ID is tied to
+      merchantName: 'Google Pay Demo',
+      // Place your own Google Pay merchant ID here. The merchant ID is tied to
       // the origin of the website.
       merchantId: '00184145120947117657',
       // If you do not yet have a merchant ID, uncomment the following line.
@@ -47,7 +47,7 @@ function initPaymentRequest() {
 }
 
 /**
- * Invokes PaymentRequest for Android Pay.
+ * Invokes PaymentRequest for Google Pay.
  *
  * @param {PaymentRequest} request The PaymentRequest object.
  */

--- a/paymentrequest/google-pay/index.html
+++ b/paymentrequest/google-pay/index.html
@@ -1,5 +1,5 @@
 ---
-feature_name: PaymentRequest Android Pay
+feature_name: PaymentRequest Google Pay
 chrome_version: 53
 feature_id: 5639348045217792
 ---
@@ -11,7 +11,7 @@ feature_id: 5639348045217792
 </p>
 
 <p>
-  This sample accepts Android Pay payments and does not request shipping
+  This sample accepts Google Pay payments and does not request shipping
   information.
 </p>
 


### PR DESCRIPTION
Changes:
* The payment method name changed from https://android.com/pay to https://google.com/pay
* Various comment changes