### PR TITLE
Fix ReferenceError in Web NFC example

### DIFF
--- a/web-nfc/index.js
+++ b/web-nfc/index.js
@@ -6,8 +6,8 @@ scanButton.addEventListener("click", async () => {
     await reader.scan();
     log("> Scan started");
 
-    reader.addEventListener("error", (error) => {
-      log(`Argh! ${error.message}`);
+    reader.addEventListener("error", (event) => {
+      log(`Argh! ${event.message}`);
     });
 
     reader.addEventListener("reading", ({ message, serialNumber }) => {

--- a/web-nfc/index.js
+++ b/web-nfc/index.js
@@ -6,7 +6,7 @@ scanButton.addEventListener("click", async () => {
     await reader.scan();
     log("> Scan started");
 
-    reader.addEventListener("error", () => {
+    reader.addEventListener("error", (error) => {
       log(`Argh! ${error.message}`);
     });
 


### PR DESCRIPTION
Currently, if there's an error while scanning for NFC, it triggers error handler which has no `error` argument. But inside error handler, `error.message` is accessed, which triggers ReferenceError (no `message` property on undefined).