### PR TITLE
perf: Unify XHR requests to fetch.

### DIFF
--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -103,30 +103,32 @@ limitations under the License.
       }
 
       function makeApiRequest() {
-        var xhr = new XMLHttpRequest();
         // See https://developers.google.com/url-shortener/v1/getting_started#shorten
-        xhr.open('POST', 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyCr0XVB-Hz1ohPpjvLatdj4qZ5zcSohHsU');
-        xhr.setRequestHeader('Content-Type', 'application/json');
+        var request = new Request('https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyCr0XVB-Hz1ohPpjvLatdj4qZ5zcSohHsU', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            longUrl: document.querySelector('#original-url').value
+          })
+        })
         // Only set the custom 'X-Mock-Response' header if the box is checked. The service worker will
         // use the header's presence to determine whether to return a mock or genuine response.
         if (document.querySelector('#mock-checkbox').checked) {
-          xhr.setRequestHeader('X-Mock-Response', 'yes');
+          request.headers.set('X-Mock-Response', 'yes')
         }
 
-        xhr.addEventListener('load', function() {
-          var response = JSON.parse(xhr.response);
-          console.log('Response is', response);
-
-          var shortUrlElement = document.querySelector('#short-url');
-          shortUrlElement.href = response.id;
-          shortUrlElement.textContent = response.id;
-        });
-
-        var request = {
-          longUrl: document.querySelector('#original-url').value
-        };
-        var requestJson = JSON.stringify(request);
-        xhr.send(requestJson);
+        fetch(request)
+          .then(response => {
+            return response.json()
+          })
+          .then(json => {
+            console.log('Response is', json);
+            var shortUrlElement = document.querySelector('#short-url');
+            shortUrlElement.href = json.id;
+            shortUrlElement.textContent = json.id;
+          })
       }
 
       if ('serviceWorker' in navigator) {

--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -89,7 +89,7 @@ limitations under the License.
           <button id="shorten-button">Shorten</button>
         </div>
         <div>
-          <input id="mock-checkbox" type="checkbox" checked>Mock Response</input>
+          <input id="mock-checkbox" type="checkbox" checked>Mock Response
         </div>
 
         <p>Short URL: <a id="short-url"></a></p>

--- a/service-worker/mock-responses/index.html
+++ b/service-worker/mock-responses/index.html
@@ -136,7 +136,6 @@ limitations under the License.
           if (navigator.serviceWorker.controller) {
             // If .controller is set, then this page is being actively controlled by the service worker.
             document.querySelector('#status').textContent = 'The service worker is currently handling network operations.';
-
             showRequest();
           } else {
             // If .controller isn't set, then prompt the user to reload the page so that the service worker can take


### PR DESCRIPTION
During my practice of how to use `service-worker`, I found that the `XHR` in this part seemed abrupt since all the other parts used `fetch`.

Also I modified the html - because the `input` tag was not being used properly. According to the `html` standard, the `input` tag should not have a closing section. This error will cause an error in the template compiler similar to `vite`.