### PR TITLE
Adding test site for getInstalledRelatedApps API on Desktop PWAs

### DIFF
--- a/pwa-testing/gira-test-app/.well-known/assetlinks.json
+++ b/pwa-testing/gira-test-app/.well-known/assetlinks.json
@@ -1,0 +1,11 @@
+[
+  {
+    "_comment": "Example Entry: Cross-origin PWA (WebAPK) verification.",
+    "relation": ["delegate_permission/common.query_webapk"],
+    "target": {
+      "namespace": "web",
+      "_comment_site": "The origin of the PWA you want to detect",
+      "site": "https://example.com"
+    }
+  }
+]

--- a/pwa-testing/gira-test-app/.well-known/windows-app-web-link
+++ b/pwa-testing/gira-test-app/.well-known/windows-app-web-link
@@ -1,0 +1,7 @@
+[
+  {
+    "_comment": "Example Entry: Maps a Windows UWP app to this website for getInstalledRelatedApps() verification. 'packageFamilyName' is the UWP app's package family name, 'paths' defines which URL paths the app can handle ('*' means all).",
+    "packageFamilyName": "GiraApp_1a2b3c4d5e6f7",
+    "paths": ["*"]
+  }
+]

--- a/pwa-testing/gira-test-app/demo.js
+++ b/pwa-testing/gira-test-app/demo.js
@@ -1,0 +1,14 @@
+async function getInstalledApps() {
+  const installedApps = await navigator.getInstalledRelatedApps();
+  const giraStatus = document.getElementById('giraStatus');
+  giraStatus.textContent = `resolved (${installedApps.length})`;
+  const giraResults = document.getElementById('giraResults');
+  giraResults.textContent = JSON.stringify(installedApps, null, 2);
+}
+
+if ('getInstalledRelatedApps' in navigator) {
+  getInstalledApps();
+} else {
+  const giraStatus = document.getElementById('giraStatus');
+  giraStatus.textContent = `not supported`;
+}

--- a/pwa-testing/gira-test-app/icons/icon-192.svg
+++ b/pwa-testing/gira-test-app/icons/icon-192.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="phone" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#e0e7ff"/>
+      <stop offset="100%" style="stop-color:#c7d2fe"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="192" height="192" rx="40" fill="url(#bg)"/>
+  
+  <!-- Phone body -->
+  <rect x="58" y="32" width="76" height="120" rx="12" fill="url(#phone)" opacity="0.95"/>
+  <rect x="64" y="44" width="64" height="88" rx="4" fill="#6366f1" opacity="0.15"/>
+  
+  <!-- Screen notch -->
+  <rect x="82" y="36" width="28" height="4" rx="2" fill="#6366f1" opacity="0.3"/>
+  
+  <!-- App grid on screen -->
+  <rect x="70" y="52" width="16" height="16" rx="4" fill="#34d399" opacity="0.9"/>
+  <rect x="70" y="52" width="16" height="16" rx="4" fill="#34d399"/>
+  <rect x="92" y="52" width="16" height="16" rx="4" fill="#fb923c"/>
+  <rect x="114" y="52" width="16" height="16" rx="4" fill="#f472b6"/>
+  
+  <rect x="70" y="74" width="16" height="16" rx="4" fill="#60a5fa"/>
+  <rect x="92" y="74" width="16" height="16" rx="4" fill="#a78bfa"/>
+  <rect x="114" y="74" width="16" height="16" rx="4" fill="#fbbf24"/>
+  
+  <rect x="70" y="96" width="16" height="16" rx="4" fill="#f87171"/>
+  <rect x="92" y="96" width="16" height="16" rx="4" fill="#2dd4bf"/>
+  <rect x="114" y="96" width="16" height="16" rx="4" fill="#818cf8"/>
+  
+  <!-- Home button -->
+  <circle cx="96" cy="142" r="5" fill="#6366f1" opacity="0.3"/>
+  
+  <!-- Checkmark badge -->
+  <circle cx="138" cy="46" r="22" fill="#10b981"/>
+  <circle cx="138" cy="46" r="19" fill="#34d399"/>
+  <path d="M128 46 L135 53 L149 39" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  
+  <!-- Sparkles -->
+  <circle cx="42" cy="56" r="3" fill="white" opacity="0.6"/>
+  <circle cx="150" cy="130" r="2.5" fill="white" opacity="0.5"/>
+  <circle cx="36" cy="140" r="2" fill="white" opacity="0.4"/>
+  <circle cx="160" cy="80" r="2" fill="white" opacity="0.3"/>
+</svg>

