### PR TITLE
Check all entries in callback

### DIFF
--- a/intersectionobserver/demo.js
+++ b/intersectionobserver/demo.js
@@ -13,16 +13,24 @@ function loadItems(n) {
 }
 
 var intersectionObserver = new IntersectionObserver(entries => {
-  // If intersectionRatio is 0, the sentinel is out of view
-  // and we do not need to do anything.
-  if (entries[0].intersectionRatio <= 0) {
-    return;
-  }
-  loadItems(10);
-  // appendChild will move the existing element, so there is no need to
-  // remove it first.
-  scroller.appendChild(sentinel);
-  loadItems(5);
-  ChromeSamples.setStatus('Loaded up to item ' + counter);
+  // If the browser is busy while scrolling happens, multiple entries can
+  // accumulate between invocations of this callback, so we loop over
+  // them.
+  entries.forEach(entry => {
+    // If intersectionRatio is 0, the sentinel is out of view
+    // and we do not need to do anything.
+    if (entry.intersectionRatio > 0) {
+      loadItems(10);
+      // appendChild will move the existing element, so there is no need to
+      // remove it first.
+      scroller.appendChild(sentinel);
+      loadItems(5);
+      ChromeSamples.setStatus('Loaded up to item ' + counter);
+
+      // We have already loaded more content, no need to look at any more
+      // entries.
+      return;
+    }
+  });
 });
 intersectionObserver.observe(sentinel);

--- a/intersectionobserver/demo.js
+++ b/intersectionobserver/demo.js
@@ -14,23 +14,17 @@ function loadItems(n) {
 
 var intersectionObserver = new IntersectionObserver(entries => {
   // If the browser is busy while scrolling happens, multiple entries can
-  // accumulate between invocations of this callback, so we loop over
+  // accumulate between invocations of this callback. As long as any one
+  // of the notifications reports the sentinel within the scrolling viewport,
+  // we add more content.
   // them.
-  entries.forEach(entry => {
-    // If intersectionRatio is 0, the sentinel is out of view
-    // and we do not need to do anything.
-    if (entry.intersectionRatio > 0) {
-      loadItems(10);
-      // appendChild will move the existing element, so there is no need to
-      // remove it first.
-      scroller.appendChild(sentinel);
-      loadItems(5);
-      ChromeSamples.setStatus('Loaded up to item ' + counter);
-
-      // We have already loaded more content, no need to look at any more
-      // entries.
-      return;
-    }
-  });
+  if (entries.some(entry => entry.intersectionRatio > 0)) {
+    loadItems(10);
+    // appendChild will move the existing element, so there is no need to
+    // remove it first.
+    scroller.appendChild(sentinel);
+    loadItems(5);
+    ChromeSamples.setStatus('Loaded up to item ' + counter);
+  }
 });
 intersectionObserver.observe(sentinel);

--- a/intersectionobserver/demo.js
+++ b/intersectionobserver/demo.js
@@ -17,7 +17,6 @@ var intersectionObserver = new IntersectionObserver(entries => {
   // accumulate between invocations of this callback. As long as any one
   // of the notifications reports the sentinel within the scrolling viewport,
   // we add more content.
-  // them.
   if (entries.some(entry => entry.intersectionRatio > 0)) {
     loadItems(10);
     // appendChild will move the existing element, so there is no need to


### PR DESCRIPTION
The existing sample code can cause IntersectionObserver events to be missed, because it only checks the first entry in the list. This came to light in a chromium bug:

https://bugs.chromium.org/p/chromium/issues/detail?id=941681#c8