### PR TITLE
A small update that allows text to be pasted manually into the textbo…

### DIFF
--- a/async-clipboard/demo.js
+++ b/async-clipboard/demo.js
@@ -23,8 +23,7 @@ document.querySelector('#paste').addEventListener('click', () => {
 
 /** Watch for pastes */
 document.addEventListener('paste', e => {
-  e.preventDefault();
-  navigator.clipboard.getText().then(text => {
+  navigator.clipboard.readText().then(text => {
     ChromeSamples.log('Updated clipboard contents: ' + text);
   });
 });


### PR DESCRIPTION
…x and fixes the error that happend when pasting manually.

If it is intended to now allow manual pasting then the e.preventDefault() needs to come back.
"navigator.clipboard.getText()" doesn't work nontheless