### PR TITLE
Update pwa-testing/index.html to link directly to source

### DIFF
--- a/pwa-testing/index.html
+++ b/pwa-testing/index.html
@@ -71,11 +71,8 @@
   </head>
   <body>
     <h1>PWA Testing Demos 🧪</h1>
-    <p>This page dynamically lists all demos from the
-      <code>pwa-testing</code>
-      directory in the
-      <a href="https://github.com/GoogleChrome/samples">GoogleChrome/samples</a>
-      repository.</p>
+    <p>This page dynamically lists all demos from 
+      <a href="https://github.com/GoogleChrome/samples/pwa-testing">github.com/GoogleChrome/samples/pwa-testing</a>.</p>
     <div id="demo-list">
       <p class="loading">Loading demos from GitHub API...</p>
     </div>


### PR DESCRIPTION
Link directly to pwa-testing source directory. This avoids needing multiple clicks when trying to go from samples listing to source.