### PR TITLE
Fix 404 links being added to sulky-lopsided-bean, and make manifest properly installable in subdirectories

### DIFF
--- a/pwa-testing/sulky-lopsided-bean/add-links.js
+++ b/pwa-testing/sulky-lopsided-bean/add-links.js
@@ -1,7 +1,7 @@
 const urls = [
-  {url: window.location.origin + "/black/", text: "navigate-existing"},
-  {url: window.location.origin + "/brown/", text: "focus-existing"},
-  {url: window.location.origin + "/white/", text: "navigate-new"},
+  {url: new URL('../black/', window.location.href).href, text: "navigate-existing"},
+  {url: new URL('../brown/', window.location.href).href, text: "focus-existing"},
+  {url: new URL('../white/', window.location.href).href, text: "navigate-new"},
   {url: "about:blank", text: ""},
 ];
 

--- a/pwa-testing/sulky-lopsided-bean/black/manifest.webmanifest
+++ b/pwa-testing/sulky-lopsided-bean/black/manifest.webmanifest
@@ -5,13 +5,14 @@
   "scope": "./",
   "theme_color": "black",
   "icons": [{
-    "src": "/black/sulky-lopsided-bean-black.svg",
+    "src": "./sulky-lopsided-bean-black.svg",
     "sizes": "192x192",
     "type": "image/svg+xml"
   }],
   "share_target": {
     "action": "./",
     "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
       "text": "text",
       "title": "title",

--- a/pwa-testing/sulky-lopsided-bean/brown/manifest.webmanifest
+++ b/pwa-testing/sulky-lopsided-bean/brown/manifest.webmanifest
@@ -5,13 +5,14 @@
   "scope": "./",
   "theme_color": "#591313",
   "icons": [{
-    "src": "/brown/sulky-lopsided-bean-brown.svg",
+    "src": "./sulky-lopsided-bean-brown.svg",
     "sizes": "192x192",
     "type": "image/svg+xml"
   }],
   "share_target": {
     "action": "./",
     "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
       "text": "text",
       "title": "title",

--- a/pwa-testing/sulky-lopsided-bean/white/manifest.webmanifest
+++ b/pwa-testing/sulky-lopsided-bean/white/manifest.webmanifest
@@ -5,13 +5,14 @@
   "scope": "./",
   "theme_color": "white",
   "icons": [{
-    "src": "/white/sulky-lopsided-bean-white.svg",
+    "src": "./sulky-lopsided-bean-white.svg",
     "sizes": "192x192",
     "type": "image/svg+xml"
   }],
   "share_target": {
     "action": "./",
     "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
       "text": "text",
       "title": "title",


### PR DESCRIPTION
# Fix PWA Installability and Link Resolution Issues

### Summary of Changes
- **Relative Icon Paths**: Changed icon `src` paths in the manifest files for `black`, `brown`, and `white` beans from origin-absolute (e.g. `/black/...`) to relative (e.g. `./...`). This ensures that the PWA icons successfully load when the sample is hosted in a subdirectory (such as on GitHub Pages).
- **Explicit Share Target Enctype**: Added `"enctype": "application/x-www-form-urlencoded"` to the `share_target` in all three manifest files. This addresses Chrome's audit/console warning regarding the default enctype.
- **Dynamic Link Resolution**: Updated `add-links.js` to resolve relative target URLs dynamically using `new URL(relativeDir, window.location.href)` instead of hardcoding `window.location.origin + "/site/"`. This prevents 404 errors when navigating between the test pages when hosted under a subdirectory.

This has been tested locally, and it fixes the site completely.