--- a/pwa-testing/gira-test-app/icons/icon-512.svg
+++ b/pwa-testing/gira-test-app/icons/icon-512.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="phone" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#e0e7ff"/>
+      <stop offset="100%" style="stop-color:#c7d2fe"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="512" height="512" rx="100" fill="url(#bg)"/>
+  
+  <!-- Phone body -->
+  <rect x="152" y="80" width="208" height="330" rx="28" fill="url(#phone)" opacity="0.95"/>
+  <rect x="168" y="112" width="176" height="244" rx="8" fill="#6366f1" opacity="0.15"/>
+  
+  <!-- Screen notch -->
+  <rect x="218" y="90" width="76" height="10" rx="5" fill="#6366f1" opacity="0.3"/>
+  
+  <!-- App grid on screen -->
+  <rect x="182" y="130" width="44" height="44" rx="10" fill="#34d399"/>
+  <rect x="234" y="130" width="44" height="44" rx="10" fill="#fb923c"/>
+  <rect x="286" y="130" width="44" height="44" rx="10" fill="#f472b6"/>
+  
+  <rect x="182" y="186" width="44" height="44" rx="10" fill="#60a5fa"/>
+  <rect x="234" y="186" width="44" height="44" rx="10" fill="#a78bfa"/>
+  <rect x="286" y="186" width="44" height="44" rx="10" fill="#fbbf24"/>
+  
+  <rect x="182" y="242" width="44" height="44" rx="10" fill="#f87171"/>
+  <rect x="234" y="242" width="44" height="44" rx="10" fill="#2dd4bf"/>
+  <rect x="286" y="242" width="44" height="44" rx="10" fill="#818cf8"/>
+  
+  <!-- Mini app labels -->
+  <rect x="186" y="168" width="36" height="3" rx="1.5" fill="white" opacity="0.3"/>
+  <rect x="238" y="168" width="36" height="3" rx="1.5" fill="white" opacity="0.3"/>
+  <rect x="290" y="168" width="36" height="3" rx="1.5" fill="white" opacity="0.3"/>
+  
+  <!-- Search bar on screen -->
+  <rect x="182" y="300" width="148" height="28" rx="14" fill="white" opacity="0.15"/>
+  <circle cx="198" cy="314" r="6" fill="white" opacity="0.3"/>
+  
+  <!-- Home button -->
+  <circle cx="256" cy="386" r="12" fill="#6366f1" opacity="0.3"/>
+  
+  <!-- Checkmark badge -->
+  <circle cx="368" cy="118" r="60" fill="#059669"/>
+  <circle cx="368" cy="118" r="52" fill="#10b981"/>
+  <path d="M340 118 L358 136 L398 96" stroke="white" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  
+  <!-- Magnifying glass (search/detect) -->
+  <circle cx="130" cy="400" r="32" stroke="white" stroke-width="6" fill="none" opacity="0.5"/>
+  <line x1="152" y1="422" x2="172" y2="442" stroke="white" stroke-width="6" stroke-linecap="round" opacity="0.5"/>
+  
+  <!-- Sparkles -->
+  <circle cx="100" cy="120" r="8" fill="white" opacity="0.5"/>
+  <circle cx="80" cy="160" r="4" fill="white" opacity="0.3"/>
+  <circle cx="420" cy="340" r="6" fill="white" opacity="0.4"/>
+  <circle cx="440" cy="380" r="3" fill="white" opacity="0.3"/>
+  <circle cx="108" cy="300" r="5" fill="white" opacity="0.35"/>
+  <circle cx="420" cy="240" r="4" fill="white" opacity="0.25"/>
+  
+  <!-- Connection dots (related apps concept) -->
+  <circle cx="430" cy="440" r="14" fill="#fbbf24" opacity="0.7"/>
+  <circle cx="460" cy="410" r="10" fill="#f472b6" opacity="0.6"/>
+  <circle cx="448" cy="460" r="8" fill="#34d399" opacity="0.5"/>
+  <line x1="430" y1="440" x2="460" y2="410" stroke="white" stroke-width="2" opacity="0.3"/>
+  <line x1="430" y1="440" x2="448" y2="460" stroke="white" stroke-width="2" opacity="0.3"/>
+</svg>

