### PR TITLE
More text and change hyphenated word to fix demo

### DIFF
--- a/css-hyphens/index.html
+++ b/css-hyphens/index.html
@@ -10,9 +10,9 @@ feature_id: 5642121184804864
 
 <p>The <a href="https://drafts.csswg.org/css-text-3">CSS Text Module Level 3</a> defines a <code>hyphens</code> property to control when hyphens are shown to users and how they behave when shown. Per the specification, the <code>hyphens</code> property has three values: <code>none</code>, <code>manual</code>, and <code>auto</code>. The use and behavior of each is shown and illustrated below.</p>
 
-<p>Notice that two of the text samples contain a soft hyphen (<code>&amp;shy&semi;</code>) between the syllables of <i>elit</i>. A soft hyphen is one that will only be shown when it occurs at the trailing margin. In the first example, the <code>hyphens</code> property is set to <code>none</code>. This prevents the soft hyphen from ever being displayed. You can confirm this by adjusting the window size so that the word 'elit' will not fit in the visible line of text.</p>
+<p>Notice that two of the text samples contain a soft hyphen (<code>&amp;shy&semi;</code>) between the syllables of <i>ipsum</i>. A soft hyphen is one that will only be shown when it occurs at the trailing margin. In the first example, the <code>hyphens</code> property is set to <code>none</code>. This prevents the soft hyphen from ever being displayed. You can confirm this by adjusting the window size so that the word 'ipsum' will not fit in the visible line of text.</p>
 
-<p>In the second example, the <code>hyphens</code> property is set to <code>manual</code> meaning the soft hyphen will only appear when the margin breaks the word 'elit'. Again, you can confirm this by adjusting the window size.</p>
+<p>In the second example, the <code>hyphens</code> property is set to <code>manual</code> meaning the soft hyphen will only appear when the margin breaks the word 'ipsum'. Again, you can confirm this by adjusting the window size.</p>
 
 <p>In the third example, the <code>hyphens</code> property is set to <code>auto</code>. In this case, no soft hyphen is needed since the user agent will determine hyphen locations automatically. If you resize the window, you'll see that the browser hyphenates the third example in the same place as in the second example, though no soft hyphen is present. If you continue to shrink the window, you'll see that your browser is able to break lines between any two syllables in the text.<p>
 
@@ -42,15 +42,15 @@ div.auto {
 
 {% capture html %}
   <div class="none">
-    Google ipsum dolor sit amet, consectetur adipiscing e&shy;lit.
+    Google ip&shy;sum dolor sit amet, consectetur adipiscing elit. Google ip&shy;sum dolor sit amet, consectetur adipiscing elit.
   </div>
   
   <div class="manual">
-    Google ipsum dolor sit amet, consectetur adipiscing e&shy;lit.
+    Google ip&shy;sum dolor sit amet, consectetur adipiscing elit. Google ip&shy;sum dolor sit amet, consectetur adipiscing elit.
   </div>
   
   <div class="auto">
-    Google ipsum dolor sit amet, consectetur adipiscing elit.
+    Google ipsum dolor sit amet, consectetur adipiscing elit. Google ipsum dolor sit amet, consectetur adipiscing elit.
   </div>
 {% endcapture %}
 {% include html_snippet.html html=html %}


### PR DESCRIPTION
# now

Even at minimum width, the Chrome (95, desktop) window is too wide to trigger the text to break and demo the hyphens:

![image](https://user-images.githubusercontent.com/1324225/141680969-6b288e81-7593-4dbb-acc3-f5151a90626e.png)


https://googlechrome.github.io/samples/css-hyphens/index.html


# PR

Double the text to allow it to break, and also move the soft hyphen into "ipsum" so it may break too:

![image](https://user-images.githubusercontent.com/1324225/141680938-827d6899-0837-449b-a4a2-256236390064.png)

https://hugovk.github.io/samples/css-hyphens/

(Just so happens this now demonstrates a Chromium tofu bug, reported here: https://bugs.chromium.org/p/chromium/issues/detail?id=1270110)