### PR TITLE
Make an unedited sample not create a gist

### DIFF
--- a/fetch-api/fetch-post.html
+++ b/fetch-api/fetch-post.html
@@ -8,9 +8,10 @@ feature_id: 6730533392351232
 <p>This sample shows how the Fetch API can make POST requests.</p>
 
 <textarea autofocus id="gist" cols="80" rows="10">
-// Enter some JavaScript here
-// e.g
 </textarea>
+<script>
+  document.getElementById("gist").placeholder = "// Enter some JavaScript here\n// e.g\n";
+</script>
 <p><button>Create new GitHub Gist</button></p>
 
 {% include output_helper.html %}


### PR DESCRIPTION
Pre-populating the box means that just pushing the button creates a bad gist.
Instead, use placeholder to show the instructions.