### PR TITLE
refactor(cos): use singular requestFileHandle() instead of requestFileHandles()

### DIFF
--- a/cos-demo/huggingface.js
+++ b/cos-demo/huggingface.js
@@ -81,9 +81,7 @@ env.customCache = {
     const hash = { algorithm: 'SHA-256', value: hashValue };
     console.log('Trying to access file in cross-origin storage...', hash);
     try {
-      const [handle] = await navigator.crossOriginStorage.requestFileHandles([
-        hash,
-      ]);
+      const handle = await navigator.crossOriginStorage.requestFileHandle(hash);
       const blob = await handle.getFile();
       console.log('File found in cross-origin storage:', blob);
       return new Response(blob);
@@ -100,8 +98,8 @@ env.customCache = {
       cachedFileHashesLocalStorageKey,
       JSON.stringify(cachedFileHashes),
     );
-    const [handle] = await navigator.crossOriginStorage.requestFileHandles(
-      [hash],
+    const handle = await navigator.crossOriginStorage.requestFileHandle(
+      hash,
       { create: true },
     );
     const writableStream = await handle.createWritable();

--- a/cos-demo/index.html
+++ b/cos-demo/index.html
@@ -126,10 +126,10 @@
         try {
           /* BEGIN MARK */
           // Retrieving a file from cross-origin storage.
-          const [handle] =
-            await navigator.crossOriginStorage.requestFileHandles([
-              hash,
-            ]); /* END MARK */
+          const handle =
+            await navigator.crossOriginStorage.requestFileHandle(
+              hash
+            ); /* END MARK */
           const fileBlob = await handle.getFile();
           console.log('File found in cross-origin storage:', fileBlob);
           return fileBlob;
@@ -165,9 +165,9 @@
           /* BEGIN MARK */
           // Storing a file in cross-origin storage.
           const options = { create: true };
-          const [handle] =
-            await navigator.crossOriginStorage.requestFileHandles(
-              [hash],
+          const handle =
+            await navigator.crossOriginStorage.requestFileHandle(
+              hash,
               options,
             ); /* END MARK */
           const writable = await handle.createWritable();

--- a/io2026-chrome-built-in-ai-demos/index.html
+++ b/io2026-chrome-built-in-ai-demos/index.html
@@ -192,8 +192,8 @@
               .join(''),
           J = async (e) => {
             try {
-              const [a] = await navigator.crossOriginStorage.requestFileHandles(
-                [{ algorithm: 'SHA-256', value: e }]
+              const a = await navigator.crossOriginStorage.requestFileHandle(
+                { algorithm: 'SHA-256', value: e }
               );
               return await a.getFile();
             } catch (a) {
@@ -203,8 +203,8 @@
           },
           i = async (e, a) => {
             try {
-              const [d] = await navigator.crossOriginStorage.requestFileHandles(
-                  [{ algorithm: 'SHA-256', value: a }],
+              const d = await navigator.crossOriginStorage.requestFileHandle(
+                  { algorithm: 'SHA-256', value: a },
                   { create: !0, origins: '*' }
                 ),
                 f = await d.createWritable();

--- a/sqlite-wasm-cos/index.html
+++ b/sqlite-wasm-cos/index.html
@@ -119,9 +119,9 @@
           if (embeddedHash && cosAvailable) {
             const cosHash = { algorithm: 'SHA-256', value: embeddedHash };
             try {
-              const handles = await navigator.crossOriginStorage.requestFileHandles([cosHash]);
+              const handle = await navigator.crossOriginStorage.requestFileHandle(cosHash);
               // Cache hit — read the wasm straight from COS
-              const bytes = await handles[0].getFile().then((f) => f.arrayBuffer());
+              const bytes = await handle.getFile().then((f) => f.arrayBuffer());
               log('COS cache HIT — wasm loaded from cross-origin cache');
               set('cos-event', 'cache hit — served from COS', 'hit');
               await finish(bytes);
@@ -136,10 +136,10 @@
                 // Fire-and-forget store
                 (async () => {
                   try {
-                    const wh = await navigator.crossOriginStorage.requestFileHandles(
-                      [cosHash], { create: true, origins: '*' },
+                    const wh = await navigator.crossOriginStorage.requestFileHandle(
+                      cosHash, { create: true, origins: '*' },
                     );
-                    const writable = await wh[0].createWritable();
+                    const writable = await wh.createWritable();
                     await writable.write(new Blob([bytes], { type: 'application/wasm' }));
                     await writable.close();
                     log('COS stored — wasm written to cross-origin cache');


### PR DESCRIPTION
All COS call sites in this repo pass a single hash and use a single handle. This switches all four files to the new singular `requestFileHandle(hash, options)` API, which returns a `FileSystemFileHandle` directly rather than a single-element array.

**Files changed:**
- `cos-demo/huggingface.js`
- `cos-demo/index.html`
- `sqlite-wasm-cos/index.html`
- `io2026-chrome-built-in-ai-demos/index.html`

The rename is tracked in the COS spec repo: https://github.com/WICG/cross-origin-storage/issues/61