### PR TITLE
netinfo: fix incorrect spacing

### DIFF
--- a/network-information/demo.js
+++ b/network-information/demo.js
@@ -5,13 +5,13 @@ function logNetworkInfo() {
   log('         type: ' + navigator.connection.type);
 
   // Effective bandwidth estimate
-  log('     downlink: ' + navigator.connection.downlink + 'Mb/s');
+  log('     downlink: ' + navigator.connection.downlink + ' Mb/s');
 
   // Effective round-trip time estimate
-  log('          rtt: ' + navigator.connection.rtt + 'ms');
+  log('          rtt: ' + navigator.connection.rtt + ' ms');
 
   // Upper bound on the downlink speed of the first network hop
-  log('  downlinkMax: ' + navigator.connection.downlinkMax + 'Mb/s');
+  log('  downlinkMax: ' + navigator.connection.downlinkMax + ' Mb/s');
 
   // Effective connection type determined using a combination of recently
   // observed rtt and downlink values: ' +
@@ -20,6 +20,9 @@ function logNetworkInfo() {
   // True if the user has requested a reduced data usage mode from the user
   // agent.
   log('     saveData: ' + navigator.connection.saveData);
+  
+  // Add whitespace for readability
+  log('');
 }
 
 logNetworkInfo();

--- a/network-information/index.html
+++ b/network-information/index.html
@@ -30,14 +30,7 @@ feature_id: 6338383617982464
 {% include output_helper.html %}
 
 <script>
-  var times = 1;
-  var log = function(args) {
-    ChromeSamples.log(args);
-    if (times % 5 == 0) {
-      ChromeSamples.log('');
-    }
-    times++;
-  }
+  var log = ChromeSamples.log;
 </script>
 
 {% include js_snippet.html filename='demo.js' %}


### PR DESCRIPTION
#544 added this modulo 5 extra spacing.
but then #561 added a 6th item.

so it broke. ([live link](https://googlechrome.github.io/samples/network-information/))

(note the top item of each group keep changing)
![image](https://user-images.githubusercontent.com/39191/94478826-aaf07f00-0188-11eb-9f93-453479083193.png)

