### PR TITLE
Add EME MediaKeySession Closed Reason sample

### DIFF
--- a/media/key-session-closed-reason.html
+++ b/media/key-session-closed-reason.html
@@ -1,0 +1,52 @@
+---
+feature_name: EME MediaKeySession Closed Reason
+chrome_version: 96
+feature_id: 5632124143009792
+check_min_version: true
+---
+
+<h3>Background</h3>
+<p>
+The current EME spec says "the CDM may close a session at any point, such as
+when the session is no longer needed or when system resources are lost".
+However, there's no way to specify the exact reason for session closure. In
+some cases, this is part of normal user flow, e.g. user close laptop lid to
+put the device into sleep mode, where the player should resume playback. In
+some other cases, this is due to some unrecoverable fatal error.
+</p>
+<p>
+This is why the <code>closed</code> attribute on <code>MediaKeySession</code>
+is updated to provide a <code>MediaKeySessionClosedReason</code> so that you
+can handle session closure differently based on the reason.
+</p>
+
+<button id="createSessionButton">create media key session</button>
+<button id="closeSessionButton">close media key session</button>
+
+{% include output_helper.html initial_output_content=initial_output_content %}
+
+{% include js_snippet.html filename='key-session-closed-reason.js' %}
+
+<script>
+  document.querySelector('#createSessionButton').addEventListener('click', function() {
+    try {
+      onCreateSessionButtonClick();
+    } catch(error) {
+      logError(error);
+    }
+  });
+
+  document.querySelector('#closeSessionButton').addEventListener('click', function() {
+    try {
+      onCloseSessionButtonClick();
+    } catch(error) {
+      logError(error);
+    }
+  });
+
+  function logError(error) {
+    log(`> Error: ${error.message}\n`);
+  }
+
+  log = ChromeSamples.log;
+</script>

--- a/media/key-session-closed-reason.js
+++ b/media/key-session-closed-reason.js
@@ -1,0 +1,34 @@
+let keySession;
+
+async function onCreateSessionButtonClick() {
+  const config = [
+    {
+      initDataTypes: ["webm"],
+      audioCapabilities: [{ contentType: 'audio/webm; codecs="opus"' }],
+    },
+  ];
+  const keySystemAccess = await navigator.requestMediaKeySystemAccess(
+    "org.w3.clearkey",
+    config
+  );
+  // Create media keys.
+  const mediaKeys = await keySystemAccess.createMediaKeys();
+  // Create a key session.
+  keySession = mediaKeys.createSession();
+  // Generate a fake license request.
+  await keySession.generateRequest("webm", new Uint8Array([1, 2, 3]));
+
+  log(`Media key session is created.`);
+
+  keySession.closed.then((reason) => {
+    // Reason is either undefined if not supported, "internal-error",
+    // "closed-by-application", "release-acknowledged",
+    // "hardware-context-reset", or "resource-evicted".
+    log(`Media key session was closed. Reason: "${reason}".`);
+  });
+}
+
+async function onCloseSessionButtonClick() {
+  // Will close media key session with "closed-by-application" reason.
+  await keySession.close();
+}


### PR DESCRIPTION
This PR adds a sample featuring the EME MediaKeySession `closed` reason that is going to ship in Chrome 96. See https://www.chromestatus.com/feature/5632124143009792

Live preview: https://beaufortfrancois.github.io/samples/media/key-session-closed-reason.html

Please review @xhwang-chromium 

Note that this sample does not feature **protected** content playback to keep it simple and focused on the `closed` promise. Let me know what you think.