### PR TITLE
Fix extended scope PWA test site

### DIFF
--- a/pwa-testing/main-pwa-origin-2/index.html
+++ b/pwa-testing/main-pwa-origin-2/index.html
@@ -12,7 +12,7 @@
     <p>
       <ul>
         <li><a href="./manifest.json">Web Manifest</a> containing "scope_extensions" member</li>
-        <li>Origin in extended scope: <a href="https://googlechrome.github.io/samples/associated-pwa-origin-2">https://googlechrome.github.io/samples/associated-pwa-origin-2</a> with <a href="https://googlechrome.github.io/samples/associated-pwa-origin-2/.well-known/web-app-origin-association">Web app origin association file</a> </li>
+        <li>Origin in extended scope: <a href="https://mkruisselbrink.github.io/scope-extensions-test-site/">https://mkruisselbrink.github.io/scope-extensions-test-site/</a> with <a href="https://mkruisselbrink.github.io/.well-known/web-app-origin-association">Web app origin association file</a> </li>
         <li>Origin not in extended scope: <a href="https://www.example.com">https://www.example.com</a></li>
       </ul>
     </p>

--- a/pwa-testing/main-pwa-origin-2/manifest.json
+++ b/pwa-testing/main-pwa-origin-2/manifest.json
@@ -14,7 +14,7 @@
   "scope_extensions": [
     {
       "type": "origin",
-      "origin": "https://googlechrome.github.io/samples/associated-pwa-origin-2/"
+      "origin": "https://mkruisselbrink.github.io/"
     }
   ]
 }


### PR DESCRIPTION
It's probably not the best long-term solution to have the extended scope site this links to be part of my personal github repo, the requirement of it containing a top-level .well-known directory makes hosting the second site within this repo tricky. With these changes at least for now this sample works again.