### PR TITLE
Add entry for predictable app updating test site on https://googlechrome.github.io/samples/pwa-testing/

### DIFF
--- a/pwa-testing/index.html
+++ b/pwa-testing/index.html
@@ -166,6 +166,7 @@
 				"paint-rightful-patch": "display_override: [\"tabbed\"]",
 				"parallel-omniscient-barberry": "file handling with .foo extension too",
 				"placeholder-app-tester": "Site to help test placeholder apps and if they re-install themselves correctly.",
+				"predictable-app-update": "Site to test manifest updates of both security and non-security sensitive fields.",
 				"principled-ring-yarrow": "file handling test site",
 				"private-brick-universe": "Test shortcut menu icons on Windows",
 				"pwa-icon-size-tester": "For updating the name and specific sizes of icons (fork of app-name-icon-tester)",


### PR DESCRIPTION
I missed this while landing the predictable app updating test site here, forgot to update the index page with the description. Better late than never!