### PR TITLE
Adds `controls` attribute to final controlsList media sample

### DIFF
--- a/media/controlslist.html
+++ b/media/controlslist.html
@@ -52,6 +52,6 @@ the ability to set them directly from HTML content using the new attribute
   <pre>&lt;video controls controlsList="nodownload nofullscreen noremoteplayback"&gt;</pre>
 </div>
 <div>
-  <video controlsList="nodownload nofullscreen noremoteplayback" src="//storage.googleapis.com/media-session/caminandes/short.mp4#t=90"></video>
+  <video controls controlsList="nodownload nofullscreen noremoteplayback" src="//storage.googleapis.com/media-session/caminandes/short.mp4#t=90"></video>
   <pre>&lt;video controlsList="nodownload nofullscreen noremoteplayback"&gt;</pre>
 </div>


### PR DESCRIPTION
The final sample on the controlsList samples page is missing the `controls` attribute, so you can't see the controls.