### PR TITLE
Add Web Bluetooth Availability Sample

### DIFF
--- a/web-bluetooth/availability-async-await.html
+++ b/web-bluetooth/availability-async-await.html
@@ -1,0 +1,20 @@
+---
+feature_name: Web Bluetooth / Availability (Async Await)
+chrome_version: 79
+check_min_version: true
+feature_id: 6229592081694720
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to determine whether
+Bluetooth is available. You may want to check out the <a
+href="availability.html">Availability (Promises)</a> sample.</p>
+
+{% include output_helper.html %}
+
+{% include_relative _includes/utils.html %}
+
+{% include js_snippet.html filename='availability-async-await.js' %}

--- a/web-bluetooth/availability-async-await.html
+++ b/web-bluetooth/availability-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Availability (Async Await)
-chrome_version: 79
+chrome_version: 78
 check_min_version: true
 feature_id: 6229592081694720
 icon_url: icon.png

--- a/web-bluetooth/availability-async-await.js
+++ b/web-bluetooth/availability-async-await.js
@@ -1,0 +1,12 @@
+(async () => {
+  try {
+    const isBluetoothAvailable = await navigator.bluetooth.getAvailability();
+    log(`> Bluetooth is ${isBluetoothAvailable ? 'available' : 'unavailable'}`);
+  } catch(error) {
+    log('Argh! ' + error);
+  }
+})();
+
+navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
+  log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
+});

--- a/web-bluetooth/availability-async-await.js
+++ b/web-bluetooth/availability-async-await.js
@@ -7,6 +7,8 @@
   }
 })();
 
-navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
-  log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
-});
+if ('onavailabilitychanged' in navigator.bluetooth) {
+  navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
+    log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
+  });
+}

--- a/web-bluetooth/availability.html
+++ b/web-bluetooth/availability.html
@@ -1,0 +1,20 @@
+---
+feature_name: Web Bluetooth / Availability
+chrome_version: 79
+check_min_version: true
+feature_id: 6229592081694720
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to determine whether
+Bluetooth is available. You may want to check out the <a
+href="availability-async-await.html">Availability (Async Await)</a> sample.</p>
+
+{% include output_helper.html %}
+
+{% include_relative _includes/utils.html %}
+
+{% include js_snippet.html filename='availability.js' %}

--- a/web-bluetooth/availability.html
+++ b/web-bluetooth/availability.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Availability
-chrome_version: 79
+chrome_version: 78
 check_min_version: true
 feature_id: 6229592081694720
 icon_url: icon.png

--- a/web-bluetooth/availability.js
+++ b/web-bluetooth/availability.js
@@ -3,6 +3,8 @@ navigator.bluetooth.getAvailability()
   log(`> Bluetooth is ${isBluetoothAvailable ? 'available' : 'unavailable'}`);
 });
 
-navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
-  log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
-});
+if ('onavailabilitychanged' in navigator.bluetooth) {
+  navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
+    log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
+  });
+}

--- a/web-bluetooth/availability.js
+++ b/web-bluetooth/availability.js
@@ -1,0 +1,8 @@
+navigator.bluetooth.getAvailability()
+.then(isBluetoothAvailable => {
+  log(`> Bluetooth is ${isBluetoothAvailable ? 'available' : 'unavailable'}`);
+});
+
+navigator.bluetooth.addEventListener('availabilitychanged', function(event) {
+  log(`> Bluetooth is ${event.value ? 'available' : 'unavailable'}`);
+});

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -18,6 +18,7 @@ icon_url: icon.png
 <p><a href="device-disconnect.html">Device Disconnect (Promises)</a> / <a href="device-disconnect-async-await.html">Device Disconnect (Async Await)</a> - disconnect and get notified from a disconnection of a BLE Device after connecting to it.</p>
 <p><a href="get-characteristics.html">Get Characteristics (Promises)</a> - / <a href="get-characteristics-async-await.html">Get Characteristics (Async Await)</a> - get all characteristics of an advertised service from a BLE Device.</p>
 <p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> - get all characteristic's descriptors of an advertised service from a BLE Device.</p>
+<p><a href="availability.html">Availability (Promises)</a> / <a href="availability-async-await.html">Availability (Async Await)</a> - determine whether Bluetooth is available.</p>
 
 <h3>Combining multiple operations</h3>
 


### PR DESCRIPTION
This PR is adding two samples for [Web Bluetooth getAvailability()](https://www.chromestatus.com/features/6229592081694720)

Does that look good @odejesush?

Live preview:
https://beaufortfrancois.github.io/samples/web-bluetooth/availability.html
https://beaufortfrancois.github.io/samples/web-bluetooth/availability-async-await.html
https://beaufortfrancois.github.io/samples/web-bluetooth/index.html

FYI @jyasskin @g-ortuno @scheib 