### PR TITLE
trailblazers: fix double push-pin tooltip and map URL path prefix

### DIFF
--- a/trailblazers/content/en/destinations/index.njk
+++ b/trailblazers/content/en/destinations/index.njk
@@ -120,11 +120,6 @@ permalink: /en/destinations/index.html
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -260,6 +255,7 @@ permalink: /en/destinations/index.html
 (function () {
   const destinations = {{ destinations | dump | safe }};
   const locale = {{ locale | dump | safe }};
+  const siteBase = {{ '/' | url | dump | safe }};
 
   const container = document.getElementById('world-map-container');
   const tooltip = document.getElementById('map-tooltip');
@@ -277,19 +273,19 @@ permalink: /en/destinations/index.html
     el.classList.add('destination-highlight');
     el.setAttribute('data-dest-slug', slug);
     el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
-    el.setAttribute('data-dest-url', '/' + locale + '/blog/' + slug + '/');
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
     el.setAttribute('tabindex', '0');
     el.setAttribute('role', 'button');
     el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
 
     // Click to navigate
     el.addEventListener('click', (e) => {
-      window.location.href = '/' + locale + '/blog/' + slug + '/';
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
     });
 
     el.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        window.location.href = '/' + locale + '/blog/' + slug + '/';
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
       }
     });
   });

--- a/trailblazers/content/es/destinations/index.njk
+++ b/trailblazers/content/es/destinations/index.njk
@@ -120,11 +120,6 @@ permalink: /es/destinations/index.html
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -234,7 +229,7 @@ permalink: /es/destinations/index.html
     <h2>{{ 'destinations_all' | i18n({}, locale) }}</h2>
     <ul class="destination-cards">
       {%- for slug, dest in destinations %}
-      {%- set postUrl = '/' + locale + '/blog/' + slug + '/' %}
+      {%- set postUrl = siteBase + locale + '/blog/' + slug + '/' %}
       <li>
         <a href="{{ postUrl }}" class="destination-card">
           <div class="destination-card-thumb">
@@ -260,6 +255,7 @@ permalink: /es/destinations/index.html
 (function () {
   const destinations = {{ destinations | dump | safe }};
   const locale = {{ locale | dump | safe }};
+  const siteBase = {{ '/' | url | dump | safe }};
 
   const container = document.getElementById('world-map-container');
   const tooltip = document.getElementById('map-tooltip');
@@ -277,19 +273,19 @@ permalink: /es/destinations/index.html
     el.classList.add('destination-highlight');
     el.setAttribute('data-dest-slug', slug);
     el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
-    el.setAttribute('data-dest-url', '/' + locale + '/blog/' + slug + '/');
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
     el.setAttribute('tabindex', '0');
     el.setAttribute('role', 'button');
     el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
 
     // Click to navigate
     el.addEventListener('click', (e) => {
-      window.location.href = '/' + locale + '/blog/' + slug + '/';
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
     });
 
     el.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        window.location.href = '/' + locale + '/blog/' + slug + '/';
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
       }
     });
   });

--- a/trailblazers/content/ja/destinations/index.njk
+++ b/trailblazers/content/ja/destinations/index.njk
@@ -120,11 +120,6 @@ permalink: /ja/destinations/index.html
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -234,7 +229,7 @@ permalink: /ja/destinations/index.html
     <h2>{{ 'destinations_all' | i18n({}, locale) }}</h2>
     <ul class="destination-cards">
       {%- for slug, dest in destinations %}
-      {%- set postUrl = '/' + locale + '/blog/' + slug + '/' %}
+      {%- set postUrl = siteBase + locale + '/blog/' + slug + '/' %}
       <li>
         <a href="{{ postUrl }}" class="destination-card">
           <div class="destination-card-thumb">
@@ -260,6 +255,7 @@ permalink: /ja/destinations/index.html
 (function () {
   const destinations = {{ destinations | dump | safe }};
   const locale = {{ locale | dump | safe }};
+  const siteBase = {{ '/' | url | dump | safe }};
 
   const container = document.getElementById('world-map-container');
   const tooltip = document.getElementById('map-tooltip');
@@ -277,19 +273,19 @@ permalink: /ja/destinations/index.html
     el.classList.add('destination-highlight');
     el.setAttribute('data-dest-slug', slug);
     el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
-    el.setAttribute('data-dest-url', '/' + locale + '/blog/' + slug + '/');
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
     el.setAttribute('tabindex', '0');
     el.setAttribute('role', 'button');
     el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
 
     // Click to navigate
     el.addEventListener('click', (e) => {
-      window.location.href = '/' + locale + '/blog/' + slug + '/';
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
     });
 
     el.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        window.location.href = '/' + locale + '/blog/' + slug + '/';
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
       }
     });
   });

--- a/trailblazers/dist/404.html
+++ b/trailblazers/dist/404.html
@@ -1719,7 +1719,7 @@ This is compatible with:
 			</form>
 		</footer>
 
-		<!-- This page `/404.html` was built on 2026-03-31T21:40:25.696Z -->
+		<!-- This page `/404.html` was built on 2026-04-01T08:41:05.306Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/zq-deDkjP5.js"></script>
 		
 		

--- a/trailblazers/dist/dist/02zMvsH_04.js
+++ b/trailblazers/dist/dist/02zMvsH_04.js
@@ -1,0 +1,397 @@
+(function () {
+  const destinations = {"amalfi-coast-winding-roads":{"countryCode":"IT","country":{"en":"Italy","es":"Italia","ja":"イタリア"}},"bali-spiritual-sanctuary":{"countryCode":"ID","country":{"en":"Indonesia","es":"Indonesia","ja":"インドネシア"}},"banff-turquoise-waters":{"countryCode":"CA","country":{"en":"Canada","es":"Canadá","ja":"カナダ"}},"cape-town-table-mountain":{"countryCode":"ZA","country":{"en":"South Africa","es":"Sudáfrica","ja":"南アフリカ"}},"machu-picchu-ancient-echoes":{"countryCode":"PE","country":{"en":"Peru","es":"Perú","ja":"ペルー"}},"new-york-concrete-jungle":{"countryCode":"US","country":{"en":"United States","es":"Estados Unidos","ja":"アメリカ合衆国"}},"paris-midnight-stroll":{"countryCode":"FR","country":{"en":"France","es":"Francia","ja":"フランス"}},"petra-rose-red-city":{"countryCode":"JO","country":{"en":"Jordan","es":"Jordania","ja":"ヨルダン"}},"reykjavik-northern-lights":{"countryCode":"IS","country":{"en":"Iceland","es":"Islandia","ja":"アイスランド"}},"santorini-blue-and-white":{"countryCode":"GR","country":{"en":"Greece","es":"Grecia","ja":"ギリシャ"}},"serengeti-safari-sunrise":{"countryCode":"TZ","country":{"en":"Tanzania","es":"Tanzania","ja":"タンザニア"}},"tokyo-neon-nights":{"countryCode":"JP","country":{"en":"Japan","es":"Japón","ja":"日本"}}};
+  const locale = "ja";
+  const siteBase = "/samples/trailblazers/dist/";
+
+  const container = document.getElementById('world-map-container');
+  const tooltip = document.getElementById('map-tooltip');
+  if (!container) return;
+
+  // Map slug → { countryCode, country }
+  const destEntries = Object.entries(destinations);
+
+  // Highlight each destination country
+  destEntries.forEach(([slug, dest]) => {
+    const code = dest.countryCode.toLowerCase();
+    const el = container.querySelector('#' + code);
+    if (!el) return;
+
+    el.classList.add('destination-highlight');
+    el.setAttribute('data-dest-slug', slug);
+    el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
+    el.setAttribute('tabindex', '0');
+    el.setAttribute('role', 'button');
+    el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
+
+    // Click to navigate
+    el.addEventListener('click', (e) => {
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
+    });
+
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
+      }
+    });
+  });
+
+  // Tooltip follow-mouse
+  container.addEventListener('mousemove', (e) => {
+    const rect = container.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    tooltip.style.left = (x + 14) + 'px';
+    tooltip.style.top = (y - 36) + 'px';
+  });
+
+  container.addEventListener('mouseover', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight) {
+      const name = highlight.getAttribute('data-dest-name');
+      if (name) {
+        tooltip.textContent = name;
+        // re-add the ::before via data attr trick isn't needed – we override textContent,
+        // so use innerHTML instead
+        tooltip.innerHTML = '📍 ' + name;
+        tooltip.style.opacity = '1';
+      }
+    }
+  });
+
+  container.addEventListener('mouseout', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight && !highlight.contains(e.relatedTarget)) {
+      tooltip.style.opacity = '0';
+    }
+  });
+
+  // Pan & zoom
+  let scale = 1, panX = 0, panY = 0;
+  let isPanning = false, startX = 0, startY = 0;
+
+  const svg = container.querySelector('svg');
+  if (!svg) return;
+
+  function applyTransform() {
+    svg.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    svg.style.transformOrigin = 'center center';
+  }
+
+  container.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    scale = Math.min(Math.max(scale * delta, 1), 6);
+    if (scale === 1) { panX = 0; panY = 0; }
+    applyTransform();
+  }, { passive: false });
+
+  container.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    isPanning = true;
+    startX = e.clientX - panX;
+    startY = e.clientY - panY;
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!isPanning) return;
+    panX = e.clientX - startX;
+    panY = e.clientY - startY;
+    applyTransform();
+  });
+
+  window.addEventListener('mouseup', () => { isPanning = false; });
+
+  // Double-click to reset
+  container.addEventListener('dblclick', () => {
+    scale = 1; panX = 0; panY = 0;
+    applyTransform();
+  });
+})();
+// Thank you to https://github.com/daviddarnes/heading-anchors
+// Thank you to https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+
+let globalInstanceIndex = 0;
+
+class HeadingAnchors extends HTMLElement {
+	static register(tagName = "heading-anchors", registry = window.customElements) {
+		if(registry && !registry.get(tagName)) {
+			registry.define(tagName, this);
+		}
+	}
+
+	static attributes = {
+		exclude: "data-ha-exclude",
+		prefix: "prefix",
+		content: "content",
+	}
+
+	static classes = {
+		anchor: "ha",
+		placeholder: "ha-placeholder",
+		srOnly: "ha-visualhide",
+	}
+
+	static defaultSelector = "h2,h3,h4,h5,h6";
+
+	static css = `
+.${HeadingAnchors.classes.srOnly} {
+	clip: rect(0 0 0 0);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	width: 1px;
+}
+.${HeadingAnchors.classes.anchor} {
+	position: absolute;
+	left: var(--ha_offsetx);
+	top: var(--ha_offsety);
+	text-decoration: none;
+	opacity: 0;
+}
+.${HeadingAnchors.classes.placeholder} {
+	opacity: .3;
+}
+.${HeadingAnchors.classes.anchor}:is(:focus-within, :hover) {
+	opacity: 1;
+}
+.${HeadingAnchors.classes.anchor},
+.${HeadingAnchors.classes.placeholder} {
+	display: inline-block;
+	padding: 0 .25em;
+
+	/* Disable selection of visually hidden label */
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+@supports (anchor-name: none) {
+	.${HeadingAnchors.classes.anchor} {
+		position: absolute;
+		left: anchor(left);
+		top: anchor(top);
+	}
+}`;
+
+	get supports() {
+		return "replaceSync" in CSSStyleSheet.prototype;
+	}
+
+	get supportsAnchorPosition() {
+		return CSS.supports("anchor-name: none");
+	}
+
+	constructor() {
+		super();
+
+		if(!this.supports) {
+			return;
+		}
+
+		let sheet = new CSSStyleSheet();
+		sheet.replaceSync(HeadingAnchors.css);
+		document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
+		this.headingStyles = {};
+		this.instanceIndex = globalInstanceIndex++;
+	}
+
+	connectedCallback() {
+		if (!this.supports) {
+			return;
+		}
+
+		this.headings.forEach((heading, index) => {
+			if(!heading.hasAttribute(HeadingAnchors.attributes.exclude)) {
+				let anchor = this.getAnchorElement(heading);
+				let placeholder = this.getPlaceholderElement();
+
+				// Prefers anchor position approach for better accessibility
+				// https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+				if(this.supportsAnchorPosition) {
+					let anchorName = `--ha_${this.instanceIndex}_${index}`;
+					placeholder.style.setProperty("anchor-name", anchorName);
+					anchor.style.positionAnchor = anchorName;
+				}
+
+				heading.appendChild(placeholder);
+				heading.after(anchor);
+			}
+		});
+	}
+
+	// Polyfill-only
+	positionAnchorFromPlaceholder(placeholder) {
+		if(!placeholder) {
+			return;
+		}
+
+		let heading = placeholder.closest("h1,h2,h3,h4,h5,h6");
+		if(!heading.nextElementSibling) {
+			return;
+		}
+
+		// TODO next element could be more defensive
+		this.positionAnchor(heading.nextElementSibling);
+	}
+
+	// Polyfill-only
+	positionAnchor(anchor) {
+		if(!anchor || !anchor.previousElementSibling) {
+			return;
+		}
+
+		// TODO previous element could be more defensive
+		let heading = anchor.previousElementSibling;
+		this.setFontProp(heading, anchor);
+
+		if(this.supportsAnchorPosition) {
+			// quit early
+			return;
+		}
+
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			anchor.style.setProperty("--ha_offsetx", `${placeholder.offsetLeft}px`);
+			anchor.style.setProperty("--ha_offsety", `${placeholder.offsetTop}px`);
+		}
+	}
+
+	setFontProp(heading, anchor) {
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			let style = getComputedStyle(placeholder);
+			let props = ["font-weight", "font-size", "line-height", "font-family"];
+			let [weight, size, lh, family] = props.map(name => style.getPropertyValue(name));
+			anchor.style.setProperty("font", `${weight} ${size}/${lh} ${family}`);
+			let vars = style.getPropertyValue("font-variation-settings");
+			if(vars) {
+				anchor.style.setProperty("font-variation-settings", vars);
+			}
+		}
+	}
+
+	getAccessibleTextPrefix() {
+		// Useful for i18n
+		return this.getAttribute(HeadingAnchors.attributes.prefix) || "Jump to section titled";
+	}
+
+	getContent() {
+		if(this.hasAttribute(HeadingAnchors.attributes.content)) {
+			return this.getAttribute(HeadingAnchors.attributes.content);
+		}
+		return "#";
+	}
+
+	// Placeholder nests inside of heading
+	getPlaceholderElement() {
+		let ph = document.createElement("span");
+		ph.setAttribute("aria-hidden", true);
+		ph.classList.add(HeadingAnchors.classes.placeholder);
+		let content = this.getContent();
+		if(content) {
+			ph.textContent = content;
+		}
+
+		ph.addEventListener("mouseover", (e) => {
+			let placeholder = e.target.closest(`.${HeadingAnchors.classes.placeholder}`);
+			if(placeholder) {
+				this.positionAnchorFromPlaceholder(placeholder);
+			}
+		});
+
+		return ph;
+	}
+
+	getAnchorElement(heading) {
+		let anchor = document.createElement("a");
+		anchor.href = `#${heading.id}`;
+		anchor.classList.add(HeadingAnchors.classes.anchor);
+
+		let content = this.getContent();
+		anchor.innerHTML = `<span class="${HeadingAnchors.classes.srOnly}">${this.getAccessibleTextPrefix()}: ${heading.textContent}</span>${content ? `<span aria-hidden="true">${content}</span>` : ""}`;
+
+		anchor.addEventListener("focus", e => {
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			if(anchor) {
+				this.positionAnchor(anchor);
+			}
+		});
+
+		anchor.addEventListener("mouseover", (e) => {
+			// when CSS anchor positioning is supported, this is only used to set the font
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			this.positionAnchor(anchor);
+		});
+
+		return anchor;
+	}
+
+	get headings() {
+		return this.querySelectorAll(this.selector.split(",").map(entry => `${entry.trim()}[id]`));
+	}
+
+	get selector() {
+		return this.getAttribute("selector") || HeadingAnchors.defaultSelector;
+	}
+}
+
+HeadingAnchors.register();
+
+export { HeadingAnchors }
+const urlParams = new URLSearchParams(window.location.search);
+			const adminFromUrl = urlParams.get('admin') === 'true';
+			const adminFromStorage = localStorage.getItem('admin') === 'true';
+
+			if (adminFromUrl) {
+				localStorage.setItem('admin', 'true');
+			} else if (adminFromStorage) {
+				urlParams.set('admin', 'true');
+				window.location.search = urlParams.toString();
+			}
+
+			const isAdmin = adminFromUrl || adminFromStorage;
+			if(isAdmin) {
+				document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'initial');
+				// Append ?admin=true to all internal links to maintain state
+				document.querySelectorAll('a[href^="/"]').forEach(a => {
+					const url = new URL(a.href, window.location.origin);
+					if (!url.searchParams.has('admin')) {
+						url.searchParams.set('admin', 'true');
+						a.href = url.pathname + url.search + url.hash;
+					}
+				});
+			}
+window.addEventListener('DOMContentLoaded', (event) => {
+				const searchToggle = document.getElementById('search-toggle');
+				const searchOverlay = document.getElementById('search-overlay');
+				const searchClose = document.getElementById('search-close');
+				let pagefindInitialized = false;
+
+				if (searchToggle && searchOverlay) {
+					searchToggle.addEventListener('click', () => {
+						searchOverlay.showModal();
+						if (!pagefindInitialized) {
+							new PagefindUI({ 
+								element: "#search",
+								showSubResults: true,
+								resetStyles: false,
+								translations: {
+									clear_search: "×"
+								}
+							});
+							pagefindInitialized = true;
+						}
+						// Focus input after init
+						setTimeout(() => {
+							const input = searchOverlay.querySelector('input');
+							if (input) input.focus();
+						}, 100);
+					});
+
+					searchClose.addEventListener('click', () => {
+						searchOverlay.close();
+					});
+				}
+			});