--- a/pwa-testing/gira-test-app/index.html
+++ b/pwa-testing/gira-test-app/index.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>getInstalledRelatedApps()</title>
+  <link rel="manifest" href="./manifest.json">
+  <meta name="theme-color" content="#8b5cf6">
+  <meta name="description" content="Detect if your app is already installed on the user's device">
+  <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="./icons/icon-192.svg">
+  <link rel="stylesheet" href="./styles.css?v=2">
+</head>
+<body>
+
+  <main>
+
+    <!-- What is it? -->
+    <div class="section">
+      <div style="text-align:center;">
+        <h1 class="section-hero-title"
+            style="background:linear-gradient(90deg,#3b82f6,#6366f1,#8b5cf6);
+                   -webkit-background-clip:text;
+                   -webkit-text-fill-color:transparent;
+                   background-clip:text;
+                   display:inline-block;">
+          getInstalledRelatedApps()
+        </h1>
+      </div>
+      <p class="section-hero-subtitle">Detect if your app is already installed on the user's device</p>
+      <hr class="section-divider">
+      <h2 class="section-title"><span class="emoji">💡</span> What is it?</h2>
+      <p>
+        The <span class="code-inline">navigator.getInstalledRelatedApps()</span> API can be used to check for the
+        installation of Progressive Web Apps (PWAs), Universal Windows Platform (UWP) apps,
+        and Android apps that are related to the web app calling this method.
+      </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <div class="section">
+      <h2 class="section-title"><span class="emoji">⚡</span> Basic Usage</h2>
+<pre>const installedApps = await navigator.getInstalledRelatedApps?.();
+console.log(installedApps);</pre>
+    </div>
+
+    <!-- Manifest Requirement -->
+    <div class="section">
+      <h2 class="section-title"><span class="emoji">📋</span> Manifest Requirement: related_applications</h2>
+<pre id="manifestDisplay">Loading manifest&hellip;</pre>
+    </div>
+
+    <!-- More on How to Set It Up -->
+    <div class="section">
+      <h2 class="section-title"><span class="emoji">🔧</span> More on How to Set It Up</h2>
+
+      <!-- PWA in scope -->
+      <details>
+        <summary>Check if your own Desktop PWA is installed (same scope)</summary>
+        <div class="supported-banner">
+          Supported on:
+          <span class="badge green">Android — Chrome 84+</span>
+          <span class="badge">Desktop — Chrome / Edge 140+</span>
+        </div>
+        <div class="info-section">
+          <h4>1. Tell your PWA about itself</h4>
+          <p>Add a <span class="code-inline">related_applications</span> entry in your web app manifest:</p>
+<pre>"related_applications": [{
+  "platform": "webapp",
+  "url": "/manifest.json",
+  "id": "https://example.com/?utm_source=home_screen"
+}]</pre>
+
+          <h4>2. Check if the PWA is installed</h4>
+          <p>
+            Call <span class="code-inline">navigator.getInstalledRelatedApps()</span> from within the scope of your PWA.
+            If called outside the scope, it returns <span class="code-inline">[]</span>.
+          </p>
+<pre>const relatedApps = await navigator.getInstalledRelatedApps();
+console.log(relatedApps);</pre>
+        </div>
+      </details>
+
+      <!-- PWA out of scope -->
+      <details>
+        <summary>Check if a PWA is installed (different scope/origin)</summary>
+        <div class="supported-banner">
+          Supported on:
+          <span class="badge amber">Android only — Chrome 84+</span>
+        </div>
+        <div class="info-section">
+          <h4>1. Tell your PWA about your website</h4>
+          <p>
+            Add an <span class="code-inline">assetlinks.json</span> file to
+            <span class="code-inline">/.well-known/</span> on the PWA's domain:
+          </p>
+<pre>// Served from https://app.example.com/.well-known/assetlinks.json
+[{
+  "relation": ["delegate_permission/common.query_webapk"],
+  "target": {
+    "namespace": "web",
+    "site": "https://www.example.com/manifest.json"
+  }
+}]</pre>
+
+          <h4>2. Tell your website about your PWA</h4>
+<pre>{
+  "related_applications": [{
+    "platform": "webapp",
+    "url": "https://app.example.com/manifest.json"
+  }]
+}</pre>
+        </div>
+      </details>
+
+      <!-- Android -->
+      <details>
+        <summary>Check if an Android app is installed</summary>
+        <div class="supported-banner">
+          Supported on:
+          <span class="badge amber">Android only — Chrome 80+</span>
+        </div>
+        <div class="info-section">
+          <h4>1. Tell your Android app about your website</h4>
+          <p>
+            Update your Android app to define the relationship using
+            <a href="https://developers.google.com/digital-asset-links/v1/getting-started" target="_blank" rel="noopener">Digital Asset Links</a>.
+          </p>
+          <p>In <span class="code-inline">AndroidManifest.xml</span>, add an <span class="code-inline">asset_statements</span> entry:</p>
+<pre>&lt;manifest&gt;
+  &lt;application&gt;
+    &lt;meta-data
+      android:name="asset_statements"
+      android:resource="@string/asset_statements" /&gt;
+  &lt;/application&gt;
+&lt;/manifest&gt;</pre>
+
+          <p>In <span class="code-inline">strings.xml</span>:</p>
+<pre>&lt;string name="asset_statements"&gt;
+  [{
+    \"relation\": [\"delegate_permission/common.handle_all_urls\"],
+    \"target\": {
+      \"namespace\": \"web\",
+      \"site\": \"https://example.com\"
+    }
+  }]
+&lt;/string&gt;</pre>
+
+          <h4>2. Tell your website about your Android app in the app manifest</h4>
+<pre>{
+  "related_applications": [{
+    "platform": "play",
+    "id": "com.android.chrome"
+  }]
+}</pre>
+        </div>
+      </details>
+
+      <!-- Windows UWP -->
+      <details>
+        <summary>Check if a Windows (UWP) app is installed</summary>
+        <div class="supported-banner">
+          Supported on:
+          <span class="badge">Windows — Chrome 85+ / Edge 85+</span>
+        </div>
+        <div class="info-section">
+          <h4>1. Tell your Windows app about your website</h4>
+          <p>
+            Use <a href="https://docs.microsoft.com/en-us/windows/uwp/launch-resume/web-to-app-linking" target="_blank" rel="noopener">URI Handlers</a>.
+            Add to <span class="code-inline">Package.appxmanifest</span>:
+          </p>
+<pre>&lt;Extensions&gt;
+  &lt;uap3:Extension Category="windows.appUriHandler"&gt;
+    &lt;uap3:AppUriHandler&gt;
+      &lt;uap3:Host Name="example.com" /&gt;
+    &lt;/uap3:AppUriHandler&gt;
+  &lt;/uap3:Extension&gt;
+&lt;/Extensions&gt;</pre>
+
+          <h4>2. Tell your website about your Windows app</h4>
+          <p>
+            Create a <span class="code-inline">windows-app-web-link</span> file (no <span class="code-inline">.json</span> extension)
+            in your web server root or <span class="code-inline">/.well-known/</span>:
+          </p>
+<pre>[{
+  "packageFamilyName": "MyApp_9jmtgj1pbbz6e",
+  "paths": ["*"]
+}]</pre>
+
+          <p>Add the UWP reference to the app manifest:</p>
+<pre>{
+  "related_applications": [{
+    "platform": "windows",
+    "id": "MyApp_9jmtgj1pbbz6e!App"
+  }]
+}</pre>
+        </div>
+      </details>
+
+    </div>
+
+    <!-- Live Desktop PWA Demo -->
+    <div class="section demo-section">
+      <h2 class="section-title"><span class="emoji">🚀</span> Live Desktop PWA Demo</h2>
+      <p>
+        This site has a self-defining <span class="code-inline">related_applications</span> entry in its
+        <span class="code-inline">manifest.json</span>.
+        The demo below checks if this PWA has been installed on your device.
+        Try installing this PWA and then reload the app to see how <span class="code-inline">getInstalledRelatedApps</span> works.
+      </p>
+
+      <div id="install" class="hidden">
+        <button id="butInstall">Install PWA</button>
+      </div>
+
+      <div class="result-box">
+        <span class="status-label">Installed App:</span>
+        <span id="giraStatus">checking&hellip;</span>
+        <pre id="giraResults">[]</pre>
+      </div>
+    </div>
+
+  </main>
+
+  <footer>
+    getInstalledRelatedApps() &middot; PWA Detection Demo
+  </footer>
+
+  <!-- Scripts -->
+  <script src="./demo.js"></script>
+  <script src="./install.js"></script>
+  <script>
+    // Register service worker
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw.js')
+          .then(reg => console.log('[SW] Registered:', reg.scope))
+          .catch(err => console.error('[SW] Registration failed:', err));
+      });
+    }
+
+    // Fetch manifest and display related_applications live
+    fetch('./manifest.json')
+      .then(r => r.json())
+      .then(manifest => {
+        const el = document.getElementById('manifestDisplay');
+        if (manifest.related_applications) {
+          el.textContent = '"related_applications": ' +
+            JSON.stringify(manifest.related_applications, null, 2);
+        } else {
+          el.textContent = '// No related_applications found in manifest.json';
+        }
+      })
+      .catch(() => {
+        document.getElementById('manifestDisplay').textContent =
+          '// Failed to load manifest.json';
+      });
+  </script>
+
+</body>
+</html>

