### PR TITLE
Fix manifest id for a couple of PWA samples.

### DIFF
--- a/pwa-testing/chat-app-deep-linking/manifest.json
+++ b/pwa-testing/chat-app-deep-linking/manifest.json
@@ -2,7 +2,6 @@
   "name": "Fake Chat App",
   "short_name": "Fake Chat",
   "start_url": "./",
-  "id": "./",
   "theme_color": "#000",
   "background_color": "#000",
   "icons": [

--- a/pwa-testing/incandescent-ginger-voyage/manifest.webmanifest
+++ b/pwa-testing/incandescent-ginger-voyage/manifest.webmanifest
@@ -3,7 +3,6 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#ffffff",
-  "id": ".",
   "scope": "./",
   "icons": [{
     "src": "incandescent-ginger-voyage.png",

--- a/pwa-testing/main-pwa-origin-2/manifest.json
+++ b/pwa-testing/main-pwa-origin-2/manifest.json
@@ -2,7 +2,6 @@
   "name": "Main PWA",
   "short_name": "Main PWA",
   "start_url": "./",
-  "id": "./",
   "icons": [
     {
       "src": "apple-touch-icon.png",


### PR DESCRIPTION
Since the manifest id field is resolved relative to the origin of the start URL, any sample that sets it to "." or "./" gets the same effective id. While explicitly setting the manifest id is generally considered a good practice, for these samples not setting the id and relying on the manifest id being derived from the start url is simpler.