### PR TITLE
Update io2026-chrome-built-in-ai-demos adjective generation

### DIFF
--- a/io2026-chrome-built-in-ai-demos/index.html
+++ b/io2026-chrome-built-in-ai-demos/index.html
@@ -1049,7 +1049,9 @@
         if (availability === 'unavailable') return;
 
         const SYSTEM_PROMPT =
-          'You complete inspirational phrases about developers. Respond with exactly one positive, creative single-word adjective. Be very creative. Do not always say "innovative", think of more exotic words. Never repeat a word you have already used in this conversation. No punctuation. No explanation. Just the adjective in lower case letters. Respond in plain text, do NOT respond in HTML. Do NOT include any formatting, tags, or markup in your response.';
+          'You generate adjectives describing developers to complete inspirational taglines. Generate one creative, positive, fun, unique, and work-friendly adjective about developers for each request. Provide a word that has not already been provided. Omit explanation, punctuation, and markup; just provide the single-word adjective in plain text with lower case letters.';
+        const USER_PROMPT =
+          'Provide just one single positive adjective that would complete the phrase "Developers are "';
 
         const reducedMotion = window.matchMedia(
           '(prefers-reduced-motion: reduce)'
@@ -1096,9 +1098,8 @@
             const stream = session.promptStreaming([
               {
                 role: 'user',
-                content: 'One positive adjective only, no punctuation:',
+                content: USER_PROMPT,
               },
-              { role: 'assistant', content: 'Developers are ', prefix: true },
             ]);
             let raw = '';
             for await (const chunk of stream) {


### PR DESCRIPTION
Improve system and user prompt clarity. Remove assistant role response prefix.
Anecdotally improves quality and reliability; may yield the word `innovative` :-P

Examples produced with these changes on MBP M4 with Stable 148.0.7778.168:
```
innovative
resourceful
curious
adaptable
persistent
collaborative
visionary
empowering
dedicated
insightful
harmonious
dynamic
captivating
pragmatic
generous
resilient
thoughtful
inspired
agile
compassionate
```

Here's an example generated before these changes on the same device, the first was an unexpectedly long set of phrases that broke layout, likely from a conflict in the semantic request of the user prompt and the forced response prefix:
```
resilient

Developers are 
luminescent

Developers are 
vivid

Developers are 
ethereal

Developers are 
captivating

Developers are 
zenith

Developers are 
radiant

Developers are 
effervescent

Developers are 
kaleidoscopic

Developers are 
serendipitous


astounding
luminary
mellifluous
ephemeral
pulchritudinous
splendiferous
phantasmagoric
luminescent
resplendent
quixotic
benevolent
exquisite
marvelous
glorious
bountiful
zen
marvelous
radiant
luminescent
```