--- a/pwa-testing/gira-test-app/install.js
+++ b/pwa-testing/gira-test-app/install.js
@@ -1,0 +1,26 @@
+/* Custom Install */
+let deferredPrompt;
+const btnAdd = document.getElementById('butInstall');
+const installContainer = document.getElementById('install');
+
+// Handle install available
+window.addEventListener('beforeinstallprompt', (e) => {
+  showInstallPromo(e);
+});
+
+// Handle user request to install
+btnAdd.addEventListener('click', (e) => {
+  deferredPrompt.prompt();
+});
+
+// Hide the install button after app is installed
+window.addEventListener('appinstalled', (evt) => {
+  installContainer.classList.toggle('hidden', true);
+  deferredPrompt = null;
+});
+
+// Show the install button when install is available
+function showInstallPromo(e) {
+  deferredPrompt = e;
+  installContainer.classList.toggle('hidden', false);
+}

--- a/pwa-testing/gira-test-app/manifest.json
+++ b/pwa-testing/gira-test-app/manifest.json
@@ -1,0 +1,37 @@
+{
+  "name": "getInstalledRelatedApps() API Test",
+  "short_name": "gIRA Test App",
+  "description": "Detect if your app is already installed on the user's device using the getInstalledRelatedApps API.",
+  "start_url": "/",
+  "id": "/",
+  "display": "standalone",
+  "background_color": "#c4b5fd",
+  "theme_color": "#8b5cf6",
+  "scope": "./",
+  "icons": [
+    {
+      "src": "./icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ],
+  "related_applications": [
+    {
+      "platform": "webapp",
+      "id": "https://googlechrome.github.io/samples/pwa-testing/gira-test-app/"
+    },
+    {
+      "platform": "play",
+      "id": "com.example.gira"
+    },
+    {
+      "platform": "windows",
+      "id": "GiraApp_1a2b3c4d5e6f7!App"
+    }
+  ]
+}

--- a/pwa-testing/gira-test-app/styles.css
+++ b/pwa-testing/gira-test-app/styles.css
@@ -1,0 +1,367 @@
+/* === Reset === */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(135deg, #e0c3fc 0%, #c4b5fd 25%, #a78bfa 50%, #c4b5fd 75%, #e0c3fc 100%);
+  color: #1e293b;
+  min-height: 100vh;
+  line-height: 1.7;
+}
+
+/* === In-card hero title === */
+.section-hero-title {
+  font-family: "Cascadia Code", "Fira Code", "SF Mono", Consolas, monospace;
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -.02em;
+  margin-bottom: .25rem;
+  text-align: center;
+}
+
+.section-hero-subtitle {
+  color: #475569;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.section-divider {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 1rem 0;
+}
+
+/* === Main container === */
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 2rem 1rem;
+}
+
+/* === Section cards === */
+.section {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.04), 0 4px 16px rgba(0,0,0,.06);
+  border: 1px solid rgba(0,0,0,.06);
+  transition: box-shadow .2s, transform .2s;
+}
+
+.section:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.08);
+  transform: translateY(-1px);
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: .75rem;
+  display: flex;
+  align-items: center;
+  gap: .1rem;
+}
+
+.section-title .emoji {
+  font-size: 1.1rem;
+  margin-right: .35rem;
+}
+
+.section p {
+  font-size: .95rem;
+  color: #334155;
+  margin-bottom: .5rem;
+}
+
+/* === Sub-sections within a card === */
+.sub-section {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.sub-section:first-child {
+  padding-top: 0;
+}
+
+.sub-section:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+/* === Code blocks === */
+pre {
+  background: linear-gradient(145deg, #1e293b, #0f172a);
+  color: #e2e8f0;
+  padding: 1.15rem 1.35rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: .85rem;
+  line-height: 1.6;
+  margin-top: .65rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid rgba(255,255,255,.05);
+}
+
+code {
+  font-family: "Cascadia Code", "Fira Code", "SF Mono", Consolas, monospace;
+}
+
+.code-inline {
+  background: #f1f5f9;
+  padding: .15rem .5rem;
+  border-radius: 5px;
+  font-family: "Cascadia Code", "Fira Code", "SF Mono", Consolas, monospace;
+  font-size: .84rem;
+  color: #6366f1;
+  border: 1px solid #e2e8f0;
+}
+
+/* === Collapsible details === */
+details {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  margin-bottom: .75rem;
+  overflow: hidden;
+  transition: box-shadow .2s;
+}
+
+details:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,.05);
+}
+
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: .95rem;
+  color: #4f46e5;
+  padding: 1rem 1.35rem;
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  transition: background .15s;
+}
+
+details summary::before {
+  content: "▸";
+  font-size: .9rem;
+  font-weight: 700;
+  transition: transform .25s ease;
+  color: #6366f1;
+}
+
+details[open] summary::before {
+  transform: rotate(90deg);
+}
+
+details summary::-webkit-details-marker { display: none; }
+
+details summary:hover {
+  background: #faf5ff;
+}
+
+details[open] summary {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+/* === Supported-on banner === */
+.supported-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .5rem;
+  background: linear-gradient(135deg, #faf5ff, #eff6ff, #f0fdf4);
+  padding: .65rem 1.35rem;
+  font-size: .82rem;
+  font-weight: 600;
+  color: #374151;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.supported-banner .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+  padding: .2rem .65rem;
+  border-radius: 20px;
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .01em;
+}
+
+.supported-banner .badge {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.supported-banner .badge.green {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.supported-banner .badge.amber {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* === Info sections inside details === */
+.info-section {
+  padding: 1rem 1.35rem 1.5rem;
+}
+
+.info-section h4 {
+  color: #1e293b;
+  font-size: .95rem;
+  margin: 1.25rem 0 .4rem;
+  padding-bottom: .25rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.info-section h4:first-child {
+  margin-top: .25rem;
+}
+
+.info-section p,
+.info-section li {
+  font-size: .875rem;
+  color: #334155;
+  margin-bottom: .4rem;
+}
+
+.info-section ul {
+  list-style: disc;
+  margin-left: 1.25rem;
+  margin-bottom: .75rem;
+}
+
+.info-section ol {
+  margin-left: 1.25rem;
+  margin-bottom: .75rem;
+}
+
+.info-section ol li {
+  margin-bottom: .25rem;
+}
+
+.info-section a {
+  color: #6366f1;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.info-section a:hover {
+  text-decoration: underline;
+  color: #4f46e5;
+}
+
+/* === Tables === */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: .75rem 0;
+  font-size: .85rem;
+}
+
+th, td {
+  text-align: left;
+  padding: .55rem .75rem;
+  border: 1px solid #e2e8f0;
+}
+
+th {
+  background: #f1f5f9;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+td {
+  color: #334155;
+}
+
+/* === Live demo section === */
+.demo-section {
+  background: linear-gradient(135deg, #fff 0%, #faf5ff 100%);
+  border: 1px solid #e9d5ff;
+}
+
+.demo-section .section-title {
+  text-align: left;
+}
+
+.demo-section p {
+  text-align: left;
+}
+
+/* === Install button === */
+#install.hidden { display: none; }
+
+#install {
+  text-align: center;
+}
+
+#butInstall {
+  background: linear-gradient(135deg, #3b82f6, #6366f1, #8b5cf6);
+  color: #fff;
+  border: none;
+  padding: .75rem 2rem;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: .95rem;
+  font-weight: 600;
+  transition: all .25s;
+  margin: 1.25rem auto;
+  display: inline-block;
+  box-shadow: 0 2px 8px rgba(99,102,241,.3);
+}
+
+#butInstall:hover {
+  background: linear-gradient(135deg, #2563eb, #4f46e5, #7c3aed);
+  box-shadow: 0 4px 16px rgba(99,102,241,.4);
+  transform: translateY(-1px);
+}
+
+/* === GIRA result area === */
+.result-box {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1.15rem 1.35rem;
+  margin-top: 1.25rem;
+  text-align: left;
+}
+
+.result-box .status-label {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: .9rem;
+}
+
+#giraStatus {
+  display: inline-block;
+  padding: .1rem .55rem;
+  border-radius: 4px;
+  background: transparent;
+  color: #16a34a;
+  font-family: "Cascadia Code", "Fira Code", "SF Mono", Consolas, monospace;
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.result-box pre {
+  margin-top: .65rem;
+}
+
+/* === Footer === */
+footer {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: #64748b;
+  font-size: .8rem;
+  letter-spacing: .01em;
+}

--- a/pwa-testing/gira-test-app/sw.js
+++ b/pwa-testing/gira-test-app/sw.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', function(e) {
+  console.log('[ServiceWorker] Install');
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(e) {
+  console.log('[ServiceWorker] Activate');
+  return self.clients.claim();
+});
+
+self.addEventListener('fetch', function(e) {
+  console.log('[Service Worker] Fetch', e.request.url);
+  e.respondWith(fetch(e.request));
+});

--- a/pwa-testing/index.html
+++ b/pwa-testing/index.html
@@ -131,6 +131,7 @@
 				"flower-confused-dinosaur": "Test site with different images embedded for testing go/shortcuts-not-apps",
 				"foggy-noiseless-cylinder": "Name is made entirely of emojis and longer than 45 characters",
 				"furry-hickory-furniture": "Change manifest url, start_url, and scope dynamically",
+				"gira-test-app": "Test app for getInstalledRelatedApps() API",
 				"global-swordfish": "Play billing APIs test site.",
 				"glossy-cuboid-attention": "Links to badssl.com to test insecure pages in web app windows.",
 				"halved-cubic-postage": "Empty name and empty page title.",


### PR DESCRIPTION
This CL adds a testing site for the getInstalledRealtedApps API on Desktop PWAs and updates the pwa-testing index to add this site to the metadata.

<img width="714" height="1246" alt="Screenshot 2026-02-26 133033" src="https://github.com/user-attachments/assets/1f4f3408-4929-4522-90e8-d96470c675cc" />