--- a/trailblazers/dist/dist/A3AQwII-0u.js
+++ b/trailblazers/dist/dist/A3AQwII-0u.js
@@ -1,0 +1,397 @@
+(function () {
+  const destinations = {"amalfi-coast-winding-roads":{"countryCode":"IT","country":{"en":"Italy","es":"Italia","ja":"イタリア"}},"bali-spiritual-sanctuary":{"countryCode":"ID","country":{"en":"Indonesia","es":"Indonesia","ja":"インドネシア"}},"banff-turquoise-waters":{"countryCode":"CA","country":{"en":"Canada","es":"Canadá","ja":"カナダ"}},"cape-town-table-mountain":{"countryCode":"ZA","country":{"en":"South Africa","es":"Sudáfrica","ja":"南アフリカ"}},"machu-picchu-ancient-echoes":{"countryCode":"PE","country":{"en":"Peru","es":"Perú","ja":"ペルー"}},"new-york-concrete-jungle":{"countryCode":"US","country":{"en":"United States","es":"Estados Unidos","ja":"アメリカ合衆国"}},"paris-midnight-stroll":{"countryCode":"FR","country":{"en":"France","es":"Francia","ja":"フランス"}},"petra-rose-red-city":{"countryCode":"JO","country":{"en":"Jordan","es":"Jordania","ja":"ヨルダン"}},"reykjavik-northern-lights":{"countryCode":"IS","country":{"en":"Iceland","es":"Islandia","ja":"アイスランド"}},"santorini-blue-and-white":{"countryCode":"GR","country":{"en":"Greece","es":"Grecia","ja":"ギリシャ"}},"serengeti-safari-sunrise":{"countryCode":"TZ","country":{"en":"Tanzania","es":"Tanzania","ja":"タンザニア"}},"tokyo-neon-nights":{"countryCode":"JP","country":{"en":"Japan","es":"Japón","ja":"日本"}}};
+  const locale = "es";
+  const siteBase = "/samples/trailblazers/dist/";
+
+  const container = document.getElementById('world-map-container');
+  const tooltip = document.getElementById('map-tooltip');
+  if (!container) return;
+
+  // Map slug → { countryCode, country }
+  const destEntries = Object.entries(destinations);
+
+  // Highlight each destination country
+  destEntries.forEach(([slug, dest]) => {
+    const code = dest.countryCode.toLowerCase();
+    const el = container.querySelector('#' + code);
+    if (!el) return;
+
+    el.classList.add('destination-highlight');
+    el.setAttribute('data-dest-slug', slug);
+    el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
+    el.setAttribute('tabindex', '0');
+    el.setAttribute('role', 'button');
+    el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
+
+    // Click to navigate
+    el.addEventListener('click', (e) => {
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
+    });
+
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
+      }
+    });
+  });
+
+  // Tooltip follow-mouse
+  container.addEventListener('mousemove', (e) => {
+    const rect = container.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    tooltip.style.left = (x + 14) + 'px';
+    tooltip.style.top = (y - 36) + 'px';
+  });
+
+  container.addEventListener('mouseover', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight) {
+      const name = highlight.getAttribute('data-dest-name');
+      if (name) {
+        tooltip.textContent = name;
+        // re-add the ::before via data attr trick isn't needed – we override textContent,
+        // so use innerHTML instead
+        tooltip.innerHTML = '📍 ' + name;
+        tooltip.style.opacity = '1';
+      }
+    }
+  });
+
+  container.addEventListener('mouseout', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight && !highlight.contains(e.relatedTarget)) {
+      tooltip.style.opacity = '0';
+    }
+  });
+
+  // Pan & zoom
+  let scale = 1, panX = 0, panY = 0;
+  let isPanning = false, startX = 0, startY = 0;
+
+  const svg = container.querySelector('svg');
+  if (!svg) return;
+
+  function applyTransform() {
+    svg.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    svg.style.transformOrigin = 'center center';
+  }
+
+  container.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    scale = Math.min(Math.max(scale * delta, 1), 6);
+    if (scale === 1) { panX = 0; panY = 0; }
+    applyTransform();
+  }, { passive: false });
+
+  container.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    isPanning = true;
+    startX = e.clientX - panX;
+    startY = e.clientY - panY;
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!isPanning) return;
+    panX = e.clientX - startX;
+    panY = e.clientY - startY;
+    applyTransform();
+  });
+
+  window.addEventListener('mouseup', () => { isPanning = false; });
+
+  // Double-click to reset
+  container.addEventListener('dblclick', () => {
+    scale = 1; panX = 0; panY = 0;
+    applyTransform();
+  });
+})();
+// Thank you to https://github.com/daviddarnes/heading-anchors
+// Thank you to https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+
+let globalInstanceIndex = 0;
+
+class HeadingAnchors extends HTMLElement {
+	static register(tagName = "heading-anchors", registry = window.customElements) {
+		if(registry && !registry.get(tagName)) {
+			registry.define(tagName, this);
+		}
+	}
+
+	static attributes = {
+		exclude: "data-ha-exclude",
+		prefix: "prefix",
+		content: "content",
+	}
+
+	static classes = {
+		anchor: "ha",
+		placeholder: "ha-placeholder",
+		srOnly: "ha-visualhide",
+	}
+
+	static defaultSelector = "h2,h3,h4,h5,h6";
+
+	static css = `
+.${HeadingAnchors.classes.srOnly} {
+	clip: rect(0 0 0 0);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	width: 1px;
+}
+.${HeadingAnchors.classes.anchor} {
+	position: absolute;
+	left: var(--ha_offsetx);
+	top: var(--ha_offsety);
+	text-decoration: none;
+	opacity: 0;
+}
+.${HeadingAnchors.classes.placeholder} {
+	opacity: .3;
+}
+.${HeadingAnchors.classes.anchor}:is(:focus-within, :hover) {
+	opacity: 1;
+}
+.${HeadingAnchors.classes.anchor},
+.${HeadingAnchors.classes.placeholder} {
+	display: inline-block;
+	padding: 0 .25em;
+
+	/* Disable selection of visually hidden label */
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+@supports (anchor-name: none) {
+	.${HeadingAnchors.classes.anchor} {
+		position: absolute;
+		left: anchor(left);
+		top: anchor(top);
+	}
+}`;
+
+	get supports() {
+		return "replaceSync" in CSSStyleSheet.prototype;
+	}
+
+	get supportsAnchorPosition() {
+		return CSS.supports("anchor-name: none");
+	}
+
+	constructor() {
+		super();
+
+		if(!this.supports) {
+			return;
+		}
+
+		let sheet = new CSSStyleSheet();
+		sheet.replaceSync(HeadingAnchors.css);
+		document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
+		this.headingStyles = {};
+		this.instanceIndex = globalInstanceIndex++;
+	}
+
+	connectedCallback() {
+		if (!this.supports) {
+			return;
+		}
+
+		this.headings.forEach((heading, index) => {
+			if(!heading.hasAttribute(HeadingAnchors.attributes.exclude)) {
+				let anchor = this.getAnchorElement(heading);
+				let placeholder = this.getPlaceholderElement();
+
+				// Prefers anchor position approach for better accessibility
+				// https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+				if(this.supportsAnchorPosition) {
+					let anchorName = `--ha_${this.instanceIndex}_${index}`;
+					placeholder.style.setProperty("anchor-name", anchorName);
+					anchor.style.positionAnchor = anchorName;
+				}
+
+				heading.appendChild(placeholder);
+				heading.after(anchor);
+			}
+		});
+	}
+
+	// Polyfill-only
+	positionAnchorFromPlaceholder(placeholder) {
+		if(!placeholder) {
+			return;
+		}
+
+		let heading = placeholder.closest("h1,h2,h3,h4,h5,h6");
+		if(!heading.nextElementSibling) {
+			return;
+		}
+
+		// TODO next element could be more defensive
+		this.positionAnchor(heading.nextElementSibling);
+	}
+
+	// Polyfill-only
+	positionAnchor(anchor) {
+		if(!anchor || !anchor.previousElementSibling) {
+			return;
+		}
+
+		// TODO previous element could be more defensive
+		let heading = anchor.previousElementSibling;
+		this.setFontProp(heading, anchor);
+
+		if(this.supportsAnchorPosition) {
+			// quit early
+			return;
+		}
+
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			anchor.style.setProperty("--ha_offsetx", `${placeholder.offsetLeft}px`);
+			anchor.style.setProperty("--ha_offsety", `${placeholder.offsetTop}px`);
+		}
+	}
+
+	setFontProp(heading, anchor) {
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			let style = getComputedStyle(placeholder);
+			let props = ["font-weight", "font-size", "line-height", "font-family"];
+			let [weight, size, lh, family] = props.map(name => style.getPropertyValue(name));
+			anchor.style.setProperty("font", `${weight} ${size}/${lh} ${family}`);
+			let vars = style.getPropertyValue("font-variation-settings");
+			if(vars) {
+				anchor.style.setProperty("font-variation-settings", vars);
+			}
+		}
+	}
+
+	getAccessibleTextPrefix() {
+		// Useful for i18n
+		return this.getAttribute(HeadingAnchors.attributes.prefix) || "Jump to section titled";
+	}
+
+	getContent() {
+		if(this.hasAttribute(HeadingAnchors.attributes.content)) {
+			return this.getAttribute(HeadingAnchors.attributes.content);
+		}
+		return "#";
+	}
+
+	// Placeholder nests inside of heading
+	getPlaceholderElement() {
+		let ph = document.createElement("span");
+		ph.setAttribute("aria-hidden", true);
+		ph.classList.add(HeadingAnchors.classes.placeholder);
+		let content = this.getContent();
+		if(content) {
+			ph.textContent = content;
+		}
+
+		ph.addEventListener("mouseover", (e) => {
+			let placeholder = e.target.closest(`.${HeadingAnchors.classes.placeholder}`);
+			if(placeholder) {
+				this.positionAnchorFromPlaceholder(placeholder);
+			}
+		});
+
+		return ph;
+	}
+
+	getAnchorElement(heading) {
+		let anchor = document.createElement("a");
+		anchor.href = `#${heading.id}`;
+		anchor.classList.add(HeadingAnchors.classes.anchor);
+
+		let content = this.getContent();
+		anchor.innerHTML = `<span class="${HeadingAnchors.classes.srOnly}">${this.getAccessibleTextPrefix()}: ${heading.textContent}</span>${content ? `<span aria-hidden="true">${content}</span>` : ""}`;
+
+		anchor.addEventListener("focus", e => {
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			if(anchor) {
+				this.positionAnchor(anchor);
+			}
+		});
+
+		anchor.addEventListener("mouseover", (e) => {
+			// when CSS anchor positioning is supported, this is only used to set the font
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			this.positionAnchor(anchor);
+		});
+
+		return anchor;
+	}
+
+	get headings() {
+		return this.querySelectorAll(this.selector.split(",").map(entry => `${entry.trim()}[id]`));
+	}
+
+	get selector() {
+		return this.getAttribute("selector") || HeadingAnchors.defaultSelector;
+	}
+}
+
+HeadingAnchors.register();
+
+export { HeadingAnchors }
+const urlParams = new URLSearchParams(window.location.search);
+			const adminFromUrl = urlParams.get('admin') === 'true';
+			const adminFromStorage = localStorage.getItem('admin') === 'true';
+
+			if (adminFromUrl) {
+				localStorage.setItem('admin', 'true');
+			} else if (adminFromStorage) {
+				urlParams.set('admin', 'true');
+				window.location.search = urlParams.toString();
+			}
+
+			const isAdmin = adminFromUrl || adminFromStorage;
+			if(isAdmin) {
+				document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'initial');
+				// Append ?admin=true to all internal links to maintain state
+				document.querySelectorAll('a[href^="/"]').forEach(a => {
+					const url = new URL(a.href, window.location.origin);
+					if (!url.searchParams.has('admin')) {
+						url.searchParams.set('admin', 'true');
+						a.href = url.pathname + url.search + url.hash;
+					}
+				});
+			}
+window.addEventListener('DOMContentLoaded', (event) => {
+				const searchToggle = document.getElementById('search-toggle');
+				const searchOverlay = document.getElementById('search-overlay');
+				const searchClose = document.getElementById('search-close');
+				let pagefindInitialized = false;
+
+				if (searchToggle && searchOverlay) {
+					searchToggle.addEventListener('click', () => {
+						searchOverlay.showModal();
+						if (!pagefindInitialized) {
+							new PagefindUI({ 
+								element: "#search",
+								showSubResults: true,
+								resetStyles: false,
+								translations: {
+									clear_search: "×"
+								}
+							});
+							pagefindInitialized = true;
+						}
+						// Focus input after init
+						setTimeout(() => {
+							const input = searchOverlay.querySelector('input');
+							if (input) input.focus();
+						}, 100);
+					});
+
+					searchClose.addEventListener('click', () => {
+						searchOverlay.close();
+					});
+				}
+			});

