### PR TITLE
Fix handling playbackState

### DIFF
--- a/media-session/audio.js
+++ b/media-session/audio.js
@@ -85,15 +85,21 @@ navigator.mediaSession.setActionHandler('seekforward', function(event) {
 navigator.mediaSession.setActionHandler('play', async function() {
   log('> User clicked "Play" icon.');
   await audio.play();
-  navigator.mediaSession.playbackState = "playing";
   // Do something more than just playing audio...
 });
 
 navigator.mediaSession.setActionHandler('pause', function() {
   log('> User clicked "Pause" icon.');
   audio.pause();
-  navigator.mediaSession.playbackState = "paused";
   // Do something more than just pausing audio...
+});
+
+audio.addEventListener('play', function() {
+  navigator.mediaSession.playbackState = 'playing';
+});
+
+audio.addEventListener('pause', function() {
+  navigator.mediaSession.playbackState = 'paused';
 });
 
 /* Stop (supported since Chrome 77) */

--- a/media-session/video.js
+++ b/media-session/video.js
@@ -84,15 +84,21 @@ navigator.mediaSession.setActionHandler('seekforward', function(event) {
 navigator.mediaSession.setActionHandler('play', async function() {
   log('> User clicked "Play" icon.');
   await video.play();
-  navigator.mediaSession.playbackState = "playing";
   // Do something more than just playing video...
 });
 
 navigator.mediaSession.setActionHandler('pause', function() {
   log('> User clicked "Pause" icon.');
   video.pause();
-  navigator.mediaSession.playbackState = "paused";
   // Do something more than just pausing video...
+});
+
+video.addEventListener('play', function() {
+  navigator.mediaSession.playbackState = 'playing';
+});
+
+video.addEventListener('pause', function() {
+  navigator.mediaSession.playbackState = 'paused';
 });
 
 /* Stop (supported since Chrome 77) */


### PR DESCRIPTION
This PR makes sure the "play/pause" button in the GMC / media notification is not stuck at the "playing" state with media session samples (both video and audio)

Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1224326
Live preview: 
- https://beaufortfrancois.github.io/samples/media-session/video.html
- https://beaufortfrancois.github.io/samples/media-session/audio.html