### PR TITLE
[paymentrequest] Remove broken link

### DIFF
--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -36,10 +36,6 @@ feature_id: 5639348045217792
     both Android Pay and credit card payments and checks whether the browser can
     make payment.</li>
 
-  <li><a href="https://emerald-eon.appspot.com">Server side</a> - sample that
-    demonstrates server-side calculation of shipping price and processing
-    transactions through a payment service provider.</li>
-
   <li><a href="stickersheet/">Stickersheet</a>  -
   A stickersheet that allows you to design a payments flow in Sketch App.</li>
 </ul>


### PR DESCRIPTION
With the assumption that https://emerald-eon.appspot.com/ is down permanently, this PR removes the link and description to the server-side demo.