--- a/trailblazers/dist/dist/oP_UqwhMW3.js
+++ b/trailblazers/dist/dist/oP_UqwhMW3.js
@@ -1,0 +1,397 @@
+(function () {
+  const destinations = {"amalfi-coast-winding-roads":{"countryCode":"IT","country":{"en":"Italy","es":"Italia","ja":"イタリア"}},"bali-spiritual-sanctuary":{"countryCode":"ID","country":{"en":"Indonesia","es":"Indonesia","ja":"インドネシア"}},"banff-turquoise-waters":{"countryCode":"CA","country":{"en":"Canada","es":"Canadá","ja":"カナダ"}},"cape-town-table-mountain":{"countryCode":"ZA","country":{"en":"South Africa","es":"Sudáfrica","ja":"南アフリカ"}},"machu-picchu-ancient-echoes":{"countryCode":"PE","country":{"en":"Peru","es":"Perú","ja":"ペルー"}},"new-york-concrete-jungle":{"countryCode":"US","country":{"en":"United States","es":"Estados Unidos","ja":"アメリカ合衆国"}},"paris-midnight-stroll":{"countryCode":"FR","country":{"en":"France","es":"Francia","ja":"フランス"}},"petra-rose-red-city":{"countryCode":"JO","country":{"en":"Jordan","es":"Jordania","ja":"ヨルダン"}},"reykjavik-northern-lights":{"countryCode":"IS","country":{"en":"Iceland","es":"Islandia","ja":"アイスランド"}},"santorini-blue-and-white":{"countryCode":"GR","country":{"en":"Greece","es":"Grecia","ja":"ギリシャ"}},"serengeti-safari-sunrise":{"countryCode":"TZ","country":{"en":"Tanzania","es":"Tanzania","ja":"タンザニア"}},"tokyo-neon-nights":{"countryCode":"JP","country":{"en":"Japan","es":"Japón","ja":"日本"}}};
+  const locale = "en";
+  const siteBase = "/samples/trailblazers/dist/";
+
+  const container = document.getElementById('world-map-container');
+  const tooltip = document.getElementById('map-tooltip');
+  if (!container) return;
+
+  // Map slug → { countryCode, country }
+  const destEntries = Object.entries(destinations);
+
+  // Highlight each destination country
+  destEntries.forEach(([slug, dest]) => {
+    const code = dest.countryCode.toLowerCase();
+    const el = container.querySelector('#' + code);
+    if (!el) return;
+
+    el.classList.add('destination-highlight');
+    el.setAttribute('data-dest-slug', slug);
+    el.setAttribute('data-dest-name', dest.country[locale] || dest.country['en']);
+    el.setAttribute('data-dest-url', siteBase + locale + '/blog/' + slug + '/');
+    el.setAttribute('tabindex', '0');
+    el.setAttribute('role', 'button');
+    el.setAttribute('aria-label', (dest.country[locale] || dest.country['en']) + ' — click to read article');
+
+    // Click to navigate
+    el.addEventListener('click', (e) => {
+      window.location.href = siteBase + locale + '/blog/' + slug + '/';
+    });
+
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        window.location.href = siteBase + locale + '/blog/' + slug + '/';
+      }
+    });
+  });
+
+  // Tooltip follow-mouse
+  container.addEventListener('mousemove', (e) => {
+    const rect = container.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    tooltip.style.left = (x + 14) + 'px';
+    tooltip.style.top = (y - 36) + 'px';
+  });
+
+  container.addEventListener('mouseover', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight) {
+      const name = highlight.getAttribute('data-dest-name');
+      if (name) {
+        tooltip.textContent = name;
+        // re-add the ::before via data attr trick isn't needed – we override textContent,
+        // so use innerHTML instead
+        tooltip.innerHTML = '📍 ' + name;
+        tooltip.style.opacity = '1';
+      }
+    }
+  });
+
+  container.addEventListener('mouseout', (e) => {
+    const highlight = e.target.closest('.destination-highlight');
+    if (highlight && !highlight.contains(e.relatedTarget)) {
+      tooltip.style.opacity = '0';
+    }
+  });
+
+  // Pan & zoom
+  let scale = 1, panX = 0, panY = 0;
+  let isPanning = false, startX = 0, startY = 0;
+
+  const svg = container.querySelector('svg');
+  if (!svg) return;
+
+  function applyTransform() {
+    svg.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    svg.style.transformOrigin = 'center center';
+  }
+
+  container.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    scale = Math.min(Math.max(scale * delta, 1), 6);
+    if (scale === 1) { panX = 0; panY = 0; }
+    applyTransform();
+  }, { passive: false });
+
+  container.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    isPanning = true;
+    startX = e.clientX - panX;
+    startY = e.clientY - panY;
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!isPanning) return;
+    panX = e.clientX - startX;
+    panY = e.clientY - startY;
+    applyTransform();
+  });
+
+  window.addEventListener('mouseup', () => { isPanning = false; });
+
+  // Double-click to reset
+  container.addEventListener('dblclick', () => {
+    scale = 1; panX = 0; panY = 0;
+    applyTransform();
+  });
+})();
+// Thank you to https://github.com/daviddarnes/heading-anchors
+// Thank you to https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+
+let globalInstanceIndex = 0;
+
+class HeadingAnchors extends HTMLElement {
+	static register(tagName = "heading-anchors", registry = window.customElements) {
+		if(registry && !registry.get(tagName)) {
+			registry.define(tagName, this);
+		}
+	}
+
+	static attributes = {
+		exclude: "data-ha-exclude",
+		prefix: "prefix",
+		content: "content",
+	}
+
+	static classes = {
+		anchor: "ha",
+		placeholder: "ha-placeholder",
+		srOnly: "ha-visualhide",
+	}
+
+	static defaultSelector = "h2,h3,h4,h5,h6";
+
+	static css = `
+.${HeadingAnchors.classes.srOnly} {
+	clip: rect(0 0 0 0);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	width: 1px;
+}
+.${HeadingAnchors.classes.anchor} {
+	position: absolute;
+	left: var(--ha_offsetx);
+	top: var(--ha_offsety);
+	text-decoration: none;
+	opacity: 0;
+}
+.${HeadingAnchors.classes.placeholder} {
+	opacity: .3;
+}
+.${HeadingAnchors.classes.anchor}:is(:focus-within, :hover) {
+	opacity: 1;
+}
+.${HeadingAnchors.classes.anchor},
+.${HeadingAnchors.classes.placeholder} {
+	display: inline-block;
+	padding: 0 .25em;
+
+	/* Disable selection of visually hidden label */
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+@supports (anchor-name: none) {
+	.${HeadingAnchors.classes.anchor} {
+		position: absolute;
+		left: anchor(left);
+		top: anchor(top);
+	}
+}`;
+
+	get supports() {
+		return "replaceSync" in CSSStyleSheet.prototype;
+	}
+
+	get supportsAnchorPosition() {
+		return CSS.supports("anchor-name: none");
+	}
+
+	constructor() {
+		super();
+
+		if(!this.supports) {
+			return;
+		}
+
+		let sheet = new CSSStyleSheet();
+		sheet.replaceSync(HeadingAnchors.css);
+		document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
+		this.headingStyles = {};
+		this.instanceIndex = globalInstanceIndex++;
+	}
+
+	connectedCallback() {
+		if (!this.supports) {
+			return;
+		}
+
+		this.headings.forEach((heading, index) => {
+			if(!heading.hasAttribute(HeadingAnchors.attributes.exclude)) {
+				let anchor = this.getAnchorElement(heading);
+				let placeholder = this.getPlaceholderElement();
+
+				// Prefers anchor position approach for better accessibility
+				// https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+				if(this.supportsAnchorPosition) {
+					let anchorName = `--ha_${this.instanceIndex}_${index}`;
+					placeholder.style.setProperty("anchor-name", anchorName);
+					anchor.style.positionAnchor = anchorName;
+				}
+
+				heading.appendChild(placeholder);
+				heading.after(anchor);
+			}
+		});
+	}
+
+	// Polyfill-only
+	positionAnchorFromPlaceholder(placeholder) {
+		if(!placeholder) {
+			return;
+		}
+
+		let heading = placeholder.closest("h1,h2,h3,h4,h5,h6");
+		if(!heading.nextElementSibling) {
+			return;
+		}
+
+		// TODO next element could be more defensive
+		this.positionAnchor(heading.nextElementSibling);
+	}
+
+	// Polyfill-only
+	positionAnchor(anchor) {
+		if(!anchor || !anchor.previousElementSibling) {
+			return;
+		}
+
+		// TODO previous element could be more defensive
+		let heading = anchor.previousElementSibling;
+		this.setFontProp(heading, anchor);
+
+		if(this.supportsAnchorPosition) {
+			// quit early
+			return;
+		}
+
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			anchor.style.setProperty("--ha_offsetx", `${placeholder.offsetLeft}px`);
+			anchor.style.setProperty("--ha_offsety", `${placeholder.offsetTop}px`);
+		}
+	}
+
+	setFontProp(heading, anchor) {
+		let placeholder = heading.querySelector(`.${HeadingAnchors.classes.placeholder}`);
+		if(placeholder) {
+			let style = getComputedStyle(placeholder);
+			let props = ["font-weight", "font-size", "line-height", "font-family"];
+			let [weight, size, lh, family] = props.map(name => style.getPropertyValue(name));
+			anchor.style.setProperty("font", `${weight} ${size}/${lh} ${family}`);
+			let vars = style.getPropertyValue("font-variation-settings");
+			if(vars) {
+				anchor.style.setProperty("font-variation-settings", vars);
+			}
+		}
+	}
+
+	getAccessibleTextPrefix() {
+		// Useful for i18n
+		return this.getAttribute(HeadingAnchors.attributes.prefix) || "Jump to section titled";
+	}
+
+	getContent() {
+		if(this.hasAttribute(HeadingAnchors.attributes.content)) {
+			return this.getAttribute(HeadingAnchors.attributes.content);
+		}
+		return "#";
+	}
+
+	// Placeholder nests inside of heading
+	getPlaceholderElement() {
+		let ph = document.createElement("span");
+		ph.setAttribute("aria-hidden", true);
+		ph.classList.add(HeadingAnchors.classes.placeholder);
+		let content = this.getContent();
+		if(content) {
+			ph.textContent = content;
+		}
+
+		ph.addEventListener("mouseover", (e) => {
+			let placeholder = e.target.closest(`.${HeadingAnchors.classes.placeholder}`);
+			if(placeholder) {
+				this.positionAnchorFromPlaceholder(placeholder);
+			}
+		});
+
+		return ph;
+	}
+
+	getAnchorElement(heading) {
+		let anchor = document.createElement("a");
+		anchor.href = `#${heading.id}`;
+		anchor.classList.add(HeadingAnchors.classes.anchor);
+
+		let content = this.getContent();
+		anchor.innerHTML = `<span class="${HeadingAnchors.classes.srOnly}">${this.getAccessibleTextPrefix()}: ${heading.textContent}</span>${content ? `<span aria-hidden="true">${content}</span>` : ""}`;
+
+		anchor.addEventListener("focus", e => {
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			if(anchor) {
+				this.positionAnchor(anchor);
+			}
+		});
+
+		anchor.addEventListener("mouseover", (e) => {
+			// when CSS anchor positioning is supported, this is only used to set the font
+			let anchor = e.target.closest(`.${HeadingAnchors.classes.anchor}`);
+			this.positionAnchor(anchor);
+		});
+
+		return anchor;
+	}
+
+	get headings() {
+		return this.querySelectorAll(this.selector.split(",").map(entry => `${entry.trim()}[id]`));
+	}
+
+	get selector() {
+		return this.getAttribute("selector") || HeadingAnchors.defaultSelector;
+	}
+}
+
+HeadingAnchors.register();
+
+export { HeadingAnchors }
+const urlParams = new URLSearchParams(window.location.search);
+			const adminFromUrl = urlParams.get('admin') === 'true';
+			const adminFromStorage = localStorage.getItem('admin') === 'true';
+
+			if (adminFromUrl) {
+				localStorage.setItem('admin', 'true');
+			} else if (adminFromStorage) {
+				urlParams.set('admin', 'true');
+				window.location.search = urlParams.toString();
+			}
+
+			const isAdmin = adminFromUrl || adminFromStorage;
+			if(isAdmin) {
+				document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'initial');
+				// Append ?admin=true to all internal links to maintain state
+				document.querySelectorAll('a[href^="/"]').forEach(a => {
+					const url = new URL(a.href, window.location.origin);
+					if (!url.searchParams.has('admin')) {
+						url.searchParams.set('admin', 'true');
+						a.href = url.pathname + url.search + url.hash;
+					}
+				});
+			}
+window.addEventListener('DOMContentLoaded', (event) => {
+				const searchToggle = document.getElementById('search-toggle');
+				const searchOverlay = document.getElementById('search-overlay');
+				const searchClose = document.getElementById('search-close');
+				let pagefindInitialized = false;
+
+				if (searchToggle && searchOverlay) {
+					searchToggle.addEventListener('click', () => {
+						searchOverlay.showModal();
+						if (!pagefindInitialized) {
+							new PagefindUI({ 
+								element: "#search",
+								showSubResults: true,
+								resetStyles: false,
+								translations: {
+									clear_search: "×"
+								}
+							});
+							pagefindInitialized = true;
+						}
+						// Focus input after init
+						setTimeout(() => {
+							const input = searchOverlay.querySelector('input');
+							if (input) input.focus();
+						}, 100);
+					});
+
+					searchClose.addEventListener('click', () => {
+						searchOverlay.close();
+					});
+				}
+			});

