### PR TITLE
Add Make Read-Only feature

### DIFF
--- a/web-nfc/index.html
+++ b/web-nfc/index.html
@@ -16,6 +16,7 @@ Card Emulation (HCE) are not supported within the current scope.
 
 <button id="scanButton">Scan</button>
 <button id="writeButton">Write</button>
+<button id="makeReadOnlyButton">Make Read-Only</button>
 
 {% include output_helper.html initial_output_content=initial_output_content %}
 
@@ -23,10 +24,7 @@ Card Emulation (HCE) are not supported within the current scope.
 log = ChromeSamples.log;
 
 if (!("NDEFReader" in window))
-  ChromeSamples.setStatus(
-    "Web NFC is not available.\n" +
-      'Please make sure the "Experimental Web Platform features" flag is enabled on Android.'
-  );
+  ChromeSamples.setStatus("Web NFC is not available. Use Chrome on Android.");
 </script>
 
 {% include js_snippet.html filename='index.js' %}

--- a/web-nfc/index.js
+++ b/web-nfc/index.js
@@ -30,3 +30,15 @@ writeButton.addEventListener("click", async () => {
     log("Argh! " + error);
   }
 });
+
+makeReadOnlyButton.addEventListener("click", async () => {
+  log("User clicked make read-only button");
+
+  try {
+    const ndef = new NDEFReader();
+    await ndef.makeReadOnly();
+    log("> NFC tag has been made permanently read-only");
+  } catch (error) {
+    log("Argh! " + error);
+  }
+});


### PR DESCRIPTION
This PR adds a button to make NFC tags permanently read-only.

Live preview: https://beaufortfrancois.github.io/samples/web-nfc/

FYI @zolkis @kenchris @reillyeon