### PR TITLE
trailblazers: Fix AI API key prompt when Writer/Rewriter polyfill falls back to native Prompt API

### DIFF
--- a/trailblazers/dist/js/ai/ai-classifier.js
+++ b/trailblazers/dist/js/ai/ai-classifier.js
@@ -1,6 +1,7 @@
 import { updateDraftData } from '../drafts/draft-manager.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 import {
   renderClassifierResults,
@@ -70,7 +71,7 @@ export async function initAIClassifier(ui, updateCallback) {
     }
 
     const input = `Title: ${title}\n\nContent: ${content}`;
-    const isNative = ClassifierClass.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(ClassifierClass);
 
     await runAIAction(
       ui,

--- a/trailblazers/dist/js/ai/ai-features.js
+++ b/trailblazers/dist/js/ai/ai-features.js
@@ -1,7 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
-import { getMonitor, runAIAction } from './ai-ui-utils.js';
+import { getMonitor, runAIAction, isNativeAIFeature } from './ai-ui-utils.js';
 
 export { getMonitor, runAIAction };
 
@@ -36,7 +36,7 @@ async function runSummarizer(ui, type, input, targetInput, updateCallback) {
   const btn =
     type === 'headline' ? ui.aiSuggestTitleBtn : ui.aiSuggestDescriptionBtn;
 
-  const isNative = Summarizer.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(Summarizer);
 
   await runAIAction(
     ui,

--- a/trailblazers/dist/js/ai/ai-multimodal.js
+++ b/trailblazers/dist/js/ai/ai-multimodal.js
@@ -1,5 +1,6 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { checkAIKeys } from './ai-config.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 
 /** @type {Object} */
 export const imageMetadataSchema = {
@@ -38,7 +39,7 @@ export async function generateImageMetadata(imageSource, ui) {
     return null;
   }
 
-  const isNative = LanguageModel.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(LanguageModel);
   if (!isNative && !checkAIKeys(ui)) {
     return null;
   }

--- a/trailblazers/dist/js/ai/ai-rewriter.js
+++ b/trailblazers/dist/js/ai/ai-rewriter.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 
 /**
@@ -89,7 +90,7 @@ export async function initAIRewriter(ui, updateCallback) {
       return customAlert(ui, 'Please write some content first.');
     }
 
-    const isNative = Rewriter.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(Rewriter);
 
     await runAIAction(
       ui,

--- a/trailblazers/dist/js/ai/ai-tag-suggestions.js
+++ b/trailblazers/dist/js/ai/ai-tag-suggestions.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 import { runTagGeneration } from './ai-tag-generator.js';
 
@@ -60,7 +61,7 @@ export async function initTagSuggestions(ui, updateCallback) {
       return customAlert(ui, 'Please write some content first.');
     }
 
-    const isNative = LanguageModel.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(LanguageModel);
 
     await runAIAction(
       ui,

--- a/trailblazers/dist/js/ai/ai-translator-core.js
+++ b/trailblazers/dist/js/ai/ai-translator-core.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { updatePreview } from './ai-translator-preview.js';
 import { drafts, currentDraftId } from '../drafts/draft-manager.js';
 import { generateMarkdown } from '../utils/markdown-utils.js';
@@ -50,7 +51,7 @@ export async function runTranslation(
   const preview = details.querySelector('.translation-preview');
   const btn = details.querySelector('.translate-btn');
 
-  const isNative = Translator.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(Translator);
 
   await runAIAction(
     ui,

--- a/trailblazers/dist/js/ai/ai-ui-utils.js
+++ b/trailblazers/dist/js/ai/ai-ui-utils.js
@@ -25,6 +25,25 @@ export const getMonitor = (ui, lang, modelName) => ({
 });
 
 /**
+ * Determines whether an on-device AI API (Writer, Rewriter, Summarizer, etc.)
+ * can run without a cloud AI API key. A `Function.toString()` "[native code]"
+ * check misses the case where `built-in-ai-task-apis-polyfills` installs a
+ * plain-class fallback that itself runs on the browser's native, on-device
+ * Prompt API (`LanguageModel`) — that path needs no key either.
+ * @param {Function} apiClass - The task API class (e.g. `Writer`, `Rewriter`).
+ * @return {boolean} True if the feature can run without a cloud AI API key.
+ */
+export function isNativeAIFeature(apiClass) {
+  if (typeof apiClass !== 'function') {
+    return false;
+  }
+  if (!apiClass.__isPolyfill) {
+    return true;
+  }
+  return typeof LanguageModel !== 'undefined' && !LanguageModel.__isPolyfill;
+}
+
+/**
  * Executes an AI action with UI feedback (loading state).
  * @param {Object} ui - The UI elements.
  * @param {HTMLButtonElement} btn - The button that triggered the action.

--- a/trailblazers/dist/js/ai/ai-writer.js
+++ b/trailblazers/dist/js/ai/ai-writer.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 
 /**
@@ -79,7 +80,7 @@ export async function initAIWriter(ui, updateCallback) {
       }
     }
 
-    const isNative = Writer.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(Writer);
 
     await runAIAction(
       ui,

--- a/trailblazers/public/js/ai/ai-classifier.js
+++ b/trailblazers/public/js/ai/ai-classifier.js
@@ -1,6 +1,7 @@
 import { updateDraftData } from '../drafts/draft-manager.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 import {
   renderClassifierResults,
@@ -70,7 +71,7 @@ export async function initAIClassifier(ui, updateCallback) {
     }
 
     const input = `Title: ${title}\n\nContent: ${content}`;
-    const isNative = ClassifierClass.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(ClassifierClass);
 
     await runAIAction(
       ui,

--- a/trailblazers/public/js/ai/ai-features.js
+++ b/trailblazers/public/js/ai/ai-features.js
@@ -1,7 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
-import { getMonitor, runAIAction } from './ai-ui-utils.js';
+import { getMonitor, runAIAction, isNativeAIFeature } from './ai-ui-utils.js';
 
 export { getMonitor, runAIAction };
 
@@ -36,7 +36,7 @@ async function runSummarizer(ui, type, input, targetInput, updateCallback) {
   const btn =
     type === 'headline' ? ui.aiSuggestTitleBtn : ui.aiSuggestDescriptionBtn;
 
-  const isNative = Summarizer.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(Summarizer);
 
   await runAIAction(
     ui,

--- a/trailblazers/public/js/ai/ai-multimodal.js
+++ b/trailblazers/public/js/ai/ai-multimodal.js
@@ -1,5 +1,6 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { checkAIKeys } from './ai-config.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 
 /** @type {Object} */
 export const imageMetadataSchema = {
@@ -38,7 +39,7 @@ export async function generateImageMetadata(imageSource, ui) {
     return null;
   }
 
-  const isNative = LanguageModel.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(LanguageModel);
   if (!isNative && !checkAIKeys(ui)) {
     return null;
   }

--- a/trailblazers/public/js/ai/ai-rewriter.js
+++ b/trailblazers/public/js/ai/ai-rewriter.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 
 /**
@@ -89,7 +90,7 @@ export async function initAIRewriter(ui, updateCallback) {
       return customAlert(ui, 'Please write some content first.');
     }
 
-    const isNative = Rewriter.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(Rewriter);
 
     await runAIAction(
       ui,

--- a/trailblazers/public/js/ai/ai-tag-suggestions.js
+++ b/trailblazers/public/js/ai/ai-tag-suggestions.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert } from '../utils/dialog-utils.js';
 import { runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 import { runTagGeneration } from './ai-tag-generator.js';
 
@@ -60,7 +61,7 @@ export async function initTagSuggestions(ui, updateCallback) {
       return customAlert(ui, 'Please write some content first.');
     }
 
-    const isNative = LanguageModel.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(LanguageModel);
 
     await runAIAction(
       ui,

--- a/trailblazers/public/js/ai/ai-translator-core.js
+++ b/trailblazers/public/js/ai/ai-translator-core.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { updatePreview } from './ai-translator-preview.js';
 import { drafts, currentDraftId } from '../drafts/draft-manager.js';
 import { generateMarkdown } from '../utils/markdown-utils.js';
@@ -50,7 +51,7 @@ export async function runTranslation(
   const preview = details.querySelector('.translation-preview');
   const btn = details.querySelector('.translate-btn');
 
-  const isNative = Translator.toString().includes('[native code]');
+  const isNative = isNativeAIFeature(Translator);
 
   await runAIAction(
     ui,

--- a/trailblazers/public/js/ai/ai-ui-utils.js
+++ b/trailblazers/public/js/ai/ai-ui-utils.js
@@ -25,6 +25,25 @@ export const getMonitor = (ui, lang, modelName) => ({
 });
 
 /**
+ * Determines whether an on-device AI API (Writer, Rewriter, Summarizer, etc.)
+ * can run without a cloud AI API key. A `Function.toString()` "[native code]"
+ * check misses the case where `built-in-ai-task-apis-polyfills` installs a
+ * plain-class fallback that itself runs on the browser's native, on-device
+ * Prompt API (`LanguageModel`) — that path needs no key either.
+ * @param {Function} apiClass - The task API class (e.g. `Writer`, `Rewriter`).
+ * @return {boolean} True if the feature can run without a cloud AI API key.
+ */
+export function isNativeAIFeature(apiClass) {
+  if (typeof apiClass !== 'function') {
+    return false;
+  }
+  if (!apiClass.__isPolyfill) {
+    return true;
+  }
+  return typeof LanguageModel !== 'undefined' && !LanguageModel.__isPolyfill;
+}
+
+/**
  * Executes an AI action with UI feedback (loading state).
  * @param {Object} ui - The UI elements.
  * @param {HTMLButtonElement} btn - The button that triggered the action.

--- a/trailblazers/public/js/ai/ai-writer.js
+++ b/trailblazers/public/js/ai/ai-writer.js
@@ -1,6 +1,7 @@
 import { detectLanguage } from './ai-language-detection.js';
 import { customAlert, customConfirm } from '../utils/dialog-utils.js';
 import { getMonitor, runAIAction } from './ai-features.js';
+import { isNativeAIFeature } from './ai-ui-utils.js';
 import { refreshAIVisibility } from './ai-toggle.js';
 
 /**
@@ -79,7 +80,7 @@ export async function initAIWriter(ui, updateCallback) {
       }
     }
 
-    const isNative = Writer.toString().includes('[native code]');
+    const isNative = isNativeAIFeature(Writer);
 
     await runAIAction(
       ui,


### PR DESCRIPTION
## Summary
- Same bug and fix as GoogleChrome/starter-extended-blog#18, applied to `trailblazers/`.
- The editor's AI features asked for a cloud AI API key even when the `built-in-ai-task-apis-polyfills` fallback was itself running entirely on-device via the browser's native Prompt API (`LanguageModel`, supported from Chrome 148).
- Root cause: `isNative` was computed as `apiClass.toString().includes('[native code]')`. The polyfill installs a plain JS class (`class extends apiClass {}`), so this check is always `false` for the polyfill path — even when it needs no cloud key at all.
- Replaces the `toString()` sniff with a shared `isNativeAIFeature()` helper (`ai-ui-utils.js`) that checks the polyfill's `__isPolyfill` marker and, when polyfilled, whether the underlying `LanguageModel` is itself native rather than also polyfilled.
- Applied consistently across all affected features: Writer, Rewriter, Summarizer, Classifier, tag suggestions, Translator, and multimodal image metadata generation.
- `dist/js/ai/*.js` is updated to mirror `public/js/ai/*.js` (eleventy passthrough-copies these files verbatim, no transform — verified byte-identical pre-fix). A full `npm install`/`npm run build` was skipped for this change since it would pull in large transitive ML runtime deps (transformers.js, onnxruntime-web, webllm) unrelated to the fix; please regenerate `dist/` via the normal build/deploy flow if preferred before merging.

## Test plan
- [x] `node --check` on all modified files
- [ ] Manually verify in a browser without native Writer/Rewriter but with native Prompt API support (Chrome 148+) that AI actions run without prompting for an API key