### PR TITLE
fix call stack error in setter for classes-es6 sample

### DIFF
--- a/classes-es6/demo.js
+++ b/classes-es6/demo.js
@@ -77,7 +77,7 @@ class Square extends Polygon {
   }
 
   set area(value) {
-    this.area = value;
+    this._area = value;
   }
 }
 


### PR DESCRIPTION
fix `Uncaught RangeError: Maximum call stack size exceeded` in Square class's setter for classes-es6 sample. 
Note: this can replace PR #616 .

CC: @jeffposnick @beaufortfrancois 