### PR TITLE
Ensure link clicks for testing create new top level browsing contexts

### DIFF
--- a/pwa-testing/saber-tabby-shield/public/index.html
+++ b/pwa-testing/saber-tabby-shield/public/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
+
 <head>
   <title>Tabby Skywalker</title>
   <link rel="manifest" href="/saber_tabby_shield/manifest.webmanifest">
   <link rel="icon" type="image/png" href="/saber_tabby_shield/TabbySkywalker.jpg">
   <style>
-    body { background: fff0db; }
+    body {
+      background: fff0db;
+    }
   </style>
 </head>
 <script type="module" src="/saber_tabby_shield/main.js"></script>
@@ -12,5 +15,5 @@
 <pre>
 Outer Tabby (Tabby Skywalker)
 If any one of inner or outer tabby is installed, the other needs to be installed via policy.
-<a href="/saber_tabby_shield/inner/index.html">Click here to go in</a>
+<a href="/saber_tabby_shield/inner/index.html" target="_blank" rel="noopener">Click here to go in</a>
 </pre>

--- a/pwa-testing/saber-tabby-shield/public/inner/index.html
+++ b/pwa-testing/saber-tabby-shield/public/inner/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
+
 <head>
   <title>Darth Tabby</title>
   <link rel="manifest" href="/saber_tabby_shield/inner/manifest.webmanifest">
   <link rel="icon" type="image/png" href="/saber_tabby_shield/DarthTabby.jpg">
   <style>
-    body { background: fff6e9; }
+    body {
+      background: fff6e9;
+    }
   </style>
 </head>
 <script type="module" src="/saber_tabby_shield/inner/main.js"></script>
 <img src="/saber_tabby_shield/DarthTabby.jpg">
 <pre>
-<a href="/saber_tabby_shield/index.html">Click here to go out</a>
+<a href="/saber_tabby_shield/index.html" target="_blank" rel="noopener">Click here to go out</a>
 Inner Tabby (Darth Tabby)
 </pre>

--- a/pwa-testing/saber-tabby-shield/public/inner/manifest.webmanifest
+++ b/pwa-testing/saber-tabby-shield/public/inner/manifest.webmanifest
@@ -8,5 +8,10 @@
     "src": "/saber_tabby_shield/DarthTabby.jpg",
     "sizes": "155x155",
     "type": "image/png"
-  }]
+  }
+],
+"launch_handler": {
+  "client_mode": "navigate-existing",
+  "route_to": "existing-client-navigate"
+}
 }


### PR DESCRIPTION
This is done by ensuring that the anchor links have a target="_blank" and rel="noopener" explicitly specified.