### PR TITLE
Add "Skip Ad in Picture-in-Picture window" sample

### DIFF
--- a/picture-in-picture/skip-ad.html
+++ b/picture-in-picture/skip-ad.html
@@ -1,0 +1,46 @@
+---
+feature_name: Skip Ad in Picture-in-Picture window
+chrome_version: 73
+feature_id: 4749278882824192
+check_min_version: true
+---
+
+<h3>Background</h3>
+<p>
+The <a href="https://wicg.github.io/media-session/">Media Session API</a> has
+a <code>skipad</code> action handler web developers can use to show a "Skip Ad"
+button in the Picture-in-Picture window and be notified when user a interacts
+with it.
+</p>
+<p>
+Note: In Chrome 73, it is <a
+href="https://developers.chrome.com/origintrials">available for trials</a> so
+that websites can use it without any experimental flag.
+</p>
+<p>
+Credits: Media files are © copyright Blender Foundation | <a href="http://www.blender.org">www.blender.org</a>.
+</p>
+
+<style>
+  video { background: #1e2327; border-radius: 4px; width: 100%; }
+  button { margin: 4px 0; }
+</style>
+
+<video id="video" controls playsinline
+    src="https://storage.googleapis.com/media-session/big-buck-bunny/trailer.mov"
+    poster="https://storage.googleapis.com/media-session/caminandes/artwork-512.png"></video>
+<button id="enterPictureInPictureButton">Enter Picture-in-Picture</button>
+
+{% include output_helper.html %}
+
+<script>
+  if (!('pictureInPictureEnabled' in document)) {
+    ChromeSamples.setStatus('The Picture-in-Picture API is not available.');
+  } else if (!document.pictureInPictureEnabled) {
+    ChromeSamples.setStatus('The Picture-in-Picture API is disabled.');
+  }
+
+  log = ChromeSamples.log;
+</script>
+
+{% include js_snippet.html filename='skip-ad.js' %}

--- a/picture-in-picture/skip-ad.js
+++ b/picture-in-picture/skip-ad.js
@@ -1,8 +1,13 @@
 try {
-  navigator.mediaSession.setActionHandler('skipad', onSkipAdButtonClick);
-  log('The Picture-in-Picture window will show a "Skip Ad" button.');
+  navigator.mediaSession.setActionHandler('skipad', null);
+  showSkipAdButton();
 } catch(error) {
   log('Argh! The "Skip Ad" media session action is not supported.');
+}
+
+function showSkipAdButton() {
+  log('The Picture-in-Picture window will show a "Skip Ad" button.');
+  navigator.mediaSession.setActionHandler('skipad', onSkipAdButtonClick);
 }
 
 // Hide "Skip Ad" button when user clicks it and play another video.

--- a/picture-in-picture/skip-ad.js
+++ b/picture-in-picture/skip-ad.js
@@ -1,0 +1,20 @@
+try {
+  navigator.mediaSession.setActionHandler('skipad', onSkipAdButtonClick);
+  log('The Picture-in-Picture window will show a "Skip Ad" button.');
+} catch(error) {
+  log('Argh! The "Skip Ad" media session action is not supported.');
+}
+
+// Hide "Skip Ad" button when user clicks it and play another video.
+function onSkipAdButtonClick() {
+  log('> User clicked "Skip Ad" button.');
+  navigator.mediaSession.setActionHandler('skipad', null);
+
+  video.src = "https://storage.googleapis.com/media-session/caminandes/short.mp4";
+  video.play();
+}
+
+enterPictureInPictureButton.addEventListener('click', async () => {
+  await video.play();
+  await video.requestPictureInPicture();
+});


### PR DESCRIPTION
This sample is about the "Skip Ad in Picture-in-Picture window" experimental feature.

Live preview will be available after https://github.com/GoogleChrome/samples/pull/628 is merged so that I can push this branch on my gh-pages branch.

R= @mounirlamouri 

![image](https://user-images.githubusercontent.com/634478/52277288-a690a600-2954-11e9-8bd6-11f273562d9e.png)
