### PR TITLE
Update CSS motion path demo to use current property names

### DIFF
--- a/css-motion-path/demo.js
+++ b/css-motion-path/demo.js
@@ -1,20 +1,20 @@
 var firstScissorHalf = document.querySelector('#firstScissorHalf');
 var secondScissorHalf = document.querySelector('#secondScissorHalf');
 
-var positionKeyframes = [{motionOffset: '0%'}, {motionOffset: '100%'}];
+var positionKeyframes = [{offsetDistance: '0%'}, {offsetDistance: '100%'}];
 var positionTiming = {duration: 12000, iterations: Infinity};
 firstScissorHalf.animate(positionKeyframes, positionTiming);
 secondScissorHalf.animate(positionKeyframes, positionTiming);
 
 var firstRotationKeyframes = [
-  {motionRotation: 'auto 0deg'},
-  {motionRotation: 'auto -45deg'},
-  {motionRotation: 'auto 0deg'}
+  {offsetRotate: 'auto 0deg'},
+  {offsetRotate: 'auto -45deg'},
+  {offsetRotate: 'auto 0deg'}
 ];
 var secondRotationKeyframes = [
-  {motionRotation: 'auto 0deg'},
-  {motionRotation: 'auto 45deg'},
-  {motionRotation: 'auto 0deg'}
+  {offsetRotate: 'auto 0deg'},
+  {offsetRotate: 'auto 45deg'},
+  {offsetRotate: 'auto 0deg'}
 ];
 var rotationTiming = {duration: 1000, iterations: Infinity};
 firstScissorHalf.animate(firstRotationKeyframes, rotationTiming);

--- a/css-motion-path/index.html
+++ b/css-motion-path/index.html
@@ -10,8 +10,8 @@ feature_id: 6190642178818048
   graphical objects along paths, specified using CSS.
 </p>
 <p>
-  It introduces the following new CSS properties: <code>motion-offset</code>,
-  <code>motion-path</code>, and <code>motion-rotation</code>.
+  It introduces the following new CSS properties: <code>offset-distance</code>,
+  <code>offset-path</code>, and <code>offset-rotate</code>.
 </p>
 
 {% capture html %}
@@ -58,11 +58,11 @@ feature_id: 6190642178818048
 
 {% capture css %}
 #firstScissorHalf {
-  motion-path: path('M900,190  L993,245 V201  A11,11 0 0,1 1004,190  H1075  A11,11 0 0,1 1086,201  V300  L1294,423 H1216  A11,11 0 0,0 1205,434  V789  A11,11 0 0,1 1194,800  H606  A11,11 0 0,1 595,789  V434  A11,11 0 0,0 584,423  H506 L900,190');
+  offset-path: path('M900,190  L993,245 V201  A11,11 0 0,1 1004,190  H1075  A11,11 0 0,1 1086,201  V300  L1294,423 H1216  A11,11 0 0,0 1205,434  V789  A11,11 0 0,1 1194,800  H606  A11,11 0 0,1 595,789  V434  A11,11 0 0,0 584,423  H506 L900,190');
 }
 
 #secondScissorHalf {
-  motion-path: path('M900,190  L993,245 V201  A11,11 0 0,1 1004,190  H1075  A11,11 0 0,1 1086,201  V300  L1294,423 H1216  A11,11 0 0,0 1205,434  V789  A11,11 0 0,1 1194,800  H606  A11,11 0 0,1 595,789  V434  A11,11 0 0,0 584,423  H506 L900,190');
+  offset-path: path('M900,190  L993,245 V201  A11,11 0 0,1 1004,190  H1075  A11,11 0 0,1 1086,201  V300  L1294,423 H1216  A11,11 0 0,0 1205,434  V789  A11,11 0 0,1 1194,800  H606  A11,11 0 0,1 595,789  V434  A11,11 0 0,0 584,423  H506 L900,190');
 }
 {% endcapture %}
 {% include css_snippet.html css=css %}


### PR DESCRIPTION
Demo isn't working currently since it's using the old property names.  This change fixes that.