--- a/trailblazers/dist/en-GB/blog/index.html
+++ b/trailblazers/dist/en-GB/blog/index.html
@@ -1730,7 +1730,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en-GB/blog/` was built on 2026-03-31T21:40:28.522Z -->
+		<!-- This page `/en-GB/blog/` was built on 2026-04-01T08:41:13.015Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en-GB/tags/index.html
+++ b/trailblazers/dist/en-GB/tags/index.html
@@ -1706,7 +1706,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en-GB/tags/` was built on 2026-03-31T21:40:28.158Z -->
+		<!-- This page `/en-GB/tags/` was built on 2026-04-01T08:41:12.387Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en-US/blog/index.html
+++ b/trailblazers/dist/en-US/blog/index.html
@@ -1730,7 +1730,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en-US/blog/` was built on 2026-03-31T21:40:28.330Z -->
+		<!-- This page `/en-US/blog/` was built on 2026-04-01T08:41:12.698Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en-US/tags/index.html
+++ b/trailblazers/dist/en-US/tags/index.html
@@ -1706,7 +1706,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en-US/tags/` was built on 2026-03-31T21:40:28.155Z -->
+		<!-- This page `/en-US/tags/` was built on 2026-04-01T08:41:12.383Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/about/index.html
+++ b/trailblazers/dist/en/about/index.html
@@ -1854,7 +1854,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/about/` was built on 2026-03-31T21:40:25.694Z -->
+		<!-- This page `/en/about/` was built on 2026-04-01T08:41:05.305Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/authors/ashok/index.html
+++ b/trailblazers/dist/en/authors/ashok/index.html
@@ -1864,7 +1864,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/authors/ashok/` was built on 2026-03-31T21:40:27.181Z -->
+		<!-- This page `/en/authors/ashok/` was built on 2026-04-01T08:41:07.568Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/authors/julia/index.html
+++ b/trailblazers/dist/en/authors/julia/index.html
@@ -1833,7 +1833,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/authors/julia/` was built on 2026-03-31T21:40:28.111Z -->
+		<!-- This page `/en/authors/julia/` was built on 2026-04-01T08:41:12.338Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/authors/maya/index.html
+++ b/trailblazers/dist/en/authors/maya/index.html
@@ -1712,6 +1712,25 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fbali-spiritual-sanctuary%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Daily newsletter</span>
+				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
+				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Sign up</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
+			</div>
+		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/en/blog/cape-town-table-mountain/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1772,25 +1791,6 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-10">Mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fparis-midnight-stroll%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
-			</div>
-		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Daily newsletter</span>
-				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
-				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Sign up</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -1895,7 +1895,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/authors/maya/` was built on 2026-03-31T21:40:25.697Z -->
+		<!-- This page `/en/authors/maya/` was built on 2026-04-01T08:41:05.308Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/amalfi-coast-winding-roads/index.html
+++ b/trailblazers/dist/en/blog/amalfi-coast-winding-roads/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/amalfi-coast-winding-roads/` was built on 2026-03-31T21:40:25.697Z -->
+		<!-- This page `/en/blog/amalfi-coast-winding-roads/` was built on 2026-04-01T08:41:05.308Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/KuwBaYDUoK.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/bali-spiritual-sanctuary/index.html
+++ b/trailblazers/dist/en/blog/bali-spiritual-sanctuary/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/bali-spiritual-sanctuary/` was built on 2026-03-31T21:40:25.697Z -->
+		<!-- This page `/en/blog/bali-spiritual-sanctuary/` was built on 2026-04-01T08:41:05.308Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/16DcOmzSb7.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/banff-turquoise-waters/index.html
+++ b/trailblazers/dist/en/blog/banff-turquoise-waters/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/banff-turquoise-waters/` was built on 2026-03-31T21:40:25.698Z -->
+		<!-- This page `/en/blog/banff-turquoise-waters/` was built on 2026-04-01T08:41:05.309Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/4soe2pdgTt.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/cape-town-table-mountain/index.html
+++ b/trailblazers/dist/en/blog/cape-town-table-mountain/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/cape-town-table-mountain/` was built on 2026-03-31T21:40:25.698Z -->
+		<!-- This page `/en/blog/cape-town-table-mountain/` was built on 2026-04-01T08:41:05.309Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/1ExotnOS1N.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/create/index.html
+++ b/trailblazers/dist/en/blog/create/index.html
@@ -2136,7 +2136,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/create/` was built on 2026-03-31T21:40:24.569Z -->
+		<!-- This page `/en/blog/create/` was built on 2026-04-01T08:41:02.454Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/index.html
+++ b/trailblazers/dist/en/blog/index.html
@@ -1765,6 +1765,25 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fpetra-rose-red-city%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Daily newsletter</span>
+				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
+				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Sign up</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
+			</div>
+		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/en/blog/bali-spiritual-sanctuary/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1825,25 +1844,6 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-11">Mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fcape-town-table-mountain%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
-			</div>
-		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Daily newsletter</span>
-				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
-				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Sign up</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -2180,7 +2180,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/` was built on 2026-03-31T21:40:25.696Z -->
+		<!-- This page `/en/blog/` was built on 2026-04-01T08:41:05.307Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/machu-picchu-ancient-echoes/index.html
+++ b/trailblazers/dist/en/blog/machu-picchu-ancient-echoes/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/machu-picchu-ancient-echoes/` was built on 2026-03-31T21:40:25.698Z -->
+		<!-- This page `/en/blog/machu-picchu-ancient-echoes/` was built on 2026-04-01T08:41:05.310Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/5-vtXy3tKH.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/new-york-concrete-jungle/index.html
+++ b/trailblazers/dist/en/blog/new-york-concrete-jungle/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/new-york-concrete-jungle/` was built on 2026-03-31T21:40:25.699Z -->
+		<!-- This page `/en/blog/new-york-concrete-jungle/` was built on 2026-04-01T08:41:05.310Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/meMuNf_jdK.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/paris-midnight-stroll/index.html
+++ b/trailblazers/dist/en/blog/paris-midnight-stroll/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/paris-midnight-stroll/` was built on 2026-03-31T21:40:25.699Z -->
+		<!-- This page `/en/blog/paris-midnight-stroll/` was built on 2026-04-01T08:41:05.311Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/C256RL3iRg.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/petra-rose-red-city/index.html
+++ b/trailblazers/dist/en/blog/petra-rose-red-city/index.html
@@ -1994,7 +1994,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/petra-rose-red-city/` was built on 2026-03-31T21:40:25.699Z -->
+		<!-- This page `/en/blog/petra-rose-red-city/` was built on 2026-04-01T08:41:05.310Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/KhPCWAQSNa.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/reykjavik-northern-lights/index.html
+++ b/trailblazers/dist/en/blog/reykjavik-northern-lights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/reykjavik-northern-lights/` was built on 2026-03-31T21:40:25.700Z -->
+		<!-- This page `/en/blog/reykjavik-northern-lights/` was built on 2026-04-01T08:41:05.311Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/VF9fW7rOa1.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/santorini-blue-and-white/index.html
+++ b/trailblazers/dist/en/blog/santorini-blue-and-white/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/santorini-blue-and-white/` was built on 2026-03-31T21:40:25.700Z -->
+		<!-- This page `/en/blog/santorini-blue-and-white/` was built on 2026-04-01T08:41:05.312Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/psCG2g5Jtw.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/serengeti-safari-sunrise/index.html
+++ b/trailblazers/dist/en/blog/serengeti-safari-sunrise/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/serengeti-safari-sunrise/` was built on 2026-03-31T21:40:25.700Z -->
+		<!-- This page `/en/blog/serengeti-safari-sunrise/` was built on 2026-04-01T08:41:05.311Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/BmdvdjhbHO.js"></script>
 		
 		

--- a/trailblazers/dist/en/blog/tokyo-neon-nights/index.html
+++ b/trailblazers/dist/en/blog/tokyo-neon-nights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/en/blog/tokyo-neon-nights/` was built on 2026-03-31T21:40:25.701Z -->
+		<!-- This page `/en/blog/tokyo-neon-nights/` was built on 2026-04-01T08:41:05.312Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/2Ue-zsbdwA.js"></script>
 		
 		

