### PR TITLE
Rename gems to plugins in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ encoding: utf-8
 exclude: [vendor]
 gh_pages_url_prefix: https://googlechrome.github.io/samples
 gh_url_prefix: https://github.com/googlechrome/samples/blob/gh-pages
-gems:
+plugins:
   - jekyll-sitemap
 defaults:
   -


### PR DESCRIPTION
The `gems` entry has been renamed.