### PR TITLE
Add "Get Devices" and "Watch Advertisements" Web Bluetooth samples

### DIFF
--- a/web-bluetooth/get-devices-async-await.html
+++ b/web-bluetooth/get-devices-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices (Async Await)
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices-async-await.html
+++ b/web-bluetooth/get-devices-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices (Async Await)
-chrome_version: 86
+chrome_version: 85
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices-async-await.html
+++ b/web-bluetooth/get-devices-async-await.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Get Devices (Async Await)
+chrome_version: 82
+check_min_version: true
+feature_id: 4797798639730688
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to get a list of
+Bluetooth devices that the website has been granted permission to use by the
+user. You may want to check out the <a href="get-devices.html">Get Devices</a>
+sample.</p>
+
+<button id="getBluetoothDevices">Get Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='get-devices-async-await.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+    document.querySelector('#getBluetoothDevices').addEventListener('click', function() {
+        onGetBluetoothDevicesButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/get-devices-async-await.html
+++ b/web-bluetooth/get-devices-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices (Async Await)
-chrome_version: 82
+chrome_version: 86
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices-async-await.html
+++ b/web-bluetooth/get-devices-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices (Async Await)
-chrome_version: 85
+chrome_version: 86
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices-async-await.js
+++ b/web-bluetooth/get-devices-async-await.js
@@ -1,0 +1,29 @@
+async function onGetBluetoothDevicesButtonClick() {
+  try {
+    log('Getting existing permitted Bluetooth devices...');
+    const devices = await navigator.bluetooth.getDevices();
+
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    for (const device of devices) {
+      log('  > ' + device.name + ' (' + device.id + ')');
+    }
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+async function onRequestBluetoothDeviceButtonClick() {
+  try {
+    // Caution: This may result in a bunch of unrelated devices being shown in
+    // the chooser and energy being wasted as there are no filters. Use it with
+    // caution.
+    log('Requesting any Bluetooth device...'); 
+    const device = await navigator.bluetooth.requestDevice({ acceptAllDevices: true });
+    
+    log('> Requested ' + device.name + ' (' + device.id + ')');
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}

--- a/web-bluetooth/get-devices-async-await.js
+++ b/web-bluetooth/get-devices-async-await.js
@@ -15,12 +15,12 @@ async function onGetBluetoothDevicesButtonClick() {
 
 async function onRequestBluetoothDeviceButtonClick() {
   try {
-    // Caution: This may result in a bunch of unrelated devices being shown in
-    // the chooser and energy being wasted as there are no filters. Use it with
-    // caution.
-    log('Requesting any Bluetooth device...'); 
-    const device = await navigator.bluetooth.requestDevice({ acceptAllDevices: true });
-    
+    log('Requesting any Bluetooth device...');
+    const device = await navigator.bluetooth.requestDevice({
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true
+    });
+
     log('> Requested ' + device.name + ' (' + device.id + ')');
   }
   catch(error) {

--- a/web-bluetooth/get-devices.html
+++ b/web-bluetooth/get-devices.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Get Devices
+chrome_version: 82
+check_min_version: true
+feature_id: 4797798639730688
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to get a list of
+Bluetooth devices that the website has been granted permission to use by the
+user. You may want to check out the <a href="get-devices-async-await.html">Get
+Devices (Async Await)</a> sample.</p>
+
+<button id="getBluetoothDevices">Get Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='get-devices.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+    document.querySelector('#getBluetoothDevices').addEventListener('click', function() {
+        onGetBluetoothDevicesButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/get-devices.html
+++ b/web-bluetooth/get-devices.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices
-chrome_version: 86
+chrome_version: 85
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices.html
+++ b/web-bluetooth/get-devices.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices.html
+++ b/web-bluetooth/get-devices.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices
-chrome_version: 85
+chrome_version: 86
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png

--- a/web-bluetooth/get-devices.html
+++ b/web-bluetooth/get-devices.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Get Devices
-chrome_version: 82
+chrome_version: 86
 check_min_version: true
 feature_id: 4797798639730688
 icon_url: icon.png
@@ -25,11 +25,11 @@ Devices (Async Await)</a> sample.</p>
 
 <script>
   if (isWebBluetoothEnabled()) {
-    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
-        onRequestBluetoothDeviceButtonClick();
-    });
     document.querySelector('#getBluetoothDevices').addEventListener('click', function() {
         onGetBluetoothDevicesButtonClick();
+    });
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
     });
   }
 </script>

--- a/web-bluetooth/get-devices.js
+++ b/web-bluetooth/get-devices.js
@@ -1,0 +1,27 @@
+function onGetBluetoothDevicesButtonClick() {
+  log('Getting existing permitted Bluetooth devices...');
+  navigator.bluetooth.getDevices()
+  .then(devices => {
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    for (const device of devices) {
+      log('  > ' + device.name + ' (' + device.id + ')');
+    }
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function onRequestBluetoothDeviceButtonClick() {
+  // Caution: This may result in a bunch of unrelated devices being shown in the
+  // chooser and energy being wasted as there are no filters. Use it with
+  // caution.
+  log('Requesting any Bluetooth device...'); 
+  navigator.bluetooth.requestDevice({ acceptAllDevices: true })
+  .then(device => {
+    log('> Requested ' + device.name + ' (' + device.id + ')');
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}

--- a/web-bluetooth/get-devices.js
+++ b/web-bluetooth/get-devices.js
@@ -13,11 +13,11 @@ function onGetBluetoothDevicesButtonClick() {
 }
 
 function onRequestBluetoothDeviceButtonClick() {
-  // Caution: This may result in a bunch of unrelated devices being shown in the
-  // chooser and energy being wasted as there are no filters. Use it with
-  // caution.
-  log('Requesting any Bluetooth device...'); 
-  navigator.bluetooth.requestDevice({ acceptAllDevices: true })
+  log('Requesting any Bluetooth device...');
+  navigator.bluetooth.requestDevice({
+ // filters: [...] <- Prefer filters to save energy & show relevant devices.
+    acceptAllDevices: true
+  })
   .then(device => {
     log('> Requested ' + device.name + ' (' + device.id + ')');
   })

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -19,6 +19,7 @@ icon_url: icon.png
 <p><a href="get-characteristics.html">Get Characteristics (Promises)</a> - / <a href="get-characteristics-async-await.html">Get Characteristics (Async Await)</a> - get all characteristics of an advertised service from a BLE Device.</p>
 <p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> - get all characteristic's descriptors of an advertised service from a BLE Device.</p>
 <p><a href="availability.html">Availability (Promises)</a> / <a href="availability-async-await.html">Availability (Async Await)</a> - determine whether Bluetooth is available.</p>
+<p><a href="get-devices.html">Get Devices (Promises)</a> / <a href="get-devices-async-await.html">Get Devices (Async Await)</a> - get permitted Bluetooth devices.</p>
 
 <h3>Combining multiple operations</h3>
 
@@ -33,6 +34,7 @@ icon_url: icon.png
 
 <h3>Scanning</h3>
 <p><a href="scan.html">Scan for Advertisements</a> - Basic scan for advertisements.</p>
+<p><a href="watch-advertisements.html">Watch Advertisements (Promises)</a> / <a href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> - watch advertisements and connect to permitted Bluetooth devices.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -20,6 +20,7 @@ icon_url: icon.png
 <p><a href="get-descriptors.html">Get Descriptors (Promises)</a> - / <a href="get-descriptors-async-await.html">Get Descriptors (Async Await)</a> - get all characteristic's descriptors of an advertised service from a BLE Device.</p>
 <p><a href="availability.html">Availability (Promises)</a> / <a href="availability-async-await.html">Availability (Async Await)</a> - determine whether Bluetooth is available.</p>
 <p><a href="get-devices.html">Get Devices (Promises)</a> / <a href="get-devices-async-await.html">Get Devices (Async Await)</a> - get permitted Bluetooth devices.</p>
+<p><a href="watch-advertisements.html">Watch Advertisements (Promises)</a> / <a href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> - watch advertisements from a BLE device.</p>
 
 <h3>Combining multiple operations</h3>
 
@@ -31,11 +32,10 @@ icon_url: icon.png
 <p><a href="read-characteristic-value-changed.html">Read Characteristic Value Changed (Promises)</a> / <a href="read-characteristic-value-changed-async-await.html">Read Characteristic Value Changed (Async Await)</a> - read battery level and be notified of changes from a BLE Device.</p>
 <p><a href="read-descriptors.html">Read Descriptors (Promises)</a> / <a href="read-descriptors-async-await.html">Read Descriptors (Async Await)</a> - read all characteristic's descriptors of a service from a BLE Device.</p>
 <p><a href="write-descriptor.html">Write Descriptor (Promises)</a> / <a href="write-descriptor-async-await.html">Write Descriptor (Async Await)</a> - write to the descriptor "Characteristic User Description" on a BLE Device.</p>
+<p><a href="watch-advertisements-and-connect.html">Watch Advertisements & Connect (Promises)</a> / <a href="watch-advertisements-and-connect-async-await.html">Watch Advertisements & Connect (Async Await)</a> - watch advertisements and connect to permitted Bluetooth devices.</p>
 
 <h3>Scanning</h3>
-<p><a href="scan.html">Scan for Advertisements</a> - Basic scan for advertisements.</p>
-<p><a href="watch-advertisements.html">Watch Advertisements (Promises)</a> / <a href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> - watch advertisements from a BLE device.</p>
-<p><a href="watch-advertisements-and-connect.html">Watch Advertisements & Connect (Promises)</a> / <a href="watch-advertisements-and-connect-async-await.html">Watch Advertisements & Connect (Async Await)</a> - watch advertisements and connect to permitted Bluetooth devices.</p>
+<p><a href="scan.html">Scan for Advertisements</a> - Scan for all advertisements data from nearby Bluetooth devices.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/index.html
+++ b/web-bluetooth/index.html
@@ -34,7 +34,8 @@ icon_url: icon.png
 
 <h3>Scanning</h3>
 <p><a href="scan.html">Scan for Advertisements</a> - Basic scan for advertisements.</p>
-<p><a href="watch-advertisements.html">Watch Advertisements (Promises)</a> / <a href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> - watch advertisements and connect to permitted Bluetooth devices.</p>
+<p><a href="watch-advertisements.html">Watch Advertisements (Promises)</a> / <a href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> - watch advertisements from a BLE device.</p>
+<p><a href="watch-advertisements-and-connect.html">Watch Advertisements & Connect (Promises)</a> / <a href="watch-advertisements-and-connect-async-await.html">Watch Advertisements & Connect (Async Await)</a> - watch advertisements and connect to permitted Bluetooth devices.</p>
 
 <script>
   if('serviceWorker' in navigator) {

--- a/web-bluetooth/watch-advertisements-and-connect-async-await.html
+++ b/web-bluetooth/watch-advertisements-and-connect-async-await.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Watch Advertisements & Connect (Async Await)
+chrome_version: 85
+check_min_version: true
+feature_id: 5180688812736512
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to check if a
+permitted Bluetooth device is in range of the system before attempting to
+connect to the Bluetooth device. You may want to check out the <a
+href="watch-advertisements-and-connect.html">Watch Advertisements</a> sample.</p>
+
+<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='watch-advertisements-and-connect-async-await.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
+        onConnectToBluetoothDevicesButtonClick();
+    });
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/watch-advertisements-and-connect-async-await.html
+++ b/web-bluetooth/watch-advertisements-and-connect-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements & Connect (Async Await)
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements-and-connect-async-await.html
+++ b/web-bluetooth/watch-advertisements-and-connect-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements & Connect (Async Await)
-chrome_version: 85
+chrome_version: 86
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements-and-connect-async-await.js
+++ b/web-bluetooth/watch-advertisements-and-connect-async-await.js
@@ -1,0 +1,57 @@
+async function onConnectToBluetoothDevicesButtonClick() {
+  try {
+    log('Getting existing permitted Bluetooth devices...');
+    const devices = await navigator.bluetooth.getDevices();
+
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    // These devices may not be powered on or in range, so scan for
+    // advertisement packets from them before connecting.
+    for (const device of devices) {
+      connectToBluetoothDevice(device);
+    }
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+async function connectToBluetoothDevice(device) {
+  const abortController = new AbortController();
+
+  device.addEventListener('advertisementreceived', async (event) => {
+    log('> Received advertisement from "' + device.name + '"...');
+    // Stop watching advertisements to conserve battery life.
+    abortController.abort();
+    log('Connecting to GATT Server from "' + device.name + '"...');
+    try {
+      await device.gatt.connect()
+      log('> Bluetooth device "' +  device.name + ' connected.');
+    }
+    catch(error) {
+      log('Argh! ' + error);
+    }
+  }, { once: true });
+
+  try {
+    log('Watching advertisements from "' + device.name + '"...');
+    await device.watchAdvertisements({ signal: abortController.signal });
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+async function onRequestBluetoothDeviceButtonClick() {
+  try {
+    log('Requesting any Bluetooth device...');
+    const device = await navigator.bluetooth.requestDevice({
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true
+    });
+
+    log('> Requested ' + device.name);
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}

--- a/web-bluetooth/watch-advertisements-and-connect.html
+++ b/web-bluetooth/watch-advertisements-and-connect.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements & Connect
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements-and-connect.html
+++ b/web-bluetooth/watch-advertisements-and-connect.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements & Connect
-chrome_version: 85
+chrome_version: 86
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements-and-connect.html
+++ b/web-bluetooth/watch-advertisements-and-connect.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Watch Advertisements & Connect
+chrome_version: 85
+check_min_version: true
+feature_id: 5180688812736512
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to check if a
+permitted Bluetooth device is in range of the system before attempting to
+connect to the Bluetooth device. You may want to check out the <a
+href="watch-advertisements-and-connect-async-await.html">Watch Advertisements & Connect (Async Await)</a> sample.</p>
+
+<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='watch-advertisements-and-connect.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
+        onConnectToBluetoothDevicesButtonClick();
+    });
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/watch-advertisements-and-connect.js
+++ b/web-bluetooth/watch-advertisements-and-connect.js
@@ -1,0 +1,53 @@
+function onConnectToBluetoothDevicesButtonClick() {
+  log('Getting existing permitted Bluetooth devices...');
+  navigator.bluetooth.getDevices()
+  .then(devices => {
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    // These devices may not be powered on or in range, so scan for
+    // advertisement packets from them before connecting.
+    for (const device of devices) {
+      connectToBluetoothDevice(device);
+    }
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function connectToBluetoothDevice(device) {
+  const abortController = new AbortController();
+
+  device.addEventListener('advertisementreceived', (event) => {
+    log('> Received advertisement from "' + device.name + '"...');
+    // Stop watching advertisements to conserve battery life.
+    abortController.abort();
+    log('Connecting to GATT Server from "' + device.name + '"...');
+    device.gatt.connect()
+    .then(() => {
+      log('> Bluetooth device "' +  device.name + ' connected.');
+    })
+    .catch(error => {
+      log('Argh! ' + error);
+    });
+  }, { once: true });
+
+  log('Watching advertisements from "' + device.name + '"...');
+  device.watchAdvertisements({ signal: abortController.signal })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function onRequestBluetoothDeviceButtonClick() {
+  log('Requesting any Bluetooth device...');
+  navigator.bluetooth.requestDevice({
+ // filters: [...] <- Prefer filters to save energy & show relevant devices.
+    acceptAllDevices: true
+  })
+  .then(device => {
+    log('> Requested ' + device.name);
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}

--- a/web-bluetooth/watch-advertisements-async-await.html
+++ b/web-bluetooth/watch-advertisements-async-await.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements (Async Await)
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements-async-await.html
+++ b/web-bluetooth/watch-advertisements-async-await.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Watch Advertisements (Async Await)
+chrome_version: 86
+check_min_version: true
+feature_id: 5180688812736512
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to check if a
+permitted Bluetooth device is in range of the system before attempting to
+connect to the Bluetooth device. You may want to check out the <a
+href="watch-advertisements.html">Watch Advertisements</a> sample.</p>
+
+<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='watch-advertisements-async-await.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
+        onConnectToBluetoothDevicesButtonClick();
+    });
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/watch-advertisements-async-await.html
+++ b/web-bluetooth/watch-advertisements-async-await.html
@@ -9,13 +9,11 @@ index: index.html
 
 {% include_relative _includes/intro.html %}
 
-<p>This sample illustrates the use of the Web Bluetooth API to check if a
-permitted Bluetooth device is in range of the system before attempting to
-connect to the Bluetooth device. You may want to check out the <a
+<p>This sample illustrates the use of the Web Bluetooth API to read out
+advertisement data from nearby Bluetooth devices. You may want to check out the <a
 href="watch-advertisements.html">Watch Advertisements</a> sample.</p>
 
-<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
-<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+<button id="watchAdvertisements">Watch Advertisements</button>
 
 {% include output_helper.html %}
 
@@ -25,11 +23,8 @@ href="watch-advertisements.html">Watch Advertisements</a> sample.</p>
 
 <script>
   if (isWebBluetoothEnabled()) {
-    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
-        onConnectToBluetoothDevicesButtonClick();
-    });
-    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
-        onRequestBluetoothDeviceButtonClick();
+    document.querySelector('#watchAdvertisements').addEventListener('click', function() {
+        onWatchAdvertisementsButtonClick();
     });
   }
 </script>

--- a/web-bluetooth/watch-advertisements-async-await.js
+++ b/web-bluetooth/watch-advertisements-async-await.js
@@ -1,0 +1,57 @@
+async function onConnectToBluetoothDevicesButtonClick() {
+  try {
+    log('Getting existing permitted Bluetooth devices...');
+    const devices = await navigator.bluetooth.getDevices();
+
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    // These devices may not be powered on or in range, so scan for
+    // advertisement packets from them before connecting.
+    for (const device of devices) {
+      connectToBluetoothDevice(device);
+    }
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+async function connectToBluetoothDevice(device) {
+  const abortController = new AbortController();
+
+  device.addEventListener('advertisementreceived', async (event) => {
+    log('> Received advertisement from "' + device.name + '"...');
+    // Stop watching advertisements to conserve battery life.
+    abortController.abort();
+    log('Connecting to GATT Server from "' + device.name + '"...');
+    try {
+      await device.gatt.connect()
+      log('> Bluetooth device "' +  device.name + ' connected.');
+    }
+    catch(error) {
+      log('Argh! ' + error);
+    }
+  }, { once: true });
+
+  try {
+    log('Watching advertisements from "' + device.name + '"...');
+    await device.watchAdvertisements({ signal: abortController.signal });
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}
+
+async function onRequestBluetoothDeviceButtonClick() {
+  try {
+    log('Requesting any Bluetooth device...');
+    const device = await navigator.bluetooth.requestDevice({
+   // filters: [...] <- Prefer filters to save energy & show relevant devices.
+      acceptAllDevices: true
+    });
+
+    log('> Requested ' + device.name);
+  }
+  catch(error) {
+    log('Argh! ' + error);
+  }
+}

--- a/web-bluetooth/watch-advertisements-async-await.js
+++ b/web-bluetooth/watch-advertisements-async-await.js
@@ -1,57 +1,44 @@
-async function onConnectToBluetoothDevicesButtonClick() {
-  try {
-    log('Getting existing permitted Bluetooth devices...');
-    const devices = await navigator.bluetooth.getDevices();
-
-    log('> Got ' + devices.length + ' Bluetooth devices.');
-    // These devices may not be powered on or in range, so scan for
-    // advertisement packets from them before connecting.
-    for (const device of devices) {
-      connectToBluetoothDevice(device);
-    }
-  }
-  catch(error) {
-    log('Argh! ' + error);
-  }
-}
-
-async function connectToBluetoothDevice(device) {
-  const abortController = new AbortController();
-
-  device.addEventListener('advertisementreceived', async (event) => {
-    log('> Received advertisement from "' + device.name + '"...');
-    // Stop watching advertisements to conserve battery life.
-    abortController.abort();
-    log('Connecting to GATT Server from "' + device.name + '"...');
-    try {
-      await device.gatt.connect()
-      log('> Bluetooth device "' +  device.name + ' connected.');
-    }
-    catch(error) {
-      log('Argh! ' + error);
-    }
-  }, { once: true });
-
-  try {
-    log('Watching advertisements from "' + device.name + '"...');
-    await device.watchAdvertisements({ signal: abortController.signal });
-  }
-  catch(error) {
-    log('Argh! ' + error);
-  }
-}
-
-async function onRequestBluetoothDeviceButtonClick() {
+async function onWatchAdvertisementsButtonClick() {
   try {
     log('Requesting any Bluetooth device...');
     const device = await navigator.bluetooth.requestDevice({
-   // filters: [...] <- Prefer filters to save energy & show relevant devices.
-      acceptAllDevices: true
-    });
+     // filters: [...] <- Prefer filters to save energy & show relevant devices.
+        acceptAllDevices: true});
 
     log('> Requested ' + device.name);
-  }
-  catch(error) {
+
+    device.addEventListener('advertisementreceived', (event) => {
+      log('Advertisement received.');
+      log('  Device Name: ' + event.device.name);
+      log('  Device ID: ' + event.device.id);
+      log('  RSSI: ' + event.rssi);
+      log('  TX Power: ' + event.txPower);
+      log('  UUIDs: ' + event.uuids);
+      event.manufacturerData.forEach((valueDataView, key) => {
+        logDataView('Manufacturer', key, valueDataView);
+      });
+      event.serviceData.forEach((valueDataView, key) => {
+        logDataView('Service', key, valueDataView);
+      });
+    });
+
+    log('Watching advertisements from "' + device.name + '"...');
+    await device.watchAdvertisements();  
+  } catch(error) {
     log('Argh! ' + error);
   }
 }
+
+/* Utils */
+
+const logDataView = (labelOfDataSource, key, valueDataView) => {
+  const hexString = [...new Uint8Array(valueDataView.buffer)].map(b => {
+    return b.toString(16).padStart(2, '0');
+  }).join(' ');
+  const textDecoder = new TextDecoder('ascii');
+  const asciiString = textDecoder.decode(valueDataView.buffer);
+  log(`  ${labelOfDataSource} Data: ` + key +
+      '\n    (Hex) ' + hexString +
+      '\n    (ASCII) ' + asciiString);
+};
+

--- a/web-bluetooth/watch-advertisements.html
+++ b/web-bluetooth/watch-advertisements.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements
-chrome_version: 85
+chrome_version: 86
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements.html
+++ b/web-bluetooth/watch-advertisements.html
@@ -1,0 +1,35 @@
+---
+feature_name: Web Bluetooth / Watch Advertisements
+chrome_version: 86
+check_min_version: true
+feature_id: 5180688812736512
+icon_url: icon.png
+index: index.html
+---
+
+{% include_relative _includes/intro.html %}
+
+<p>This sample illustrates the use of the Web Bluetooth API to check if a
+permitted Bluetooth device is in range of the system before attempting to
+connect to the Bluetooth device. You may want to check out the <a
+href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> sample.</p>
+
+<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
+<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='watch-advertisements.js' %}
+
+{% include_relative _includes/utils.html %}
+
+<script>
+  if (isWebBluetoothEnabled()) {
+    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
+        onConnectToBluetoothDevicesButtonClick();
+    });
+    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
+        onRequestBluetoothDeviceButtonClick();
+    });
+  }
+</script>

--- a/web-bluetooth/watch-advertisements.html
+++ b/web-bluetooth/watch-advertisements.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements
-chrome_version: 86
+chrome_version: 85
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png
@@ -9,13 +9,11 @@ index: index.html
 
 {% include_relative _includes/intro.html %}
 
-<p>This sample illustrates the use of the Web Bluetooth API to check if a
-permitted Bluetooth device is in range of the system before attempting to
-connect to the Bluetooth device. You may want to check out the <a
+<p>This sample illustrates the use of the Web Bluetooth API to read out
+advertisement data from nearby Bluetooth devices. You may want to check out the <a
 href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)</a> sample.</p>
 
-<button id="connectToBluetoothDevices">Connect to Bluetooth Devices</button>
-<button id="requestBluetoothDevice">Request Bluetooth Device</button>
+<button id="watchAdvertisements">Watch Advertisements</button>
 
 {% include output_helper.html %}
 
@@ -25,11 +23,8 @@ href="watch-advertisements-async-await.html">Watch Advertisements (Async Await)<
 
 <script>
   if (isWebBluetoothEnabled()) {
-    document.querySelector('#connectToBluetoothDevices').addEventListener('click', function() {
-        onConnectToBluetoothDevicesButtonClick();
-    });
-    document.querySelector('#requestBluetoothDevice').addEventListener('click', function() {
-        onRequestBluetoothDeviceButtonClick();
+    document.querySelector('#watchAdvertisements').addEventListener('click', function() {
+        onWatchAdvertisementsButtonClick();
     });
   }
 </script>

--- a/web-bluetooth/watch-advertisements.html
+++ b/web-bluetooth/watch-advertisements.html
@@ -1,6 +1,6 @@
 ---
 feature_name: Web Bluetooth / Watch Advertisements
-chrome_version: 86
+chrome_version: 87
 check_min_version: true
 feature_id: 5180688812736512
 icon_url: icon.png

--- a/web-bluetooth/watch-advertisements.js
+++ b/web-bluetooth/watch-advertisements.js
@@ -1,0 +1,53 @@
+function onConnectToBluetoothDevicesButtonClick() {
+  log('Getting existing permitted Bluetooth devices...');
+  navigator.bluetooth.getDevices()
+  .then(devices => {
+    log('> Got ' + devices.length + ' Bluetooth devices.');
+    // These devices may not be powered on or in range, so scan for
+    // advertisement packets from them before connecting.
+    for (const device of devices) {
+      connectToBluetoothDevice(device);
+    }
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function connectToBluetoothDevice(device) {
+  const abortController = new AbortController();
+
+  device.addEventListener('advertisementreceived', (event) => {
+    log('> Received advertisement from "' + device.name + '"...');
+    // Stop watching advertisements to conserve battery life.
+    abortController.abort();
+    log('Connecting to GATT Server from "' + device.name + '"...');
+    device.gatt.connect()
+    .then(() => {
+      log('> Bluetooth device "' +  device.name + ' connected.');
+    })
+    .catch(error => {
+      log('Argh! ' + error);
+    });
+  }, { once: true });
+
+  log('Watching advertisements from "' + device.name + '"...');
+  device.watchAdvertisements({ signal: abortController.signal })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}
+
+function onRequestBluetoothDeviceButtonClick() {
+  log('Requesting any Bluetooth device...');
+  navigator.bluetooth.requestDevice({
+ // filters: [...] <- Prefer filters to save energy & show relevant devices.
+    acceptAllDevices: true
+  })
+  .then(device => {
+    log('> Requested ' + device.name);
+  })
+  .catch(error => {
+    log('Argh! ' + error);
+  });
+}


### PR DESCRIPTION
This PR adds some basic samples for the upcoming "Web Bluetooth - Get Devices" feature described at https://www.chromestatus.com/feature/4797798639730688 and "Web Bluetooth - Watch Advertisements" feature described at https://www.chromestatus.com/features/5180688812736512

Live preview:
- https://beaufortfrancois.github.io/samples/web-bluetooth/get-devices
- https://beaufortfrancois.github.io/samples/web-bluetooth/get-devices-async-await
- https://beaufortfrancois.github.io/samples/web-bluetooth/watch-advertisements
- https://beaufortfrancois.github.io/samples/web-bluetooth/watch-advertisements-async-await
- https://beaufortfrancois.github.io/samples/web-bluetooth/watch-advertisements-and-connect
- https://beaufortfrancois.github.io/samples/web-bluetooth/watch-advertisements-and-connect-async-await

@odejesush Let me know if that looks good to you.
It obviously requires a developer build of Chromium with your [patch](https://chromium-review.googlesource.com/c/chromium/src/+/2044660) for now ;)

![image](https://user-images.githubusercontent.com/634478/75780786-48531400-5d5c-11ea-87df-cf0a500537bf.png)

<img width="1312" alt="Screen Shot 2020-08-11 at 8 52 24 AM" src="https://user-images.githubusercontent.com/634478/89866580-174ef900-dbb0-11ea-9ff4-b0baff990b32.png">
<img width="1312" alt="Screen Shot 2020-08-11 at 8 52 33 AM" src="https://user-images.githubusercontent.com/634478/89866600-1c13ad00-dbb0-11ea-97d9-4cc65b0607f3.png">