--- a/trailblazers/dist/en/destinations/index.html
+++ b/trailblazers/dist/en/destinations/index.html
@@ -1700,11 +1700,6 @@ dialog.search-overlay::backdrop {
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -5288,8 +5283,8 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/destinations/` was built on 2026-03-31T21:40:24.562Z -->
-		<script type="module" src="/samples/trailblazers/dist/dist/rXe6bMamXf.js"></script>
+		<!-- This page `/en/destinations/` was built on 2026-04-01T08:41:02.447Z -->
+		<script type="module" src="/samples/trailblazers/dist/dist/oP_UqwhMW3.js"></script>
 		
 		
 	</body>

--- a/trailblazers/dist/en/imprint/index.html
+++ b/trailblazers/dist/en/imprint/index.html
@@ -1729,7 +1729,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/imprint/` was built on 2026-03-31T21:40:24.558Z -->
+		<!-- This page `/en/imprint/` was built on 2026-04-01T08:41:02.443Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/index.html
+++ b/trailblazers/dist/en/index.html
@@ -1762,6 +1762,25 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fsantorini-blue-and-white%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Daily newsletter</span>
+				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
+				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Sign up</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
+			</div>
+		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/en/blog/petra-rose-red-city/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1822,25 +1841,6 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-12">Mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fen%2Fblog%2Fbali-spiritual-sanctuary%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
-			</div>
-		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Daily newsletter</span>
-				<h3 class="newsletter-title" id="reward-your-inbox-with-the-trailblazers-daily-newsletter">Reward your inbox with the Trailblazers Daily newsletter</h3>
-				<p class="postlist-description">Join over 1,000,000 readers for breaking news, in-depth guides, and exclusive deals.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Your email…" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Sign up</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">By signing up, you agree to our <a href="//imprint/">Terms of Use</a> and acknowledge the data practices in our <a href="//privacy/">Privacy Policy</a>.</p>
 			</div>
 		</li>
 </ul>
@@ -1998,7 +1998,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/` was built on 2026-03-31T21:40:25.696Z -->
+		<!-- This page `/en/` was built on 2026-04-01T08:41:05.307Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/privacy/index.html
+++ b/trailblazers/dist/en/privacy/index.html
@@ -1732,7 +1732,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/privacy/` was built on 2026-03-31T21:40:24.559Z -->
+		<!-- This page `/en/privacy/` was built on 2026-04-01T08:41:02.444Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/adventure/index.html
+++ b/trailblazers/dist/en/tags/adventure/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/adventure/` was built on 2026-03-31T21:40:29.012Z -->
+		<!-- This page `/en/tags/adventure/` was built on 2026-04-01T08:41:13.939Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/canada/index.html
+++ b/trailblazers/dist/en/tags/canada/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/canada/` was built on 2026-03-31T21:40:28.906Z -->
+		<!-- This page `/en/tags/canada/` was built on 2026-04-01T08:41:14.283Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/city/index.html
+++ b/trailblazers/dist/en/tags/city/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/city/` was built on 2026-03-31T21:40:29.177Z -->
+		<!-- This page `/en/tags/city/` was built on 2026-04-01T08:41:14.533Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/coast/index.html
+++ b/trailblazers/dist/en/tags/coast/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/coast/` was built on 2026-03-31T21:40:25.865Z -->
+		<!-- This page `/en/tags/coast/` was built on 2026-04-01T08:41:05.492Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/culture/index.html
+++ b/trailblazers/dist/en/tags/culture/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/culture/` was built on 2026-03-31T21:40:29.777Z -->
+		<!-- This page `/en/tags/culture/` was built on 2026-04-01T08:41:16.113Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/energy/index.html
+++ b/trailblazers/dist/en/tags/energy/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/energy/` was built on 2026-03-31T21:40:29.312Z -->
+		<!-- This page `/en/tags/energy/` was built on 2026-04-01T08:41:14.759Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/france/index.html
+++ b/trailblazers/dist/en/tags/france/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/france/` was built on 2026-03-31T21:40:29.321Z -->
+		<!-- This page `/en/tags/france/` was built on 2026-04-01T08:41:15.301Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/greece/index.html
+++ b/trailblazers/dist/en/tags/greece/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/greece/` was built on 2026-03-31T21:40:29.522Z -->
+		<!-- This page `/en/tags/greece/` was built on 2026-04-01T08:41:15.941Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/hidden-gem/index.html
+++ b/trailblazers/dist/en/tags/hidden-gem/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/hidden-gem/` was built on 2026-03-31T21:40:29.352Z -->
+		<!-- This page `/en/tags/hidden-gem/` was built on 2026-04-01T08:41:14.923Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/history/index.html
+++ b/trailblazers/dist/en/tags/history/index.html
@@ -1872,7 +1872,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/history/` was built on 2026-03-31T21:40:29.021Z -->
+		<!-- This page `/en/tags/history/` was built on 2026-04-01T08:41:14.339Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/iceland/index.html
+++ b/trailblazers/dist/en/tags/iceland/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/iceland/` was built on 2026-03-31T21:40:29.397Z -->
+		<!-- This page `/en/tags/iceland/` was built on 2026-04-01T08:41:15.162Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/index.html
+++ b/trailblazers/dist/en/tags/index.html
@@ -1673,14 +1673,6 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/en/tags/lakes/" class="post-tag">Lakes <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/en/tags/canada/" class="post-tag">Canada <span class="tag-count">(1)</span></a>
-
-	
-	
 	<a href="/samples/trailblazers/dist/en/tags/mountains/" class="post-tag">Mountains <span class="tag-count">(1)</span></a>
 
 	
@@ -1690,6 +1682,14 @@ dialog.search-overlay::backdrop {
 	
 	
 	<a href="/samples/trailblazers/dist/en/tags/adventure/" class="post-tag">Adventure <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/en/tags/lakes/" class="post-tag">Lakes <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/en/tags/canada/" class="post-tag">Canada <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1706,14 +1706,6 @@ dialog.search-overlay::backdrop {
 	
 	
 	<a href="/samples/trailblazers/dist/en/tags/energy/" class="post-tag">Energy <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/en/tags/france/" class="post-tag">France <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/en/tags/romance/" class="post-tag">Romance <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1737,6 +1729,22 @@ dialog.search-overlay::backdrop {
 
 	
 	
+	<a href="/samples/trailblazers/dist/en/tags/france/" class="post-tag">France <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/en/tags/romance/" class="post-tag">Romance <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/en/tags/wildlife/" class="post-tag">Wildlife <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/en/tags/tanzania/" class="post-tag">Tanzania <span class="tag-count">(1)</span></a>
+
+	
+	
 	<a href="/samples/trailblazers/dist/en/tags/islands/" class="post-tag">Islands <span class="tag-count">(1)</span></a>
 
 	
@@ -1746,14 +1754,6 @@ dialog.search-overlay::backdrop {
 	
 	
 	<a href="/samples/trailblazers/dist/en/tags/relaxation/" class="post-tag">Relaxation <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/en/tags/wildlife/" class="post-tag">Wildlife <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/en/tags/tanzania/" class="post-tag">Tanzania <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1834,7 +1834,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/` was built on 2026-03-31T21:40:25.695Z -->
+		<!-- This page `/en/tags/` was built on 2026-04-01T08:41:05.306Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/indonesia/index.html
+++ b/trailblazers/dist/en/tags/indonesia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/indonesia/` was built on 2026-03-31T21:40:28.602Z -->
+		<!-- This page `/en/tags/indonesia/` was built on 2026-04-01T08:41:13.182Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/islands/index.html
+++ b/trailblazers/dist/en/tags/islands/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/islands/` was built on 2026-03-31T21:40:29.481Z -->
+		<!-- This page `/en/tags/islands/` was built on 2026-04-01T08:41:15.900Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/italy/index.html
+++ b/trailblazers/dist/en/tags/italy/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/italy/` was built on 2026-03-31T21:40:27.182Z -->
+		<!-- This page `/en/tags/italy/` was built on 2026-04-01T08:41:07.569Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/japan/index.html
+++ b/trailblazers/dist/en/tags/japan/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/japan/` was built on 2026-03-31T21:40:29.766Z -->
+		<!-- This page `/en/tags/japan/` was built on 2026-04-01T08:41:16.103Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/jordan/index.html
+++ b/trailblazers/dist/en/tags/jordan/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/jordan/` was built on 2026-03-31T21:40:29.339Z -->
+		<!-- This page `/en/tags/jordan/` was built on 2026-04-01T08:41:14.880Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/lakes/index.html
+++ b/trailblazers/dist/en/tags/lakes/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/lakes/` was built on 2026-03-31T21:40:28.896Z -->
+		<!-- This page `/en/tags/lakes/` was built on 2026-04-01T08:41:14.128Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/magic/index.html
+++ b/trailblazers/dist/en/tags/magic/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/magic/` was built on 2026-03-31T21:40:29.472Z -->
+		<!-- This page `/en/tags/magic/` was built on 2026-04-01T08:41:15.263Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/mountains/index.html
+++ b/trailblazers/dist/en/tags/mountains/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/mountains/` was built on 2026-03-31T21:40:28.915Z -->
+		<!-- This page `/en/tags/mountains/` was built on 2026-04-01T08:41:13.714Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/nature/index.html
+++ b/trailblazers/dist/en/tags/nature/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/nature/` was built on 2026-03-31T21:40:28.757Z -->
+		<!-- This page `/en/tags/nature/` was built on 2026-04-01T08:41:13.447Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/peru/index.html
+++ b/trailblazers/dist/en/tags/peru/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/peru/` was built on 2026-03-31T21:40:29.058Z -->
+		<!-- This page `/en/tags/peru/` was built on 2026-04-01T08:41:14.511Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/relaxation/index.html
+++ b/trailblazers/dist/en/tags/relaxation/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/relaxation/` was built on 2026-03-31T21:40:29.601Z -->
+		<!-- This page `/en/tags/relaxation/` was built on 2026-04-01T08:41:16.092Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/romance/index.html
+++ b/trailblazers/dist/en/tags/romance/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/romance/` was built on 2026-03-31T21:40:29.330Z -->
+		<!-- This page `/en/tags/romance/` was built on 2026-04-01T08:41:15.718Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/south-africa/index.html
+++ b/trailblazers/dist/en/tags/south-africa/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/south-africa/` was built on 2026-03-31T21:40:28.948Z -->
+		<!-- This page `/en/tags/south-africa/` was built on 2026-04-01T08:41:13.770Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/spirituality/index.html
+++ b/trailblazers/dist/en/tags/spirituality/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/spirituality/` was built on 2026-03-31T21:40:28.510Z -->
+		<!-- This page `/en/tags/spirituality/` was built on 2026-04-01T08:41:12.990Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/summer/index.html
+++ b/trailblazers/dist/en/tags/summer/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/summer/` was built on 2026-03-31T21:40:28.141Z -->
+		<!-- This page `/en/tags/summer/` was built on 2026-04-01T08:41:12.366Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/tanzania/index.html
+++ b/trailblazers/dist/en/tags/tanzania/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/tanzania/` was built on 2026-03-31T21:40:29.675Z -->
+		<!-- This page `/en/tags/tanzania/` was built on 2026-04-01T08:41:15.889Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/unesco/index.html
+++ b/trailblazers/dist/en/tags/unesco/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/unesco/` was built on 2026-03-31T21:40:29.166Z -->
+		<!-- This page `/en/tags/unesco/` was built on 2026-04-01T08:41:14.522Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/usa/index.html
+++ b/trailblazers/dist/en/tags/usa/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/usa/` was built on 2026-03-31T21:40:29.220Z -->
+		<!-- This page `/en/tags/usa/` was built on 2026-04-01T08:41:14.607Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/wildlife/index.html
+++ b/trailblazers/dist/en/tags/wildlife/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/wildlife/` was built on 2026-03-31T21:40:29.639Z -->
+		<!-- This page `/en/tags/wildlife/` was built on 2026-04-01T08:41:15.878Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/en/tags/winter/index.html
+++ b/trailblazers/dist/en/tags/winter/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/en/tags/winter/` was built on 2026-03-31T21:40:29.361Z -->
+		<!-- This page `/en/tags/winter/` was built on 2026-04-01T08:41:15.112Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es-ES/blog/index.html
+++ b/trailblazers/dist/es-ES/blog/index.html
@@ -1730,7 +1730,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es-ES/blog/` was built on 2026-03-31T21:40:28.525Z -->
+		<!-- This page `/es-ES/blog/` was built on 2026-04-01T08:41:13.021Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es-ES/tags/index.html
+++ b/trailblazers/dist/es-ES/tags/index.html
@@ -1706,7 +1706,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es-ES/tags/` was built on 2026-03-31T21:40:28.161Z -->
+		<!-- This page `/es-ES/tags/` was built on 2026-04-01T08:41:12.391Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es-US/blog/index.html
+++ b/trailblazers/dist/es-US/blog/index.html
@@ -1730,7 +1730,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es-US/blog/` was built on 2026-03-31T21:40:28.529Z -->
+		<!-- This page `/es-US/blog/` was built on 2026-04-01T08:41:13.026Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es-US/tags/index.html
+++ b/trailblazers/dist/es-US/tags/index.html
@@ -1706,7 +1706,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es-US/tags/` was built on 2026-03-31T21:40:28.164Z -->
+		<!-- This page `/es-US/tags/` was built on 2026-04-01T08:41:12.394Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/about/index.html
+++ b/trailblazers/dist/es/about/index.html
@@ -1854,7 +1854,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/about/` was built on 2026-03-31T21:40:25.695Z -->
+		<!-- This page `/es/about/` was built on 2026-04-01T08:41:05.305Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/authors/ashok/index.html
+++ b/trailblazers/dist/es/authors/ashok/index.html
@@ -1712,6 +1712,25 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fsantorini-blue-and-white%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Boletín diario</span>
+				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
+				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Registrarse</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
+			</div>
+		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/es/blog/petra-rose-red-city/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1741,25 +1760,6 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-13">mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fpetra-rose-red-city%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
-			</div>
-		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Boletín diario</span>
-				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
-				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Registrarse</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -1864,7 +1864,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/authors/ashok/` was built on 2026-03-31T21:40:28.413Z -->
+		<!-- This page `/es/authors/ashok/` was built on 2026-04-01T08:41:12.812Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/authors/julia/index.html
+++ b/trailblazers/dist/es/authors/julia/index.html
@@ -1833,7 +1833,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/authors/julia/` was built on 2026-03-31T21:40:28.424Z -->
+		<!-- This page `/es/authors/julia/` was built on 2026-04-01T08:41:12.826Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/authors/maya/index.html
+++ b/trailblazers/dist/es/authors/maya/index.html
@@ -1743,25 +1743,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fcape-town-table-mountain%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Boletín diario</span>
-				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
-				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Registrarse</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/es/blog/paris-midnight-stroll/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1822,6 +1803,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-07">mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fmachu-picchu-ancient-echoes%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Boletín diario</span>
+				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
+				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Registrarse</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
 			</div>
 		</li>
 </ul>
@@ -1895,7 +1895,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/authors/maya/` was built on 2026-03-31T21:40:28.399Z -->
+		<!-- This page `/es/authors/maya/` was built on 2026-04-01T08:41:12.796Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/amalfi-coast-winding-roads/index.html
+++ b/trailblazers/dist/es/blog/amalfi-coast-winding-roads/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/amalfi-coast-winding-roads/` was built on 2026-03-31T21:40:25.701Z -->
+		<!-- This page `/es/blog/amalfi-coast-winding-roads/` was built on 2026-04-01T08:41:05.312Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/JhrVhBhcbG.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/bali-spiritual-sanctuary/index.html
+++ b/trailblazers/dist/es/blog/bali-spiritual-sanctuary/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/bali-spiritual-sanctuary/` was built on 2026-03-31T21:40:25.702Z -->
+		<!-- This page `/es/blog/bali-spiritual-sanctuary/` was built on 2026-04-01T08:41:05.313Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/5GELof3LbB.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/banff-turquoise-waters/index.html
+++ b/trailblazers/dist/es/blog/banff-turquoise-waters/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/banff-turquoise-waters/` was built on 2026-03-31T21:40:25.701Z -->
+		<!-- This page `/es/blog/banff-turquoise-waters/` was built on 2026-04-01T08:41:05.313Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/mztdHgYYgH.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/cape-town-table-mountain/index.html
+++ b/trailblazers/dist/es/blog/cape-town-table-mountain/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/cape-town-table-mountain/` was built on 2026-03-31T21:40:25.702Z -->
+		<!-- This page `/es/blog/cape-town-table-mountain/` was built on 2026-04-01T08:41:05.314Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/jqT5aTvx9p.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/index.html
+++ b/trailblazers/dist/es/blog/index.html
@@ -1703,25 +1703,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Famalfi-coast-winding-roads%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Boletín diario</span>
-				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
-				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Registrarse</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/es/blog/santorini-blue-and-white/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1875,6 +1856,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-10">mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fparis-midnight-stroll%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Boletín diario</span>
+				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
+				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Registrarse</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -2180,7 +2180,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/` was built on 2026-03-31T21:40:27.181Z -->
+		<!-- This page `/es/blog/` was built on 2026-04-01T08:41:07.567Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/machu-picchu-ancient-echoes/index.html
+++ b/trailblazers/dist/es/blog/machu-picchu-ancient-echoes/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/machu-picchu-ancient-echoes/` was built on 2026-03-31T21:40:25.702Z -->
+		<!-- This page `/es/blog/machu-picchu-ancient-echoes/` was built on 2026-04-01T08:41:05.313Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/Dy23ZKf67o.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/new-york-concrete-jungle/index.html
+++ b/trailblazers/dist/es/blog/new-york-concrete-jungle/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/new-york-concrete-jungle/` was built on 2026-03-31T21:40:25.702Z -->
+		<!-- This page `/es/blog/new-york-concrete-jungle/` was built on 2026-04-01T08:41:05.314Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/_vxq-_HfoS.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/paris-midnight-stroll/index.html
+++ b/trailblazers/dist/es/blog/paris-midnight-stroll/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/paris-midnight-stroll/` was built on 2026-03-31T21:40:25.703Z -->
+		<!-- This page `/es/blog/paris-midnight-stroll/` was built on 2026-04-01T08:41:05.314Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/DJECwb-KW6.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/petra-rose-red-city/index.html
+++ b/trailblazers/dist/es/blog/petra-rose-red-city/index.html
@@ -1994,7 +1994,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/petra-rose-red-city/` was built on 2026-03-31T21:40:25.703Z -->
+		<!-- This page `/es/blog/petra-rose-red-city/` was built on 2026-04-01T08:41:05.315Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/vM8904LXSc.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/reykjavik-northern-lights/index.html
+++ b/trailblazers/dist/es/blog/reykjavik-northern-lights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/reykjavik-northern-lights/` was built on 2026-03-31T21:40:25.704Z -->
+		<!-- This page `/es/blog/reykjavik-northern-lights/` was built on 2026-04-01T08:41:05.316Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/rCpVvf5Ylw.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/santorini-blue-and-white/index.html
+++ b/trailblazers/dist/es/blog/santorini-blue-and-white/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/santorini-blue-and-white/` was built on 2026-03-31T21:40:25.703Z -->
+		<!-- This page `/es/blog/santorini-blue-and-white/` was built on 2026-04-01T08:41:05.315Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/e1QBrbLcXi.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/serengeti-safari-sunrise/index.html
+++ b/trailblazers/dist/es/blog/serengeti-safari-sunrise/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/serengeti-safari-sunrise/` was built on 2026-03-31T21:40:25.704Z -->
+		<!-- This page `/es/blog/serengeti-safari-sunrise/` was built on 2026-04-01T08:41:05.315Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/PYtVkN7nHE.js"></script>
 		
 		

--- a/trailblazers/dist/es/blog/tokyo-neon-nights/index.html
+++ b/trailblazers/dist/es/blog/tokyo-neon-nights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/es/blog/tokyo-neon-nights/` was built on 2026-03-31T21:40:25.704Z -->
+		<!-- This page `/es/blog/tokyo-neon-nights/` was built on 2026-04-01T08:41:05.316Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/PX_3JCf0DS.js"></script>
 		
 		

--- a/trailblazers/dist/es/destinations/index.html
+++ b/trailblazers/dist/es/destinations/index.html
@@ -1700,11 +1700,6 @@ dialog.search-overlay::backdrop {
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -5083,9 +5078,9 @@ dialog.search-overlay::backdrop {
     <h2 id="todos-los-destinos">Todos los destinos</h2>
     <ul class="destination-cards">
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/amalfi-coast-winding-roads/" class="destination-card">
+        <a href="undefinedes/blog/amalfi-coast-winding-roads/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.jpeg" alt="amalfi-coast-winding-roads" width="3000" height="2000"></picture>
+            <img src="content/es/destinations/undefinedes/blog/amalfi-coast-winding-roads/cover.jpg" alt="amalfi-coast-winding-roads" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Italia</span>
@@ -5094,9 +5089,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/bali-spiritual-sanctuary/" class="destination-card">
+        <a href="undefinedes/blog/bali-spiritual-sanctuary/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.jpeg" alt="bali-spiritual-sanctuary" width="3000" height="2000"></picture>
+            <img src="content/es/destinations/undefinedes/blog/bali-spiritual-sanctuary/cover.jpg" alt="bali-spiritual-sanctuary" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Indonesia</span>
@@ -5105,9 +5100,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/banff-turquoise-waters/" class="destination-card">
+        <a href="undefinedes/blog/banff-turquoise-waters/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.jpeg" alt="banff-turquoise-waters" width="3000" height="2148"></picture>
+            <img src="content/es/destinations/undefinedes/blog/banff-turquoise-waters/cover.jpg" alt="banff-turquoise-waters" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Canadá</span>
@@ -5116,9 +5111,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/cape-town-table-mountain/" class="destination-card">
+        <a href="undefinedes/blog/cape-town-table-mountain/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.jpeg" alt="cape-town-table-mountain" width="3000" height="2000"></picture>
+            <img src="content/es/destinations/undefinedes/blog/cape-town-table-mountain/cover.jpg" alt="cape-town-table-mountain" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Sudáfrica</span>
@@ -5127,9 +5122,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/machu-picchu-ancient-echoes/" class="destination-card">
+        <a href="undefinedes/blog/machu-picchu-ancient-echoes/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.jpeg" alt="machu-picchu-ancient-echoes" width="3000" height="1987"></picture>
+            <img src="content/es/destinations/undefinedes/blog/machu-picchu-ancient-echoes/cover.jpg" alt="machu-picchu-ancient-echoes" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Perú</span>
@@ -5138,9 +5133,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/new-york-concrete-jungle/" class="destination-card">
+        <a href="undefinedes/blog/new-york-concrete-jungle/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.jpeg" alt="new-york-concrete-jungle" width="3000" height="2000"></picture>
+            <img src="content/es/destinations/undefinedes/blog/new-york-concrete-jungle/cover.jpg" alt="new-york-concrete-jungle" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Estados Unidos</span>
@@ -5149,9 +5144,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/paris-midnight-stroll/" class="destination-card">
+        <a href="undefinedes/blog/paris-midnight-stroll/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.jpeg" alt="paris-midnight-stroll" width="3000" height="2122"></picture>
+            <img src="content/es/destinations/undefinedes/blog/paris-midnight-stroll/cover.jpg" alt="paris-midnight-stroll" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Francia</span>
@@ -5160,9 +5155,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/petra-rose-red-city/" class="destination-card">
+        <a href="undefinedes/blog/petra-rose-red-city/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.jpeg" alt="petra-rose-red-city" width="3000" height="2250"></picture>
+            <img src="content/es/destinations/undefinedes/blog/petra-rose-red-city/cover.jpg" alt="petra-rose-red-city" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Jordania</span>
@@ -5171,9 +5166,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/reykjavik-northern-lights/" class="destination-card">
+        <a href="undefinedes/blog/reykjavik-northern-lights/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/Smie_eEJlo-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/Smie_eEJlo-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/Smie_eEJlo-3000.jpeg" alt="reykjavik-northern-lights" width="3000" height="1699"></picture>
+            <img src="content/es/destinations/undefinedes/blog/reykjavik-northern-lights/cover.jpg" alt="reykjavik-northern-lights" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Islandia</span>
@@ -5182,9 +5177,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/santorini-blue-and-white/" class="destination-card">
+        <a href="undefinedes/blog/santorini-blue-and-white/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/mHBp0glhnT-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/mHBp0glhnT-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/mHBp0glhnT-3000.jpeg" alt="santorini-blue-and-white" width="3000" height="4000"></picture>
+            <img src="content/es/destinations/undefinedes/blog/santorini-blue-and-white/cover.jpg" alt="santorini-blue-and-white" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Grecia</span>
@@ -5193,9 +5188,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/serengeti-safari-sunrise/" class="destination-card">
+        <a href="undefinedes/blog/serengeti-safari-sunrise/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.jpeg" alt="serengeti-safari-sunrise" width="3000" height="1792"></picture>
+            <img src="content/es/destinations/undefinedes/blog/serengeti-safari-sunrise/cover.jpg" alt="serengeti-safari-sunrise" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Tanzania</span>
@@ -5204,9 +5199,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/es/blog/tokyo-neon-nights/" class="destination-card">
+        <a href="undefinedes/blog/tokyo-neon-nights/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/iFW5b38xmH-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/iFW5b38xmH-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/iFW5b38xmH-3000.jpeg" alt="tokyo-neon-nights" width="3000" height="1997"></picture>
+            <img src="content/es/destinations/undefinedes/blog/tokyo-neon-nights/cover.jpg" alt="tokyo-neon-nights" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">Japón</span>
@@ -5288,8 +5283,8 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/destinations/` was built on 2026-03-31T21:40:24.562Z -->
-		<script type="module" src="/samples/trailblazers/dist/dist/au1OZIBdh6.js"></script>
+		<!-- This page `/es/destinations/` was built on 2026-04-01T08:41:02.447Z -->
+		<script type="module" src="/samples/trailblazers/dist/dist/A3AQwII-0u.js"></script>
 		
 		
 	</body>

--- a/trailblazers/dist/es/imprint/index.html
+++ b/trailblazers/dist/es/imprint/index.html
@@ -1729,7 +1729,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/imprint/` was built on 2026-03-31T21:40:24.559Z -->
+		<!-- This page `/es/imprint/` was built on 2026-04-01T08:41:02.444Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/index.html
+++ b/trailblazers/dist/es/index.html
@@ -1789,25 +1789,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fpetra-rose-red-city%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">Boletín diario</span>
-				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
-				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">Registrarse</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/es/blog/bali-spiritual-sanctuary/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1837,6 +1818,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-12">mar 2026</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fes%2Fblog%2Fbali-spiritual-sanctuary%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">Boletín diario</span>
+				<h3 class="newsletter-title" id="recompensa-tu-bandeja-de-entrada-con-el-boletin-diario-de-trailblazers">Recompensa tu bandeja de entrada con el boletín diario de Trailblazers</h3>
+				<p class="postlist-description">Únete a más de 1.000.000 de lectores para recibir noticias de última hora, guías detalladas y ofertas exclusivas.</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="Tu dirección de correo electrónico" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">Registrarse</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">Al registrarte, aceptas nuestras <a href="//imprint/">Condiciones de uso</a> y reconoces las prácticas de datos en nuestra <a href="//privacy/">Política de privacidad</a>.</p>
 			</div>
 		</li>
 </ul>
@@ -1916,7 +1916,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/` was built on 2026-03-31T21:40:25.694Z -->
+		<!-- This page `/es/` was built on 2026-04-01T08:41:05.304Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/privacy/index.html
+++ b/trailblazers/dist/es/privacy/index.html
@@ -1732,7 +1732,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/privacy/` was built on 2026-03-31T21:40:24.560Z -->
+		<!-- This page `/es/privacy/` was built on 2026-04-01T08:41:02.445Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/aventura/index.html
+++ b/trailblazers/dist/es/tags/aventura/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/aventura/` was built on 2026-03-31T21:40:29.885Z -->
+		<!-- This page `/es/tags/aventura/` was built on 2026-04-01T08:41:18.112Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/canada/index.html
+++ b/trailblazers/dist/es/tags/canada/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/canada/` was built on 2026-03-31T21:40:29.826Z -->
+		<!-- This page `/es/tags/canada/` was built on 2026-04-01T08:41:17.540Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/ciudad/index.html
+++ b/trailblazers/dist/es/tags/ciudad/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/ciudad/` was built on 2026-03-31T21:40:29.925Z -->
+		<!-- This page `/es/tags/ciudad/` was built on 2026-04-01T08:41:18.242Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/costa/index.html
+++ b/trailblazers/dist/es/tags/costa/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/costa/` was built on 2026-03-31T21:40:29.787Z -->
+		<!-- This page `/es/tags/costa/` was built on 2026-04-01T08:41:16.123Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/cultura/index.html
+++ b/trailblazers/dist/es/tags/cultura/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/cultura/` was built on 2026-03-31T21:40:30.077Z -->
+		<!-- This page `/es/tags/cultura/` was built on 2026-04-01T08:41:18.901Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/ee-uu/index.html
+++ b/trailblazers/dist/es/tags/ee-uu/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/ee-uu/` was built on 2026-03-31T21:40:29.937Z -->
+		<!-- This page `/es/tags/ee-uu/` was built on 2026-04-01T08:41:18.472Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/energia/index.html
+++ b/trailblazers/dist/es/tags/energia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/energia/` was built on 2026-03-31T21:40:29.947Z -->
+		<!-- This page `/es/tags/energia/` was built on 2026-04-01T08:41:18.516Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/espiritualidad/index.html
+++ b/trailblazers/dist/es/tags/espiritualidad/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/espiritualidad/` was built on 2026-03-31T21:40:29.847Z -->
+		<!-- This page `/es/tags/espiritualidad/` was built on 2026-04-01T08:41:16.673Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/francia/index.html
+++ b/trailblazers/dist/es/tags/francia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/francia/` was built on 2026-03-31T21:40:29.956Z -->
+		<!-- This page `/es/tags/francia/` was built on 2026-04-01T08:41:18.299Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/grecia/index.html
+++ b/trailblazers/dist/es/tags/grecia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/grecia/` was built on 2026-03-31T21:40:30.003Z -->
+		<!-- This page `/es/tags/grecia/` was built on 2026-04-01T08:41:18.866Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/historia/index.html
+++ b/trailblazers/dist/es/tags/historia/index.html
@@ -1872,7 +1872,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/historia/` was built on 2026-03-31T21:40:29.894Z -->
+		<!-- This page `/es/tags/historia/` was built on 2026-04-01T08:41:17.553Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/index.html
+++ b/trailblazers/dist/es/tags/index.html
@@ -1681,6 +1681,10 @@ dialog.search-overlay::backdrop {
 
 	
 	
+	<a href="/samples/trailblazers/dist/es/tags/espiritualidad/" class="post-tag">Espiritualidad <span class="tag-count">(1)</span></a>
+
+	
+	
 	<a href="/samples/trailblazers/dist/es/tags/lagos/" class="post-tag">Lagos <span class="tag-count">(1)</span></a>
 
 	
@@ -1689,7 +1693,7 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/es/tags/espiritualidad/" class="post-tag">Espiritualidad <span class="tag-count">(1)</span></a>
+	<a href="/samples/trailblazers/dist/es/tags/peru/" class="post-tag">Perú <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1705,7 +1709,7 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/es/tags/peru/" class="post-tag">Perú <span class="tag-count">(1)</span></a>
+	<a href="/samples/trailblazers/dist/es/tags/francia/" class="post-tag">Francia <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1717,15 +1721,15 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/es/tags/francia/" class="post-tag">Francia <span class="tag-count">(1)</span></a>
-
-	
-	
 	<a href="/samples/trailblazers/dist/es/tags/jordania/" class="post-tag">Jordania <span class="tag-count">(1)</span></a>
 
 	
 	
 	<a href="/samples/trailblazers/dist/es/tags/joyas-ocultas/" class="post-tag">Joyas Ocultas <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/es/tags/vida-silvestre/" class="post-tag">Vida Silvestre <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1741,6 +1745,14 @@ dialog.search-overlay::backdrop {
 
 	
 	
+	<a href="/samples/trailblazers/dist/es/tags/japon/" class="post-tag">Japón <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/es/tags/cultura/" class="post-tag">Cultura <span class="tag-count">(1)</span></a>
+
+	
+	
 	<a href="/samples/trailblazers/dist/es/tags/invierno/" class="post-tag">Invierno <span class="tag-count">(1)</span></a>
 
 	
@@ -1750,18 +1762,6 @@ dialog.search-overlay::backdrop {
 	
 	
 	<a href="/samples/trailblazers/dist/es/tags/magia/" class="post-tag">Magia <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/es/tags/vida-silvestre/" class="post-tag">Vida Silvestre <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/es/tags/japon/" class="post-tag">Japón <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/es/tags/cultura/" class="post-tag">Cultura <span class="tag-count">(1)</span></a>
 
 </div>
 
@@ -1834,7 +1834,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/` was built on 2026-03-31T21:40:26.404Z -->
+		<!-- This page `/es/tags/` was built on 2026-04-01T08:41:07.427Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/indonesia/index.html
+++ b/trailblazers/dist/es/tags/indonesia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/indonesia/` was built on 2026-03-31T21:40:29.858Z -->
+		<!-- This page `/es/tags/indonesia/` was built on 2026-04-01T08:41:16.684Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/invierno/index.html
+++ b/trailblazers/dist/es/tags/invierno/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/invierno/` was built on 2026-03-31T21:40:30.021Z -->
+		<!-- This page `/es/tags/invierno/` was built on 2026-04-01T08:41:18.912Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/islandia/index.html
+++ b/trailblazers/dist/es/tags/islandia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/islandia/` was built on 2026-03-31T21:40:30.030Z -->
+		<!-- This page `/es/tags/islandia/` was built on 2026-04-01T08:41:18.926Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/islas/index.html
+++ b/trailblazers/dist/es/tags/islas/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/islas/` was built on 2026-03-31T21:40:29.995Z -->
+		<!-- This page `/es/tags/islas/` was built on 2026-04-01T08:41:18.856Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/italia/index.html
+++ b/trailblazers/dist/es/tags/italia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/italia/` was built on 2026-03-31T21:40:29.796Z -->
+		<!-- This page `/es/tags/italia/` was built on 2026-04-01T08:41:16.237Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/japon/index.html
+++ b/trailblazers/dist/es/tags/japon/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/japon/` was built on 2026-03-31T21:40:30.067Z -->
+		<!-- This page `/es/tags/japon/` was built on 2026-04-01T08:41:18.890Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/jordania/index.html
+++ b/trailblazers/dist/es/tags/jordania/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/jordania/` was built on 2026-03-31T21:40:29.975Z -->
+		<!-- This page `/es/tags/jordania/` was built on 2026-04-01T08:41:18.558Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/joyas-ocultas/index.html
+++ b/trailblazers/dist/es/tags/joyas-ocultas/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/joyas-ocultas/` was built on 2026-03-31T21:40:29.984Z -->
+		<!-- This page `/es/tags/joyas-ocultas/` was built on 2026-04-01T08:41:18.703Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/lagos/index.html
+++ b/trailblazers/dist/es/tags/lagos/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/lagos/` was built on 2026-03-31T21:40:29.817Z -->
+		<!-- This page `/es/tags/lagos/` was built on 2026-04-01T08:41:16.763Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/magia/index.html
+++ b/trailblazers/dist/es/tags/magia/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/magia/` was built on 2026-03-31T21:40:30.040Z -->
+		<!-- This page `/es/tags/magia/` was built on 2026-04-01T08:41:18.936Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/montanas/index.html
+++ b/trailblazers/dist/es/tags/montanas/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/montanas/` was built on 2026-03-31T21:40:29.867Z -->
+		<!-- This page `/es/tags/montanas/` was built on 2026-04-01T08:41:17.897Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/naturaleza/index.html
+++ b/trailblazers/dist/es/tags/naturaleza/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/naturaleza/` was built on 2026-03-31T21:40:29.836Z -->
+		<!-- This page `/es/tags/naturaleza/` was built on 2026-04-01T08:41:16.696Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/peru/index.html
+++ b/trailblazers/dist/es/tags/peru/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/peru/` was built on 2026-03-31T21:40:29.906Z -->
+		<!-- This page `/es/tags/peru/` was built on 2026-04-01T08:41:17.643Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/relajacion/index.html
+++ b/trailblazers/dist/es/tags/relajacion/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/relajacion/` was built on 2026-03-31T21:40:30.012Z -->
+		<!-- This page `/es/tags/relajacion/` was built on 2026-04-01T08:41:18.879Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/romance/index.html
+++ b/trailblazers/dist/es/tags/romance/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/romance/` was built on 2026-03-31T21:40:29.965Z -->
+		<!-- This page `/es/tags/romance/` was built on 2026-04-01T08:41:18.439Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/sudafrica/index.html
+++ b/trailblazers/dist/es/tags/sudafrica/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/sudafrica/` was built on 2026-03-31T21:40:29.876Z -->
+		<!-- This page `/es/tags/sudafrica/` was built on 2026-04-01T08:41:18.076Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/tanzania/index.html
+++ b/trailblazers/dist/es/tags/tanzania/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/tanzania/` was built on 2026-03-31T21:40:30.058Z -->
+		<!-- This page `/es/tags/tanzania/` was built on 2026-04-01T08:41:18.844Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/unesco/index.html
+++ b/trailblazers/dist/es/tags/unesco/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/unesco/` was built on 2026-03-31T21:40:29.915Z -->
+		<!-- This page `/es/tags/unesco/` was built on 2026-04-01T08:41:17.761Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/verano/index.html
+++ b/trailblazers/dist/es/tags/verano/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/verano/` was built on 2026-03-31T21:40:29.806Z -->
+		<!-- This page `/es/tags/verano/` was built on 2026-04-01T08:41:16.419Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/es/tags/vida-silvestre/index.html
+++ b/trailblazers/dist/es/tags/vida-silvestre/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/es/tags/vida-silvestre/` was built on 2026-03-31T21:40:30.049Z -->
+		<!-- This page `/es/tags/vida-silvestre/` was built on 2026-04-01T08:41:18.833Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/about/index.html
+++ b/trailblazers/dist/ja/about/index.html
@@ -1854,7 +1854,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/about/` was built on 2026-03-31T21:40:25.695Z -->
+		<!-- This page `/ja/about/` was built on 2026-04-01T08:41:05.306Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/authors/ashok/index.html
+++ b/trailblazers/dist/ja/authors/ashok/index.html
@@ -1743,25 +1743,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fpetra-rose-red-city%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">デイリーニュースレター</span>
-				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
-				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">登録する</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/ja/blog/tokyo-neon-nights/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1791,6 +1772,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-06">2026年3月</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Ftokyo-neon-nights%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">デイリーニュースレター</span>
+				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
+				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">登録する</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
 			</div>
 		</li>
 </ul>
@@ -1864,7 +1864,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/authors/ashok/` was built on 2026-03-31T21:40:28.578Z -->
+		<!-- This page `/ja/authors/ashok/` was built on 2026-04-01T08:41:13.088Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/authors/julia/index.html
+++ b/trailblazers/dist/ja/authors/julia/index.html
@@ -1833,7 +1833,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/authors/julia/` was built on 2026-03-31T21:40:28.685Z -->
+		<!-- This page `/ja/authors/julia/` was built on 2026-04-01T08:41:13.336Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/authors/maya/index.html
+++ b/trailblazers/dist/ja/authors/maya/index.html
@@ -1774,6 +1774,25 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fparis-midnight-stroll%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">デイリーニュースレター</span>
+				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
+				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">登録する</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
+			</div>
+		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/ja/blog/machu-picchu-ancient-echoes/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1803,25 +1822,6 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-07">2026年3月</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fmachu-picchu-ancient-echoes%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
-			</div>
-		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">デイリーニュースレター</span>
-				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
-				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">登録する</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
 			</div>
 		</li>
 </ul>
@@ -1895,7 +1895,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/authors/maya/` was built on 2026-03-31T21:40:28.434Z -->
+		<!-- This page `/ja/authors/maya/` was built on 2026-04-01T08:41:12.841Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/amalfi-coast-winding-roads/index.html
+++ b/trailblazers/dist/ja/blog/amalfi-coast-winding-roads/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/amalfi-coast-winding-roads/` was built on 2026-03-31T21:40:25.704Z -->
+		<!-- This page `/ja/blog/amalfi-coast-winding-roads/` was built on 2026-04-01T08:41:05.316Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/fyw6qqOZC7.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/bali-spiritual-sanctuary/index.html
+++ b/trailblazers/dist/ja/blog/bali-spiritual-sanctuary/index.html
@@ -1992,7 +1992,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/bali-spiritual-sanctuary/` was built on 2026-03-31T21:40:25.705Z -->
+		<!-- This page `/ja/blog/bali-spiritual-sanctuary/` was built on 2026-04-01T08:41:05.317Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/IyaX7HauBO.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/banff-turquoise-waters/index.html
+++ b/trailblazers/dist/ja/blog/banff-turquoise-waters/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/banff-turquoise-waters/` was built on 2026-03-31T21:40:25.705Z -->
+		<!-- This page `/ja/blog/banff-turquoise-waters/` was built on 2026-04-01T08:41:05.317Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/K3ySczLX42.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/cape-town-table-mountain/index.html
+++ b/trailblazers/dist/ja/blog/cape-town-table-mountain/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/cape-town-table-mountain/` was built on 2026-03-31T21:40:25.705Z -->
+		<!-- This page `/ja/blog/cape-town-table-mountain/` was built on 2026-04-01T08:41:05.318Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/MCWsmD6Eo5.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/index.html
+++ b/trailblazers/dist/ja/blog/index.html
@@ -1734,25 +1734,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fsantorini-blue-and-white%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">デイリーニュースレター</span>
-				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
-				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">登録する</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/ja/blog/petra-rose-red-city/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1844,6 +1825,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-11">2026年3月</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fcape-town-table-mountain%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">デイリーニュースレター</span>
+				<h3 class="newsletter-title" id="trailblazers">Trailblazersのデイリーニュースレターを購読しましょう</h3>
+				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">登録する</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -2180,7 +2180,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/` was built on 2026-03-31T21:40:28.064Z -->
+		<!-- This page `/ja/blog/` was built on 2026-04-01T08:41:12.273Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/machu-picchu-ancient-echoes/index.html
+++ b/trailblazers/dist/ja/blog/machu-picchu-ancient-echoes/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/machu-picchu-ancient-echoes/` was built on 2026-03-31T21:40:25.706Z -->
+		<!-- This page `/ja/blog/machu-picchu-ancient-echoes/` was built on 2026-04-01T08:41:05.317Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/mymmyc2KYR.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/new-york-concrete-jungle/index.html
+++ b/trailblazers/dist/ja/blog/new-york-concrete-jungle/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/new-york-concrete-jungle/` was built on 2026-03-31T21:40:25.706Z -->
+		<!-- This page `/ja/blog/new-york-concrete-jungle/` was built on 2026-04-01T08:41:05.319Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/HQhKhUd1zR.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/paris-midnight-stroll/index.html
+++ b/trailblazers/dist/ja/blog/paris-midnight-stroll/index.html
@@ -1990,7 +1990,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/paris-midnight-stroll/` was built on 2026-03-31T21:40:25.706Z -->
+		<!-- This page `/ja/blog/paris-midnight-stroll/` was built on 2026-04-01T08:41:05.318Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/_NLxN8z9do.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/petra-rose-red-city/index.html
+++ b/trailblazers/dist/ja/blog/petra-rose-red-city/index.html
@@ -1994,7 +1994,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/petra-rose-red-city/` was built on 2026-03-31T21:40:25.706Z -->
+		<!-- This page `/ja/blog/petra-rose-red-city/` was built on 2026-04-01T08:41:05.318Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/nXgfL3cjz7.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/reykjavik-northern-lights/index.html
+++ b/trailblazers/dist/ja/blog/reykjavik-northern-lights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/reykjavik-northern-lights/` was built on 2026-03-31T21:40:25.707Z -->
+		<!-- This page `/ja/blog/reykjavik-northern-lights/` was built on 2026-04-01T08:41:05.319Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/bacLJX0zkG.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/santorini-blue-and-white/index.html
+++ b/trailblazers/dist/ja/blog/santorini-blue-and-white/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/santorini-blue-and-white/` was built on 2026-03-31T21:40:25.707Z -->
+		<!-- This page `/ja/blog/santorini-blue-and-white/` was built on 2026-04-01T08:41:05.319Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/lwwtHxDmnX.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/serengeti-safari-sunrise/index.html
+++ b/trailblazers/dist/ja/blog/serengeti-safari-sunrise/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/serengeti-safari-sunrise/` was built on 2026-03-31T21:40:25.707Z -->
+		<!-- This page `/ja/blog/serengeti-safari-sunrise/` was built on 2026-04-01T08:41:05.320Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/G1ooNWX65j.js"></script>
 		
 		

--- a/trailblazers/dist/ja/blog/tokyo-neon-nights/index.html
+++ b/trailblazers/dist/ja/blog/tokyo-neon-nights/index.html
@@ -1991,7 +1991,7 @@ pre[class*='language-diff-'] {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/blog/tokyo-neon-nights/` was built on 2026-03-31T21:40:25.708Z -->
+		<!-- This page `/ja/blog/tokyo-neon-nights/` was built on 2026-04-01T08:41:05.320Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/-ceq6hDRKZ.js"></script>
 		
 		

--- a/trailblazers/dist/ja/destinations/index.html
+++ b/trailblazers/dist/ja/destinations/index.html
@@ -1700,11 +1700,6 @@ dialog.search-overlay::backdrop {
   gap: 0.4rem;
 }
 
-.map-tooltip::before {
-  content: '📍';
-  font-size: 0.8rem;
-}
-
 .map-hint {
   text-align: center;
   font-size: 0.85rem;
@@ -5083,9 +5078,9 @@ dialog.search-overlay::backdrop {
     <h2 id="-3">すべての目的地</h2>
     <ul class="destination-cards">
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/amalfi-coast-winding-roads/" class="destination-card">
+        <a href="undefinedja/blog/amalfi-coast-winding-roads/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/IRwP0Zg7Ka-3000.jpeg" alt="amalfi-coast-winding-roads" width="3000" height="2000"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/amalfi-coast-winding-roads/cover.jpg" alt="amalfi-coast-winding-roads" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">イタリア</span>
@@ -5094,9 +5089,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/bali-spiritual-sanctuary/" class="destination-card">
+        <a href="undefinedja/blog/bali-spiritual-sanctuary/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/O3Mi_dqgwz-3000.jpeg" alt="bali-spiritual-sanctuary" width="3000" height="2000"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/bali-spiritual-sanctuary/cover.jpg" alt="bali-spiritual-sanctuary" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">インドネシア</span>
@@ -5105,9 +5100,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/banff-turquoise-waters/" class="destination-card">
+        <a href="undefinedja/blog/banff-turquoise-waters/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/Zo2dj1BQuY-3000.jpeg" alt="banff-turquoise-waters" width="3000" height="2148"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/banff-turquoise-waters/cover.jpg" alt="banff-turquoise-waters" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">カナダ</span>
@@ -5116,9 +5111,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/cape-town-table-mountain/" class="destination-card">
+        <a href="undefinedja/blog/cape-town-table-mountain/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/eA6kvoWk_a-3000.jpeg" alt="cape-town-table-mountain" width="3000" height="2000"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/cape-town-table-mountain/cover.jpg" alt="cape-town-table-mountain" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">南アフリカ</span>
@@ -5127,9 +5122,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/machu-picchu-ancient-echoes/" class="destination-card">
+        <a href="undefinedja/blog/machu-picchu-ancient-echoes/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/3fMS8Ty_9n-3000.jpeg" alt="machu-picchu-ancient-echoes" width="3000" height="1987"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/machu-picchu-ancient-echoes/cover.jpg" alt="machu-picchu-ancient-echoes" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">ペルー</span>
@@ -5138,9 +5133,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/new-york-concrete-jungle/" class="destination-card">
+        <a href="undefinedja/blog/new-york-concrete-jungle/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/t9VX-0sKGQ-3000.jpeg" alt="new-york-concrete-jungle" width="3000" height="2000"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/new-york-concrete-jungle/cover.jpg" alt="new-york-concrete-jungle" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">アメリカ合衆国</span>
@@ -5149,9 +5144,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/paris-midnight-stroll/" class="destination-card">
+        <a href="undefinedja/blog/paris-midnight-stroll/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/vl8VYA-VsZ-3000.jpeg" alt="paris-midnight-stroll" width="3000" height="2122"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/paris-midnight-stroll/cover.jpg" alt="paris-midnight-stroll" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">フランス</span>
@@ -5160,9 +5155,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/petra-rose-red-city/" class="destination-card">
+        <a href="undefinedja/blog/petra-rose-red-city/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/fiCl4aJmQy-3000.jpeg" alt="petra-rose-red-city" width="3000" height="2250"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/petra-rose-red-city/cover.jpg" alt="petra-rose-red-city" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">ヨルダン</span>
@@ -5171,9 +5166,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/reykjavik-northern-lights/" class="destination-card">
+        <a href="undefinedja/blog/reykjavik-northern-lights/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/Smie_eEJlo-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/Smie_eEJlo-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/Smie_eEJlo-3000.jpeg" alt="reykjavik-northern-lights" width="3000" height="1699"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/reykjavik-northern-lights/cover.jpg" alt="reykjavik-northern-lights" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">アイスランド</span>
@@ -5182,9 +5177,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/santorini-blue-and-white/" class="destination-card">
+        <a href="undefinedja/blog/santorini-blue-and-white/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/mHBp0glhnT-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/mHBp0glhnT-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/mHBp0glhnT-3000.jpeg" alt="santorini-blue-and-white" width="3000" height="4000"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/santorini-blue-and-white/cover.jpg" alt="santorini-blue-and-white" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">ギリシャ</span>
@@ -5193,9 +5188,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/serengeti-safari-sunrise/" class="destination-card">
+        <a href="undefinedja/blog/serengeti-safari-sunrise/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/3xH6pTS7KU-3000.jpeg" alt="serengeti-safari-sunrise" width="3000" height="1792"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/serengeti-safari-sunrise/cover.jpg" alt="serengeti-safari-sunrise" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">タンザニア</span>
@@ -5204,9 +5199,9 @@ dialog.search-overlay::backdrop {
         </a>
       </li>
       <li>
-        <a href="/samples/trailblazers/dist/ja/blog/tokyo-neon-nights/" class="destination-card">
+        <a href="undefinedja/blog/tokyo-neon-nights/" class="destination-card">
           <div class="destination-card-thumb">
-            <picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/iFW5b38xmH-3000.avif 3000w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/iFW5b38xmH-3000.webp 3000w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/iFW5b38xmH-3000.jpeg" alt="tokyo-neon-nights" width="3000" height="1997"></picture>
+            <img src="content/ja/destinations/undefinedja/blog/tokyo-neon-nights/cover.jpg" alt="tokyo-neon-nights" loading="lazy">
           </div>
           <div class="destination-card-body">
             <span class="destination-card-country">日本</span>
@@ -5288,8 +5283,8 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/destinations/` was built on 2026-03-31T21:40:24.563Z -->
-		<script type="module" src="/samples/trailblazers/dist/dist/OE4EBunwVr.js"></script>
+		<!-- This page `/ja/destinations/` was built on 2026-04-01T08:41:02.447Z -->
+		<script type="module" src="/samples/trailblazers/dist/dist/02zMvsH_04.js"></script>
 		
 		
 	</body>

--- a/trailblazers/dist/ja/imprint/index.html
+++ b/trailblazers/dist/ja/imprint/index.html
@@ -1729,7 +1729,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/imprint/` was built on 2026-03-31T21:40:24.561Z -->
+		<!-- This page `/ja/imprint/` was built on 2026-04-01T08:41:02.446Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/index.html
+++ b/trailblazers/dist/ja/index.html
@@ -1758,25 +1758,6 @@ dialog.search-overlay::backdrop {
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fsantorini-blue-and-white%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
 			</div>
 		</li>
-		<li class="postlist-item postlist-item-newsletter">
-			<div class="postlist-thumbnail-container">
-				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
-			</div>
-			<div class="postlist-content">
-				<span class="newsletter-label">デイリーニュースレター</span>
-				<h3 class="newsletter-title" id="trailblazers-2">Trailblazersのデイリーニュースレターを購読しましょう</h3>
-				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
-				
-				<form class="newsletter-form">
-					<div class="newsletter-input-group">
-						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
-						<button type="submit" class="newsletter-button">登録する</button>
-					</div>
-				</form>
-				
-				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
-			</div>
-		</li>
 		<li class="postlist-item">
 			<a href="/samples/trailblazers/dist/ja/blog/petra-rose-red-city/" class="postlist-thumbnail-link">
 				<div class="postlist-thumbnail-container">
@@ -1806,6 +1787,25 @@ dialog.search-overlay::backdrop {
 					<time class="postlist-date" datetime="2026-03-13">2026年3月</time>
 				</div>
 				<a href="/samples/trailblazers/dist/blog/create/?edit=.%2Fcontent%2Fja%2Fblog%2Fpetra-rose-red-city%2Findex.md" class="admin-only edit-post-link btn" style="display: none;">✏️ Edit</a>
+			</div>
+		</li>
+		<li class="postlist-item postlist-item-newsletter">
+			<div class="postlist-thumbnail-container">
+				<picture><source type="image/avif" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.avif 2048w"><source type="image/webp" srcset="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.webp 2048w"><img loading="lazy" decoding="async" src="/samples/trailblazers/dist/img/XPa3BM1XjF-2048.jpeg" alt="Newsletter" class="postlist-thumbnail" width="2048" height="2048"></picture>
+			</div>
+			<div class="postlist-content">
+				<span class="newsletter-label">デイリーニュースレター</span>
+				<h3 class="newsletter-title" id="trailblazers-2">Trailblazersのデイリーニュースレターを購読しましょう</h3>
+				<p class="postlist-description">100万人以上の読者に混じって、最新ニュースや詳細なガイド、お得な情報を手に入れましょう。</p>
+				
+				<form class="newsletter-form">
+					<div class="newsletter-input-group">
+						<input type="email" placeholder="メールアドレス" required="" class="newsletter-input">
+						<button type="submit" class="newsletter-button">登録する</button>
+					</div>
+				</form>
+				
+				<p class="newsletter-disclaimer">登録すると、<a href="//imprint/">利用規約</a>に同意し、<a href="//privacy/">プライバシーポリシー</a>のデータ取り扱い方法を認めたことになります。</p>
 			</div>
 		</li>
 		<li class="postlist-item">
@@ -1916,7 +1916,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/` was built on 2026-03-31T21:40:25.694Z -->
+		<!-- This page `/ja/` was built on 2026-04-01T08:41:05.304Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/privacy/index.html
+++ b/trailblazers/dist/ja/privacy/index.html
@@ -1732,7 +1732,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/privacy/` was built on 2026-03-31T21:40:24.561Z -->
+		<!-- This page `/ja/privacy/` was built on 2026-04-01T08:41:02.446Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/index.html
+++ b/trailblazers/dist/ja/tags/index.html
@@ -1685,6 +1685,10 @@ dialog.search-overlay::backdrop {
 
 	
 	
+	<a href="/samples/trailblazers/dist/ja/tags/ペルー/" class="post-tag">ペルー <span class="tag-count">(1)</span></a>
+
+	
+	
 	<a href="/samples/trailblazers/dist/ja/tags/山/" class="post-tag">山 <span class="tag-count">(1)</span></a>
 
 	
@@ -1697,15 +1701,11 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/ja/tags/ペルー/" class="post-tag">ペルー <span class="tag-count">(1)</span></a>
+	<a href="/samples/trailblazers/dist/ja/tags/ヨルダン/" class="post-tag">ヨルダン <span class="tag-count">(1)</span></a>
 
 	
 	
-	<a href="/samples/trailblazers/dist/ja/tags/アメリカ/" class="post-tag">アメリカ <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/ja/tags/エネルギー/" class="post-tag">エネルギー <span class="tag-count">(1)</span></a>
+	<a href="/samples/trailblazers/dist/ja/tags/秘境/" class="post-tag">秘境 <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1714,14 +1714,6 @@ dialog.search-overlay::backdrop {
 	
 	
 	<a href="/samples/trailblazers/dist/ja/tags/ロマンス/" class="post-tag">ロマンス <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/ja/tags/ヨルダン/" class="post-tag">ヨルダン <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/ja/tags/秘境/" class="post-tag">秘境 <span class="tag-count">(1)</span></a>
 
 	
 	
@@ -1737,6 +1729,14 @@ dialog.search-overlay::backdrop {
 
 	
 	
+	<a href="/samples/trailblazers/dist/ja/tags/アメリカ/" class="post-tag">アメリカ <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/ja/tags/エネルギー/" class="post-tag">エネルギー <span class="tag-count">(1)</span></a>
+
+	
+	
 	<a href="/samples/trailblazers/dist/ja/tags/島/" class="post-tag">島 <span class="tag-count">(1)</span></a>
 
 	
@@ -1749,19 +1749,19 @@ dialog.search-overlay::backdrop {
 
 	
 	
-	<a href="/samples/trailblazers/dist/ja/tags/野生動物/" class="post-tag">野生動物 <span class="tag-count">(1)</span></a>
-
-	
-	
-	<a href="/samples/trailblazers/dist/ja/tags/タンザニア/" class="post-tag">タンザニア <span class="tag-count">(1)</span></a>
-
-	
-	
 	<a href="/samples/trailblazers/dist/ja/tags/日本/" class="post-tag">日本 <span class="tag-count">(1)</span></a>
 
 	
 	
 	<a href="/samples/trailblazers/dist/ja/tags/文化/" class="post-tag">文化 <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/ja/tags/野生動物/" class="post-tag">野生動物 <span class="tag-count">(1)</span></a>
+
+	
+	
+	<a href="/samples/trailblazers/dist/ja/tags/タンザニア/" class="post-tag">タンザニア <span class="tag-count">(1)</span></a>
 
 </div>
 
@@ -1834,7 +1834,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/` was built on 2026-03-31T21:40:27.904Z -->
+		<!-- This page `/ja/tags/` was built on 2026-04-01T08:41:11.993Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/unesco/index.html
+++ b/trailblazers/dist/ja/tags/unesco/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/unesco/` was built on 2026-03-31T21:40:30.675Z -->
+		<!-- This page `/ja/tags/unesco/` was built on 2026-04-01T08:41:19.967Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/アイスランド/index.html
+++ b/trailblazers/dist/ja/tags/アイスランド/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/アイスランド/` was built on 2026-03-31T21:40:30.955Z -->
+		<!-- This page `/ja/tags/アイスランド/` was built on 2026-04-01T08:41:20.840Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/アドベンチャー/index.html
+++ b/trailblazers/dist/ja/tags/アドベンチャー/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/アドベンチャー/` was built on 2026-03-31T21:40:30.515Z -->
+		<!-- This page `/ja/tags/アドベンチャー/` was built on 2026-04-01T08:41:20.145Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/アメリカ/index.html
+++ b/trailblazers/dist/ja/tags/アメリカ/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/アメリカ/` was built on 2026-03-31T21:40:30.717Z -->
+		<!-- This page `/ja/tags/アメリカ/` was built on 2026-04-01T08:41:21.121Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/イタリア/index.html
+++ b/trailblazers/dist/ja/tags/イタリア/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/イタリア/` was built on 2026-03-31T21:40:30.124Z -->
+		<!-- This page `/ja/tags/イタリア/` was built on 2026-04-01T08:41:18.978Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/インドネシア/index.html
+++ b/trailblazers/dist/ja/tags/インドネシア/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/インドネシア/` was built on 2026-03-31T21:40:30.248Z -->
+		<!-- This page `/ja/tags/インドネシア/` was built on 2026-04-01T08:41:19.685Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/エネルギー/index.html
+++ b/trailblazers/dist/ja/tags/エネルギー/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/エネルギー/` was built on 2026-03-31T21:40:30.783Z -->
+		<!-- This page `/ja/tags/エネルギー/` was built on 2026-04-01T08:41:21.160Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/カナダ/index.html
+++ b/trailblazers/dist/ja/tags/カナダ/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/カナダ/` was built on 2026-03-31T21:40:30.391Z -->
+		<!-- This page `/ja/tags/カナダ/` was built on 2026-04-01T08:41:19.859Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/ギリシャ/index.html
+++ b/trailblazers/dist/ja/tags/ギリシャ/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/ギリシャ/` was built on 2026-03-31T21:40:31.051Z -->
+		<!-- This page `/ja/tags/ギリシャ/` was built on 2026-04-01T08:41:21.496Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/スピリチュアル/index.html
+++ b/trailblazers/dist/ja/tags/スピリチュアル/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/スピリチュアル/` was built on 2026-03-31T21:40:30.209Z -->
+		<!-- This page `/ja/tags/スピリチュアル/` was built on 2026-04-01T08:41:19.553Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/タンザニア/index.html
+++ b/trailblazers/dist/ja/tags/タンザニア/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/タンザニア/` was built on 2026-03-31T21:40:31.139Z -->
+		<!-- This page `/ja/tags/タンザニア/` was built on 2026-04-01T08:41:22.779Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/フランス/index.html
+++ b/trailblazers/dist/ja/tags/フランス/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/フランス/` was built on 2026-03-31T21:40:30.809Z -->
+		<!-- This page `/ja/tags/フランス/` was built on 2026-04-01T08:41:20.385Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/ペルー/index.html
+++ b/trailblazers/dist/ja/tags/ペルー/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/ペルー/` was built on 2026-03-31T21:40:30.665Z -->
+		<!-- This page `/ja/tags/ペルー/` was built on 2026-04-01T08:41:19.910Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/ヨルダン/index.html
+++ b/trailblazers/dist/ja/tags/ヨルダン/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/ヨルダン/` was built on 2026-03-31T21:40:30.883Z -->
+		<!-- This page `/ja/tags/ヨルダン/` was built on 2026-04-01T08:41:20.175Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/リラクゼーション/index.html
+++ b/trailblazers/dist/ja/tags/リラクゼーション/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/リラクゼーション/` was built on 2026-03-31T21:40:31.120Z -->
+		<!-- This page `/ja/tags/リラクゼーション/` was built on 2026-04-01T08:41:22.640Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/ロマンス/index.html
+++ b/trailblazers/dist/ja/tags/ロマンス/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/ロマンス/` was built on 2026-03-31T21:40:30.873Z -->
+		<!-- This page `/ja/tags/ロマンス/` was built on 2026-04-01T08:41:20.523Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/冬/index.html
+++ b/trailblazers/dist/ja/tags/冬/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/冬/` was built on 2026-03-31T21:40:30.902Z -->
+		<!-- This page `/ja/tags/冬/` was built on 2026-04-01T08:41:20.551Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/南アフリカ/index.html
+++ b/trailblazers/dist/ja/tags/南アフリカ/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/南アフリカ/` was built on 2026-03-31T21:40:30.427Z -->
+		<!-- This page `/ja/tags/南アフリカ/` was built on 2026-04-01T08:41:19.999Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/夏/index.html
+++ b/trailblazers/dist/ja/tags/夏/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/夏/` was built on 2026-03-31T21:40:30.200Z -->
+		<!-- This page `/ja/tags/夏/` was built on 2026-04-01T08:41:19.478Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/山/index.html
+++ b/trailblazers/dist/ja/tags/山/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/山/` was built on 2026-03-31T21:40:30.400Z -->
+		<!-- This page `/ja/tags/山/` was built on 2026-04-01T08:41:19.977Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/島/index.html
+++ b/trailblazers/dist/ja/tags/島/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/島/` was built on 2026-03-31T21:40:31.024Z -->
+		<!-- This page `/ja/tags/島/` was built on 2026-04-01T08:41:21.350Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/文化/index.html
+++ b/trailblazers/dist/ja/tags/文化/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/文化/` was built on 2026-03-31T21:40:31.160Z -->
+		<!-- This page `/ja/tags/文化/` was built on 2026-04-01T08:41:22.704Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/日本/index.html
+++ b/trailblazers/dist/ja/tags/日本/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/日本/` was built on 2026-03-31T21:40:31.148Z -->
+		<!-- This page `/ja/tags/日本/` was built on 2026-04-01T08:41:22.687Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/歴史/index.html
+++ b/trailblazers/dist/ja/tags/歴史/index.html
@@ -1872,7 +1872,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/歴史/` was built on 2026-03-31T21:40:30.579Z -->
+		<!-- This page `/ja/tags/歴史/` was built on 2026-04-01T08:41:19.869Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/海岸/index.html
+++ b/trailblazers/dist/ja/tags/海岸/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/海岸/` was built on 2026-03-31T21:40:30.086Z -->
+		<!-- This page `/ja/tags/海岸/` was built on 2026-04-01T08:41:18.946Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/湖/index.html
+++ b/trailblazers/dist/ja/tags/湖/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/湖/` was built on 2026-03-31T21:40:30.382Z -->
+		<!-- This page `/ja/tags/湖/` was built on 2026-04-01T08:41:19.849Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/秘境/index.html
+++ b/trailblazers/dist/ja/tags/秘境/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/秘境/` was built on 2026-03-31T21:40:30.892Z -->
+		<!-- This page `/ja/tags/秘境/` was built on 2026-04-01T08:41:20.233Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/自然/index.html
+++ b/trailblazers/dist/ja/tags/自然/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/自然/` was built on 2026-03-31T21:40:30.316Z -->
+		<!-- This page `/ja/tags/自然/` was built on 2026-04-01T08:41:19.835Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/都市/index.html
+++ b/trailblazers/dist/ja/tags/都市/index.html
@@ -1903,7 +1903,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/都市/` was built on 2026-03-31T21:40:30.685Z -->
+		<!-- This page `/ja/tags/都市/` was built on 2026-04-01T08:41:20.324Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/野生動物/index.html
+++ b/trailblazers/dist/ja/tags/野生動物/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/野生動物/` was built on 2026-03-31T21:40:31.130Z -->
+		<!-- This page `/ja/tags/野生動物/` was built on 2026-04-01T08:41:22.719Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		

--- a/trailblazers/dist/ja/tags/魔法/index.html
+++ b/trailblazers/dist/ja/tags/魔法/index.html
@@ -1841,7 +1841,7 @@ dialog.search-overlay::backdrop {
 			</form>
 		</footer>
 
-		<!-- This page `/ja/tags/魔法/` was built on 2026-03-31T21:40:31.015Z -->
+		<!-- This page `/ja/tags/魔法/` was built on 2026-04-01T08:41:21.110Z -->
 		<script type="module" src="/samples/trailblazers/dist/dist/ogpROWI0ob.js"></script>
 		
 		


### PR DESCRIPTION
- Remove `.map-tooltip::before { content: '📍' }` CSS rule that caused a second push-pin emoji alongside the one already set via innerHTML

- Add `const siteBase = {{ '/' | url | dump | safe }}` to the JS block on the destinations page so URLs include the site's pathPrefix ("/samples/trailblazers/dist/") at build time, fixing navigation both on localhost (/samples/trailblazers/dist/...) and GitHub Pages (https://googlechrome.github.io/samples/trailblazers/dist/...)

https://claude.ai/code/session_0189No8K3pnouv5XZHkf1gk6